### PR TITLE
Drop the MSS for GCE instances

### DIFF
--- a/algo
+++ b/algo
@@ -286,7 +286,7 @@ Please choose the number of your zone. Press enter for default (#8) zone.
   esac
 
   ROLES="gce vpn cloud"
-  EXTRA_VARS="credentials_file=$credentials_file server_name=$server_name ssh_public_key=$ssh_public_key zone=$zone"
+  EXTRA_VARS="credentials_file=$credentials_file server_name=$server_name ssh_public_key=$ssh_public_key zone=$zone max_mss=1348"
 }
 
 non_cloud () {

--- a/roles/vpn/templates/rules.v4.j2
+++ b/roles/vpn/templates/rules.v4.j2
@@ -1,3 +1,13 @@
+*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+{% if max_mss is defined %}
+-A FORWARD -s {{ vpn_network }} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss {{ max_mss }}
+{% endif %}
+COMMIT
 *nat
 :PREROUTING ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]

--- a/roles/vpn/templates/rules.v6.j2
+++ b/roles/vpn/templates/rules.v6.j2
@@ -1,3 +1,13 @@
+*mangle
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+{% if max_mss is defined %}
+-A FORWARD -s {{ vpn_network_ipv6 }} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss {{ max_mss }}
+{% endif %}
+COMMIT
 *nat
 :PREROUTING ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]


### PR DESCRIPTION
This forces the MSS for GCE instances only down to 1348, which seems to be the maximum value permitted for this tunnel. Without this, various parts of the internet appear to be offline through the VPN.

### Ansible version
```
ansible 2.2.0.0
  config file = /home/dwg/src/github.com/trailofbits/algo/ansible.cfg
  configured module search path = Default w/o overrides
```

### Version of components from `requirements.txt`
```
Name: ansible
Version: 2.2.0.0
---
Name: dopy
Version: 0.3.5
---
Name: boto
Version: 2.45.0
---
Name: azure
Version: 2.0.0rc5
---
Name: apache-libcloud
Version: 1.4.0
---
Name: six
Version: 1.10.0
---
Name: pyOpenSSL
Version: 16.2.0
```

### Summary of the problem
Algo instances deployed in GCE don't have an appropriate MSS configured, so some sites -- notably `github.com` -- will seem to hang when attempting to load them, as packets marked with DF are being silently dropped.

### Steps to reproduce the behavior
1. Create a new `algo` instance in GCE.
2. Provision the VPN on an endpoint (any one; I've seen this on OS X, iOS, and Windows)
3. Attempt to load `https://github.com/`
4. Observe as it times out.

Bonus points: run a `tcpdump` locally and on the `algo` instance, and watch as packets arrive to the `algo` instance, but don't get forwarded across the tunnel.

### Expected behavior
The site loads.