### PR TITLE
Change EC2 VPC CIDR blocks to uncommon non-routable addresses

### DIFF
--- a/roles/cloud-ec2/defaults/main.yml
+++ b/roles/cloud-ec2/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 
 ec2_vpc_nets:
-  cidr_block: 192.168.0.0/23
-  subnet_cidr: 192.168.1.0/24
+  cidr_block: 172.16.0.0/12
+  subnet_cidr: 172.30.0.0/23


### PR DESCRIPTION
While the last PR keeps the ips in the private range, it will look show 192.168.x.x in traceroutes as well, which will confuse some people, I suspect.

This fixes https://github.com/trailofbits/algo/issues/325 

