### PR TITLE
Check for creation of private key during its generation

### DIFF
--- a/playbooks/local.yml
+++ b/playbooks/local.yml
@@ -3,7 +3,7 @@
 - name: Generate the SSH private key
   local_action: shell echo -e  'n' | ssh-keygen -b 2048 -C {{ SSH_keys.comment }} -t rsa -f {{ SSH_keys.private }} -q -N ""
   args:
-    creates: "{{ SSH_keys.public }}"
+    creates: "{{ SSH_keys.private }}"
 
 - name: Generate the SSH public key
   local_action: shell echo `ssh-keygen -y -f {{ SSH_keys.private }}` {{ SSH_keys.comment }} > {{ SSH_keys.public }}


### PR DESCRIPTION
This task was previously checking for the public key even though it is in place to generate the private key. A simple switch to the `creates` arg resolves the issue.