### PR TITLE
Fix undefined variable crash for local installs

### DIFF
--- a/roles/local/tasks/main.yml
+++ b/roles/local/tasks/main.yml
@@ -4,6 +4,7 @@
     groups: vpn-host
     ansible_ssh_user: "{{ server_user }}"
     ansible_python_interpreter: "/usr/bin/python2.7"
+    ansible_ssh_private_key_file: "{{ SSH_keys.private }}"
     cloud_provider: local
   when: server_ip != "localhost"
 
@@ -13,6 +14,7 @@
     groups: vpn-host
     ansible_ssh_user: "{{ server_user }}"
     ansible_python_interpreter: "/usr/bin/python2.7"
+    ansible_ssh_private_key_file: "{{ SSH_keys.private }}"
     ansible_connection: local
     cloud_provider: local
   when: server_ip == "localhost"


### PR DESCRIPTION
Corrects this crash that occurs at the end of a local (e.g., a new DigitalOcean Ubuntu 16.04.1 x64 droplet) at the "congrats" parsing stage. Confirmed that patch works against 2 new local 16.04.1 droplets.

TASK [debug] *******************************************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: \"#----------------------------------------------------------------------#\"\n\"#                          Congratulations!                            #\"\n\"#                     Your Algo server is running.                     #\"\n\"#    Config files and certificates are in the ./configs/ directory.    #\"\n\"#              Go to https://whoer.net/ after connecting               #\"\n\"#        and ensure that all your traffic passes through the VPN.      #\"\n\"#          Local DNS resolver and Proxy IP address: {{ local_service_ip }}         #\"\n\"#                     The p12 password is {{ easyrsa_p12_export_password }}                     #\"\n\"#                  The CA key password is {{ easyrsa_CA_password }}                 #\"\n\"#      Shell access: ssh -i {{ ansible_ssh_private_key_file }} {{ ansible_ssh_user }}@{{ ansible_ssh_host }}        #\"\n\"#----------------------------------------------------------------------#\"\n: 'ansible_ssh_private_key_file' is undefined\n\nThe error appears to have been in '/root/algo/deploy.yml': line 61, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  post_tasks:\n    - debug: msg=\"{{ congrats.split('\\n') }}\"\n      ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}