### PR TITLE
Ensure that ssh keys and configs are exist

### DIFF
--- a/algo
+++ b/algo
@@ -308,6 +308,13 @@ Enter the public IP address of your server: (IMPORTANT! This IP is used to verif
   ROLES="local vpn"
   EXTRA_VARS="server_ip=$server_ip server_user=$server_user IP_subject_alt_name=$IP_subject"
   SKIP_TAGS+=" cloud update-alternatives"
+
+  read -p "
+Was this server deployed by Algo previously?
+[y/N]: " -r Deployed_By_Algo
+Deployed_By_Algo=${Deployed_By_Algo:-n}
+if [[ "$Deployed_By_Algo" =~ ^(y|Y)$ ]]; then EXTRA_VARS+=" Deployed_By_Algo=Y"; fi
+
 }
 
 algo_provisioning () {

--- a/deploy.yml
+++ b/deploy.yml
@@ -9,6 +9,12 @@
       include: playbooks/local.yml
       tags: [ 'always' ]
 
+    - name: Local pre-tasks
+      include: playbooks/local_ssh.yml
+      become: false
+      when: Deployed_By_Algo is defined and Deployed_By_Algo == "Y"
+      tags: [ 'local' ]      
+
   roles:
     - { role: cloud-digitalocean, tags: ['digitalocean'] }
     - { role: cloud-ec2, tags: ['ec2'] }
@@ -17,24 +23,10 @@
     - { role: local, tags: ['local'] }
 
   post_tasks:
-    - name: Wait until SSH becomes ready...
-      local_action:
-        module: wait_for
-        port: 22
-        host: "{{ cloud_instance_ip }}"
-        search_regex: "OpenSSH"
-        delay: 10
-        timeout: 320
-        state: present
+    - name: Local pre-tasks
+      include: playbooks/post.yml
       become: false
-      tags:
-        - cloud
-
-    - name: A short pause, in order to be sure the instance is ready
-      pause:
-        seconds: 10
-      tags:
-        - cloud
+      tags: [ 'cloud' ]
 
 - name: Configure the server and install required software
   hosts: vpn-host

--- a/playbooks/local_ssh.yml
+++ b/playbooks/local_ssh.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Ensure the local ssh directory is exist
+  local_action:
+    module: file
+    path: "~/.ssh/"
+    state: directory
+
+- name: Copy the algo ssh key to the local ssh directory
+  local_action:
+    module: copy
+    src: configs/algo.pem
+    dest: ~/.ssh/algo.pem
+    mode: '0600'
+
+- name: Configure the local ssh config
+  blockinfile:
+    dest: "~/.ssh/config"
+    marker: "# {mark} ALGO MANAGED BLOCK {{ cloud_instance_ip|default(server_ip) }}"
+    insertbefore: BOF
+    block: |
+      Host {{ cloud_instance_ip|default(server_ip) }}
+      	IdentityFile ~/.ssh/algo.pem

--- a/playbooks/post.yml
+++ b/playbooks/post.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Wait until SSH becomes ready...
+  local_action:
+    module: wait_for
+    port: 22
+    host: "{{ cloud_instance_ip }}"
+    search_regex: "OpenSSH"
+    delay: 10
+    timeout: 320
+    state: present
+
+- name: A short pause, in order to be sure the instance is ready
+  pause:
+    seconds: 10
+
+- include: local_ssh.yml


### PR DESCRIPTION
If the server was deployed by any of cloud roles and a user wants to re-deploy the server by the local role, the deployment will fail, because the algo ssh key is not exist neither in client's ssh config nor in the ssh-agent
Related to #250