### PR TITLE
Add missing playbook tags

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,9 +2,13 @@
 
 - name: Gather Facts
   setup:
+  tags:
+    - always
 
 - name: Install software updates
   apt: update_cache=yes upgrade=dist
+  tags:
+    - cloud
 
 - name: Check if reboot is required
   shell: >
@@ -43,6 +47,8 @@
   with_items:
     - { regexp: '^session.*optional.*pam_motd.so.*', line: '# MOTD DISABLED', file: '/etc/pam.d/login' }
     - { regexp: '^session.*optional.*pam_motd.so.*', line: '# MOTD DISABLED', file: '/etc/pam.d/sshd' }
+  tags:
+    - cloud
 
 - name: Install tools
   apt: name="{{ item }}" state=latest
@@ -55,24 +61,36 @@
     - sendmail
     - iptables-persistent
     - cgroup-tools
+  tags:
+    - always
 
 - name: Loopback for services configured
   template: src=10-loopback-services.cfg.j2 dest=/etc/network/interfaces.d/10-loopback-services.cfg
   notify:
     - restart loopback
+  tags:
+    - always
 
 - name: Loopback included into the network config
   lineinfile: dest=/etc/network/interfaces line='source /etc/network/interfaces.d/10-loopback-services.cfg' state=present
   notify:
     - restart loopback
+  tags:
+    - always
 
 - meta: flush_handlers
+  tags:
+    - always
 
 - name: Enable packet forwarding for IPv4
   sysctl: name="{{ item }}" value=1
   with_items:
     - net.ipv4.ip_forward
     - net.ipv4.conf.all.forwarding
+  tags:
+    - always
 
 - name: Enable packet forwarding for IPv6
   sysctl: name=net.ipv6.conf.all.forwarding value=1
+  tags:
+    - always

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Check if reboot is required
   shell: >
-    if [[ $(readlink -f /vmlinuz) != /boot/vmlinuz-$(uname -r) ]]; then echo "required"; else echo "no"; fi
+    if [[ -e /var/run/reboot-required ]]; then echo "required"; else echo "no"; fi
   args:
     executable: /bin/bash
   register: reboot_required


### PR DESCRIPTION
I believe this broke in d052cb8e772af160c8a13b934f7146d53d1a7876

If the common playbook is invoked with the "cloud" tag, non-cloud tasks will be skipped.  On GCE this causes "Install tools" to be skipped, apparmor-utils is not installed, and then the "Enforcing ipsec with apparmor" step fails.

Also, fix the "reboot required by apt-get upgrade" check.