### PR TITLE
Use Ansible variables for ssh key and user name in congrats text

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -77,7 +77,7 @@ congrats: |
   "#          Local DNS resolver and Proxy IP address: {{ local_service_ip }}         #"
   "#                     The p12 password is {{ easyrsa_p12_export_password }}                     #"
   "#                  The CA key password is {{ easyrsa_CA_password }}                 #"
-  "#            Shell access: ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }}          #"
+  "#      Shell access: ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }}        #"
   "#----------------------------------------------------------------------#"
 
 SSH_keys:

--- a/config.cfg
+++ b/config.cfg
@@ -77,7 +77,7 @@ congrats: |
   "#          Local DNS resolver and Proxy IP address: {{ local_service_ip }}         #"
   "#                     The p12 password is {{ easyrsa_p12_export_password }}                     #"
   "#                  The CA key password is {{ easyrsa_CA_password }}                 #"
-  "#            Shell access: ssh -i algo.pem root@{{ ansible_ssh_host }}          #"
+  "#            Shell access: ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }}          #"
   "#----------------------------------------------------------------------#"
 
 SSH_keys:


### PR DESCRIPTION
Addresses @gunph1ld PR: https://github.com/trailofbits/algo/pull/173. Patch verified via new deploys on both Digital Ocean and GCE instances. See: https://gist.github.com/kennwhite/c44f5144c6699e49f8ab3f3e568b0560