### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ Copy the CA certificate, user certificate, and the user PowerShell script to the
 
 If you want to perform these steps by hand, you will need to import the user certificate to the Personal certificate store, add an IKEv2 connection in the network settings, then activate stronger ciphers on it via the following PowerShell script:
 
-`Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo" -AuthenticationTransformConstants SHA25612
-8 -CipherTransformConstants AES256 -EncryptionMethod AES256 -IntegrityCheckMethod SHA256 -DHGroup Group14 -PfsGroup none`
+`Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo" -AuthenticationTransformConstants SHA256128 -CipherTransformConstants AES256 -EncryptionMethod AES256 -IntegrityCheckMethod SHA256 -DHGroup Group14 -PfsGroup none`
 
 ### Linux strongSwan Clients (e.g., OpenWRT, Ubuntu, etc.)
 


### PR DESCRIPTION
Windows manual steps `-AuthenticationTransformConstants SHA25612 8` had a space that causes this command to fail. Should be `-AuthenticationTransformConstants SHA256128`