### PR TITLE
Add `URLStringProbe` to iOS config to all networks to allow access to captive portals

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Trail of Bits
+Copyright (c) 2016 Trail of Bits, Google Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/roles/vpn/templates/mobileconfig.j2
+++ b/roles/vpn/templates/mobileconfig.j2
@@ -37,6 +37,8 @@
 {% endif %}
                     <key>InterfaceTypeMatch</key>
                       <string>WiFi</string>
+                    <key>URLStringProbe</key>
+                      <string>http://www.gstatic.com/generate_204</string>
                   </dict>
                   <dict>
                     <key>Action</key>
@@ -47,6 +49,8 @@
 {% endif %}
                     <key>InterfaceTypeMatch</key>
                       <string>Cellular</string>
+                    <key>URLStringProbe</key>
+                      <string>http://www.gstatic.com/generate_204</string>
                   </dict>
                 </array>
 {% else %}


### PR DESCRIPTION
See Feature #288 

Currently, the behavior on iOS is to try to connect to VPN regardless of if the internet is accessible or not. When disabling a VPN for a captive portal scenario, it disables the VPN and disconnects the current network. This causes it to switch to another network (either a wifi network or mobile network) triggering an OnDemand reconnect. This rule disables VPN until the internet is available (using `google.com`) as the endpoint.

I need to validate that the VPN will autoreconnect as soon as google.com is available, but this is currently working better than the current solution. I've tested that the reconnection attempt doesn't happen on a captive network that hasn't been connected yet. `xfinitywifi` has a captive portal that you need to log in to.

**Current configuration generated by HEAD**
![img_1503](https://cloud.githubusercontent.com/assets/2623147/24584012/b676ee22-1712-11e7-84ce-a475453311af.png)

**Configuration generated by this version**
![img_1504](https://cloud.githubusercontent.com/assets/2623147/24584013/b678288c-1712-11e7-9aab-9d21a191378f.png)

