### PR TITLE
Show congrats message at the end - #115

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -38,3 +38,18 @@
   handlers:
     - name: reload eth0
       shell: sh -c 'ifdown eth0; ip addr flush dev eth0; ifup eth0'
+
+  post_tasks:
+    - shell: |
+        echo "#----------------------------------------------------------------------#"
+        echo "#                          Congratulations!                            #"
+        echo "#                     Your Algo server is running.                     #"
+        echo "#    Config files and certificates are in the ./configs/ directory.    #"
+        echo "#              Go to https://whoer.net/ after connecting               #"
+        echo "#        and ensure that all your traffic passes through the VPN.      #"
+        echo "#          Local DNS resolver and Proxy IP address: {{ local_service_ip }}"
+        echo "#----------------------------------------------------------------------#"
+      tags: always
+      register: congrats
+    - debug: msg="{{ congrats.stdout_lines }}"
+      tags: always

--- a/roles/vpn/handlers/main.yml
+++ b/roles/vpn/handlers/main.yml
@@ -12,15 +12,3 @@
 
 - name: restart iptables
   service: name=netfilter-persistent state=restarted
-
-- name: congrats
-  debug:
-    msg:
-      - "#----------------------------------------------------------------------#"
-      - "#                          Congratulations!                            #"
-      - "#                     Your Algo server is running.                     #"
-      - "#    Config files and certificates are in the ./configs/ directory.    #"
-      - "#              Go to https://whoer.net/ after connecting               #"
-      - "#        and ensure that all your traffic passes through the VPN.      #"
-      - "#          Local DNS resolver and Proxy IP address: {{ local_service_ip }}"
-      - "#----------------------------------------------------------------------#"

--- a/roles/vpn/tasks/main.yml
+++ b/roles/vpn/tasks/main.yml
@@ -222,8 +222,6 @@
 
 - name: Fetch server CA certificate
   fetch: src=/{{ easyrsa_dir }}/easyrsa3/pki/ca.crt dest=configs/{{ IP_subject_alt_name }}_ca.crt flat=yes
-  notify:
-    - congrats
 
 - include: iptables.yml
   tags: iptables


### PR DESCRIPTION
Using a post_task seems to be a good idea here. The handler was called from a task in the vpn role and if other roles as dns_adblocking were added by the setup script the tasks of this role got executed after the handler.