### PR TITLE
Fix name tag key

### DIFF
--- a/roles/cloud-ec2/tasks/main.yml
+++ b/roles/cloud-ec2/tasks/main.yml
@@ -95,11 +95,11 @@
     wait: true
     region: "{{ region }}"
     instance_tags:
-      name: "{{ aws_server_name }}"
+      Name: "{{ aws_server_name }}"
       Environment: Algo
     exact_count: 1
     count_tag:
-      name: "{{ aws_server_name }}"
+      Name: "{{ aws_server_name }}"
     assign_public_ip: yes
     instance_initiated_shutdown_behavior: terminate
   register: ec2


### PR DESCRIPTION
Fixes the EC2 instance name tag so it shows up in the AWS console, as reported in #281 