### PR TITLE
Install the recommended packages with strongswan

### DIFF
--- a/roles/vpn/tasks/main.yml
+++ b/roles/vpn/tasks/main.yml
@@ -17,7 +17,7 @@
   when: Win10_Enabled is defined and Win10_Enabled == "Y"
 
 - name: Install StrongSwan
-  apt: name=strongswan state=latest update_cache=yes
+  apt: name=strongswan state=latest update_cache=yes install_recommends=yes
 
 - name: Enforcing ipsec with apparmor
   shell: aa-enforce "{{ item }}"


### PR DESCRIPTION
I spent some time tonight beating my head against the desk because Algo would not work on a brand-new, up-to-date Ubuntu 16.04.2 LTS install.

Turns out that for some reason the image I was using had `apt(8)` configured to not install recommended packages by default, and without the OpenSSL plugin from libstrongswan-standard-plugins the daemons will not start.

This change makes sure that strongswan gets installed with its recommendations.