### PR TITLE
Modify creation of GCE Instance

### DIFF
--- a/roles/cloud-gce/tasks/main.yml
+++ b/roles/cloud-gce/tasks/main.yml
@@ -15,10 +15,10 @@
     zone: "{{ zone }}"
     machine_type: f1-micro
     image: ubuntu-1604
-    service_account_email: "{{ service_account_email  }}"
-    credentials_file: "{{ credentials_file_path  }}"
-    project_id: "{{ project_id  }}"
-    metadata: '{"sshKeys":"root:{{ ssh_public_key_lookup }}"}'
+    service_account_email: "{{ service_account_email }}"
+    credentials_file: "{{ credentials_file_path }}"
+    project_id: "{{ project_id }}"
+    metadata: '{"ssh-keys":"ubuntu:{{ ssh_public_key_lookup }}"}'
     tags:
       - "environment-algo"
   register: google_vm


### PR DESCRIPTION
This commit adjusts the creation of the GCE instance, specifically related to the addition of the `sshKeys` metadata. That key has been deprecated in favor of `ssh-keys` ([reference](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys)).

Also changed is the association of the ssh key with the root user, which is by default disabled on GCP public images ([reference](https://cloud.google.com/compute/docs/instances/ssh-keys#root)).
