### PR TITLE
Minor AWS improvements

### DIFF
--- a/algo
+++ b/algo
@@ -208,59 +208,70 @@ EXTRA_VARS="do_access_token=$do_access_token do_server_name=$do_server_name do_r
 }
 
 ec2 () {
-  read -p "
-Enter your aws_access_key (http://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html)
-Note: Make sure to use either your root key (recommended) or an IAM user with an acceptable policy attached
-[pasted values will not be displayed]
-[AKIA...]: " -rs aws_access_key
+  if [[ -z $AWS_ACCESS_KEY_ID ]]; then
+    read -p "
+  Enter your aws_access_key (http://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html)
+  Note: Make sure to use either your root key (recommended) or an IAM user with an acceptable policy attached
+  [pasted values will not be displayed]
+  [AKIA...]: " -rs aws_access_key
+  else
+    aws_access_key=$AWS_ACCESS_KEY_ID
+  fi
+
+  if [[ -z $AWS_SECRET_ACCESS_KEY ]]; then
+    read -p "
+  Enter your aws_secret_key (http://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html)
+  Note: Make sure to use either your root key (recommended) or an IAM user with an acceptable policy attached
+  [pasted values will not be displayed]
+  [ABCD...]: " -rs aws_secret_key
+  else
+    aws_secret_key=$AWS_SECRET_ACCESS_KEY
+  fi
 
   read -p "
-Enter your aws_secret_key (http://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html)
-Note: Make sure to use either your root key (recommended) or an IAM user with an acceptable policy attached
-[pasted values will not be displayed]
-[ABCD...]: " -rs aws_secret_key
+  Name the vpn server:
+  [algo]: " -r aws_server_name
+    aws_server_name=${aws_server_name:-algo}
 
-read -p "
-Name the vpn server:
-[algo]: " -r aws_server_name
-  aws_server_name=${aws_server_name:-algo}
-
-  read -p "
-  What region should the server be located in?
-    1.   us-east-1           US East (N. Virginia)
-    2.   us-east-2           US East (Ohio)
-    3.   us-west-1           US West (N. California)
-    4.   us-west-2           US West (Oregon)
-    5.   ap-south-1          Asia Pacific (Mumbai)
-    6.   ap-northeast-2      Asia Pacific (Seoul)
-    7.   ap-southeast-1      Asia Pacific (Singapore)
-    8.   ap-southeast-2      Asia Pacific (Sydney)
-    9.   ap-northeast-1      Asia Pacific (Tokyo)
-    10.  eu-central-1        EU (Frankfurt)
-    11.  eu-west-1           EU (Ireland)
-    12.  eu-west-2           EU (London)
-    13.  sa-east-1           South America (São Paulo)
-    14.  ca-central-1        Canada (Central)
-Enter the number of your desired region:
-[1]: " -r aws_region
-  aws_region=${aws_region:-1}
-
-  case "$aws_region" in
-    1) region="us-east-1" ;;
-    2) region="us-east-2" ;;
-    3) region="us-west-1" ;;
-    4) region="us-west-2" ;;
-    5) region="ap-south-1" ;;
-    6) region="ap-northeast-2" ;;
-    7) region="ap-southeast-1" ;;
-    8) region="ap-southeast-2" ;;
-    9) region="ap-northeast-1" ;;
-    10) region="eu-central-1" ;;
-    11) region="eu-west-1" ;;
-	12) region="eu-west-2";;
-    13) region="sa-east-1" ;;
-    14) region="ca-central-1" ;;
-  esac
+  if [[ -z $AWS_DEFAULT_REGION ]]; then
+    read -p "
+    What region should the server be located in?
+      1.   us-east-1           US East (N. Virginia)
+      2.   us-east-2           US East (Ohio)
+      3.   us-west-1           US West (N. California)
+      4.   us-west-2           US West (Oregon)
+      5.   ap-south-1          Asia Pacific (Mumbai)
+      6.   ap-northeast-2      Asia Pacific (Seoul)
+      7.   ap-southeast-1      Asia Pacific (Singapore)
+      8.   ap-southeast-2      Asia Pacific (Sydney)
+      9.   ap-northeast-1      Asia Pacific (Tokyo)
+      10.  eu-central-1        EU (Frankfurt)
+      11.  eu-west-1           EU (Ireland)
+      12.  eu-west-2           EU (London)
+      13.  sa-east-1           South America (São Paulo)
+      14.  ca-central-1        Canada (Central)
+  Enter the number of your desired region:
+  [1]: " -r aws_region
+    aws_region=${aws_region:-1}
+    case "$aws_region" in
+      1) region="us-east-1" ;;
+      2) region="us-east-2" ;;
+      3) region="us-west-1" ;;
+      4) region="us-west-2" ;;
+      5) region="ap-south-1" ;;
+      6) region="ap-northeast-2" ;;
+      7) region="ap-southeast-1" ;;
+      8) region="ap-southeast-2" ;;
+      9) region="ap-northeast-1" ;;
+      10) region="eu-central-1" ;;
+      11) region="eu-west-1" ;;
+  	  12) region="eu-west-2";;
+      13) region="sa-east-1" ;;
+      14) region="ca-central-1" ;;
+    esac
+  else
+    region=$AWS_DEFAULT_REGION
+  fi
 
   ROLES="ec2 vpn cloud"
   EXTRA_VARS="aws_access_key=$aws_access_key aws_secret_key=$aws_secret_key aws_server_name=$aws_server_name ssh_public_key=$ssh_public_key region=$region"

--- a/roles/cloud-ec2/tasks/main.yml
+++ b/roles/cloud-ec2/tasks/main.yml
@@ -104,9 +104,19 @@
     instance_initiated_shutdown_behavior: terminate
   register: ec2
 
+- name: Allocate and attach a new elastic IP to the instance
+  ec2_eip:
+    state: present
+    region: "{{ region }}"
+    release_on_disassociation: yes
+    reuse_existing_ip_allowed: yes
+    in_vpc: yes
+    device_id: "{{ ec2.tagged_instances[0].id }}"
+  register: eip
+
 - name: Add new instance to host group
   add_host:
-    hostname: "{{ item.public_ip }}"
+    hostname: "{{ eip.public_ip }}"
     groupname: vpn-host
     ansible_ssh_user: ubuntu
     ansible_python_interpreter: "/usr/bin/python2.7"
@@ -116,7 +126,7 @@
   with_items: "{{ ec2.tagged_instances }}"
 
 - set_fact:
-    cloud_instance_ip: "{{ ec2.tagged_instances[0].public_ip }}"
+    cloud_instance_ip: "{{ eip.public_ip }}"
 
 - name: Get EC2 instances
   ec2_remote_facts:


### PR DESCRIPTION
This pull request has two minor changes for AWS:

1. Check for standard AWS environment variables before asking the user. The variables `$AWS_ACCESS_KEY_ID`, `$AWS_SECRET_ACCESS_KEY`, and `$AWS_DEFAULT_REGION` are all standards used by tools like the [aws-cli](https://github.com/aws/aws-cli).
1. Use an [Elastic IP Address](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) on the VPN server instead of a regular public IP. Elastic IPs are free to use, persist beyond an instance stop, and can be attached/detached to a different instance.
