### PR TITLE
Change EC2 VPC CIDR blocks to non-routable addresses.

### DIFF
--- a/roles/cloud-ec2/defaults/main.yml
+++ b/roles/cloud-ec2/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 
 ec2_vpc_nets:
-  cidr_block: 172.251.0.0/23
-  subnet_cidr: 172.251.1.0/24
+  cidr_block: 192.168.0.0/23
+  subnet_cidr: 192.168.1.0/24


### PR DESCRIPTION
The previous address ranges were actually routable addresses, which caused some concern for some people because it looked suspicious in tracert. The new CIDR blocks are non-routable addresses, which resolves this concern.

(See #325)