### PR TITLE
Change default instance to free tier (t2.micro)

### DIFF
--- a/roles/cloud-ec2/tasks/main.yml
+++ b/roles/cloud-ec2/tasks/main.yml
@@ -55,7 +55,7 @@
     aws_secret_key: "{{ aws_secret_key | default(lookup('env','AWS_SECRET_ACCESS_KEY'))}}"
     keypair: "VPNKEY"
     group: vpn-secgroup
-    instance_type: t2.nano
+    instance_type: t2.micro
     image: "{{ ami_image }}"
     wait: true
     region: "{{ region }}"


### PR DESCRIPTION
I know this is a bit goofy, but the t2.nano is not in the free tier for AWS even though it is smaller than the t2.micro instance. See: https://aws.amazon.com/blogs/aws/ec2-update-t2-nano-instances-now-available/ (the "PS" at the bottom), confirmed on pricing page. The difference is $4.30 per mo vs. free/$8.76  per mo. Maybe add this to config questions, but at least one reviewer has noted this as an issue for his just-setup AWS free account.