### PR TITLE
Add HTTPS support in adblock.sh

### DIFF
--- a/roles/dns_adblocking/templates/adblock.sh
+++ b/roles/dns_adblocking/templates/adblock.sh
@@ -14,9 +14,9 @@ rm -f /var/lib/dnsmasq/block.hosts
 echo 'Downloading hosts lists...'
 #Download and process the files needed to make the lists (enable/add more, if you want)
 wget -qO- http://winhelp2002.mvps.org/hosts.txt| awk -v r="$ENDPOINT_IP4" '{sub(/^0.0.0.0/, r)} $0 ~ "^"r' > "$TEMP"
-wget -qO- "http://adaway.org/hosts.txt"|awk -v r="$ENDPOINT_IP4" '{sub(/^127.0.0.1/, r)} $0 ~ "^"r' >> "$TEMP"
-wget -qO- http://www.malwaredomainlist.com/hostslist/hosts.txt|awk -v r="$ENDPOINT_IP4" '{sub(/^127.0.0.1/, r)} $0 ~ "^"r' >> "$TEMP"
-wget -qO- "http://hosts-file.net/.\ad_servers.txt"|awk -v r="$ENDPOINT_IP4" '{sub(/^127.0.0.1/, r)} $0 ~ "^"r' >> "$TEMP"
+wget -qO- "https://adaway.org/hosts.txt"|awk -v r="$ENDPOINT_IP4" '{sub(/^127.0.0.1/, r)} $0 ~ "^"r' >> "$TEMP"
+wget -qO- https://www.malwaredomainlist.com/hostslist/hosts.txt|awk -v r="$ENDPOINT_IP4" '{sub(/^127.0.0.1/, r)} $0 ~ "^"r' >> "$TEMP"
+wget -qO- "https://hosts-file.net/.\ad_servers.txt"|awk -v r="$ENDPOINT_IP4" '{sub(/^127.0.0.1/, r)} $0 ~ "^"r' >> "$TEMP"
 
 #Add black list, if non-empty
 if [ -s "/var/lib/dnsmasq/black.list" ]

--- a/roles/dns_adblocking/templates/adblock.sh
+++ b/roles/dns_adblocking/templates/adblock.sh
@@ -13,7 +13,7 @@ rm -f /var/lib/dnsmasq/block.hosts
 
 echo 'Downloading hosts lists...'
 #Download and process the files needed to make the lists (enable/add more, if you want)
-wget -qO- http://www.mvps.org/winhelp2002/hosts.txt| awk -v r="$ENDPOINT_IP4" '{sub(/^0.0.0.0/, r)} $0 ~ "^"r' > "$TEMP"
+wget -qO- http://winhelp2002.mvps.org/hosts.txt| awk -v r="$ENDPOINT_IP4" '{sub(/^0.0.0.0/, r)} $0 ~ "^"r' > "$TEMP"
 wget -qO- "http://adaway.org/hosts.txt"|awk -v r="$ENDPOINT_IP4" '{sub(/^127.0.0.1/, r)} $0 ~ "^"r' >> "$TEMP"
 wget -qO- http://www.malwaredomainlist.com/hostslist/hosts.txt|awk -v r="$ENDPOINT_IP4" '{sub(/^127.0.0.1/, r)} $0 ~ "^"r' >> "$TEMP"
 wget -qO- "http://hosts-file.net/.\ad_servers.txt"|awk -v r="$ENDPOINT_IP4" '{sub(/^127.0.0.1/, r)} $0 ~ "^"r' >> "$TEMP"


### PR DESCRIPTION
Just a quick change to adblock.sh. First commit changes http://www.mvps.org/winhelp2002/hosts.txt to point to http://winhelp2002.mvps.org/hosts.txt, there's a server-side redirect to the latter page when accessing the former page.

I've also added HTTPS to hosts-file.net, malwaredomainlist.com, and adaway.org as each of these domains support it with a valid certificate. 

I've tested this on my instance of algo to ensure there is no breakage, but feel free to doublecheck my PR :)