### PR TITLE
Add new Azure regions and allow user to select VM size

### DIFF
--- a/algo
+++ b/algo
@@ -157,19 +157,17 @@ Enter the number of your desired region:
 
   read -p "
   What size do you want your VM?
-  1) Standard D1 (not available in all regions)
-  2) Standard D1 v2
-  3) Standard A0 (cheap)
-  4) Basic A0 (cheapest)
+  1) Standard D1 v2
+  2) Standard A0 (cheap)
+  3) Basic A0 (cheapest)
 Enter the number of your desired size
 [1]: " -r azure_vm_size
   azure_vm_size=${azure_vm_size:-1}
   
   case "$azure_vm_size" in
-    1) vm_size="Standard_D1"
-    2) vm_size="Standard_D1_v2"
-    3) vm_size="ExtraSmall"
-    4) vm_size="Basic_A0"
+    1) vm_size="Standard_D1_v2"
+    2) vm_size="ExtraSmall" #Conflicting documentation says this might need to be Standard_A0...
+    3) vm_size="Basic_A0"
   esac
   #source for sizes: https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs
 

--- a/algo
+++ b/algo
@@ -155,24 +155,8 @@ Enter the number of your desired region:
     26) region="westindia" ;;
   esac
 
-  read -p "
-  What size do you want your VM?
-  1) Standard D1 v2
-  2) Standard A0 - cheap
-  3) Basic A0 - cheapest
-Enter the number of your desired size
-[1]: " -r azure_vm_size
-  azure_vm_size=${azure_vm_size:-1}
-  
-  case "$azure_vm_size" in
-    1) vm_size="Standard_D1_v2" ;;
-    2) vm_size="ExtraSmall" ;; #Conflicting documentation says this might need to be Standard_A0...
-    3) vm_size="Basic_A0" ;;
-  esac
-  #source for sizes: https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs
-
   ROLES="azure vpn cloud"
-  EXTRA_VARS="azure_secret=$azure_secret azure_tenant=$azure_tenant azure_client_id=$azure_client_id azure_subscription_id=$azure_subscription_id azure_server_name=$azure_server_name ssh_public_key=$ssh_public_key region=$region vm_size=$vm_size"
+  EXTRA_VARS="azure_secret=$azure_secret azure_tenant=$azure_tenant azure_client_id=$azure_client_id azure_subscription_id=$azure_subscription_id azure_server_name=$azure_server_name ssh_public_key=$ssh_public_key region=$region"
 }
 
 digitalocean () {

--- a/algo
+++ b/algo
@@ -159,7 +159,8 @@ Enter the number of your desired region:
   What size do you want your VM?
   1) Standard D1 (not available in all regions)
   2) Standard D1 v2
-  3) A0 (cheapest)
+  3) Standard A0 (cheap)
+  4) Basic A0 (cheapest)
 Enter the number of your desired size
 [1]: " -r azure_vm_size
   azure_vm_size=${azure_vm_size:-1}
@@ -168,6 +169,7 @@ Enter the number of your desired size
     1) vm_size="Standard_D1"
     2) vm_size="Standard_D1_v2"
     3) vm_size="ExtraSmall"
+    4) vm_size="Basic_A0"
   esac
   #source for sizes: https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs
 

--- a/algo
+++ b/algo
@@ -158,16 +158,16 @@ Enter the number of your desired region:
   read -p "
   What size do you want your VM?
   1) Standard D1 v2
-  2) Standard A0 (cheap)
-  3) Basic A0 (cheapest)
+  2) Standard A0 - cheap
+  3) Basic A0 - cheapest
 Enter the number of your desired size
 [1]: " -r azure_vm_size
   azure_vm_size=${azure_vm_size:-1}
   
   case "$azure_vm_size" in
-    1) vm_size="Standard_D1_v2"
-    2) vm_size="ExtraSmall" #Conflicting documentation says this might need to be Standard_A0...
-    3) vm_size="Basic_A0"
+    1) vm_size="Standard_D1_v2" ;;
+    2) vm_size="ExtraSmall" ;; #Conflicting documentation says this might need to be Standard_A0...
+    3) vm_size="Basic_A0" ;;
   esac
   #source for sizes: https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs
 

--- a/algo
+++ b/algo
@@ -130,8 +130,24 @@ Enter the number of your desired region:
     14) region="ukwest" ;;
   esac
 
+  read -p "
+  What size do you want your VM?
+  1) Standard D1 (not available in all regions)
+  2) Standard D1 v2
+  3) A0 (cheapest)
+Enter the number of your desired size
+[1]: " -r azure_vm_size
+  azure_vm_size=${azure_vm_size:-1}
+  
+  case "$azure_vm_size" in
+    1) vm_size="Standard_D1"
+    2) vm_size="Standard_D1_v2"
+    3) vm_size="ExtraSmall"
+  esac
+  #source for sizes: https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs
+
   ROLES="azure vpn cloud"
-  EXTRA_VARS="azure_secret=$azure_secret azure_tenant=$azure_tenant azure_client_id=$azure_client_id azure_subscription_id=$azure_subscription_id azure_server_name=$azure_server_name ssh_public_key=$ssh_public_key region=$region"
+  EXTRA_VARS="azure_secret=$azure_secret azure_tenant=$azure_tenant azure_client_id=$azure_client_id azure_subscription_id=$azure_subscription_id azure_server_name=$azure_server_name ssh_public_key=$ssh_public_key region=$region vm_size=$vm_size"
 }
 
 digitalocean () {

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -88,7 +88,7 @@ You may be trying to run Algo with Python3. Algo uses [Ansible](https://github.c
 
 ### 7. The region you want is not available
 
-You want to install Algo to a specific region in a cloud provider, but that region is not available in the list give to you by the installer. In that case, you should [file an issue](https://github.com/trailofbits/algo/issues/new). Cloud providers add new regions on a regular basis and we don't always keep up. File an issue and give us information about what region is missing and we'll add it.
+You want to install Algo to a specific region in a cloud provider, but that region is not available in the list given by the installer. In that case, you should [file an issue](https://github.com/trailofbits/algo/issues/new). Cloud providers add new regions on a regular basis and we don't always keep up. File an issue and give us information about what region is missing and we'll add it.
 
 ### I have a problem not covered here
 

--- a/roles/cloud-azure/tasks/main.yml
+++ b/roles/cloud-azure/tasks/main.yml
@@ -80,7 +80,6 @@
     virtual_network: algo_net
     name: "{{ azure_server_name }}"
     ssh_password_enabled: false
-    # I have no idea how to use the variable I created and passed from Algo. Do I need this lookup stuff?
     vm_size: "{{ vm_size | default(lookup('env','VM_SIZE')) }}"
     tags:
       Environment: Algo

--- a/roles/cloud-azure/tasks/main.yml
+++ b/roles/cloud-azure/tasks/main.yml
@@ -80,7 +80,8 @@
     virtual_network: algo_net
     name: "{{ azure_server_name }}"
     ssh_password_enabled: false
-    vm_size: Standard_D1
+    # I have no idea how to use the variable I created and passed from Algo. Do I need this lookup stuff?
+    vm_size: "{{ vm_size | default(lookup('env','VM_SIZE')) }}"
     tags:
       Environment: Algo
     ssh_public_keys:
@@ -91,6 +92,8 @@
       sku: '16.04-LTS'
       version: latest
   register: azure_rm_virtualmachine
+  
+  # To-do: Add error handling - if vm_size requested is not available, can we fall back to another, ideally with a prompt?
 
 - set_fact:
     ip_address: "{{ azure_rm_virtualmachine.ansible_facts.azure_vm.properties.networkProfile.networkInterfaces[0].properties.ipConfigurations[0].properties.publicIPAddress.properties.ipAddress }}"

--- a/roles/cloud-azure/tasks/main.yml
+++ b/roles/cloud-azure/tasks/main.yml
@@ -80,7 +80,7 @@
     virtual_network: algo_net
     name: "{{ azure_server_name }}"
     ssh_password_enabled: false
-    vm_size: "{{ vm_size | default(lookup('env','VM_SIZE')) }}"
+    vm_size: Basic_A0
     tags:
       Environment: Algo
     ssh_public_keys:


### PR DESCRIPTION
- Added a bunch of additional Azure regions
- Added a prompt to let the user choose VM size between 3 options, including 2 super low cost ones.
- Removed the default VM size of D1 which is being phased out, replaced with D1v2.

Future enhancements could include:
- Asking for a continent before the Azure region - this way it isn't such a long list to choose from.
- Auto-pulling of Azure regions as described in https://github.com/trailofbits/algo/issues/291