### PR TITLE
Avoid using + for email address

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -5,7 +5,8 @@ users:
   - dan
   - jack
 
-# Add an email address to send logs if you're using auditd for monitoring, 
+# Add an email address to send logs if you're using auditd for monitoring.
+# Avoid using '+' in your email address otherwise auditd will fail to start.
 auditd_action_mail_acct: email@example.com
 
 # Exported certificates will be protected by the password below:


### PR DESCRIPTION
using + in email add (eg email+auditd@domain.tld) would cause auditd fail to start
see #117
