### PR TITLE
Support for Ubuntu network-manager VPN connections

### DIFF
--- a/roles/vpn/templates/ipsec.conf.j2
+++ b/roles/vpn/templates/ipsec.conf.j2
@@ -14,8 +14,8 @@ conn %default
     ike=aes128gcm16-sha2_256-prfsha256-ecp256,aes256-sha2_256-prfsha256-modp2048!
     esp=aes128gcm16-sha2_256-ecp256,aes256-sha2_256-modp2048!
 {% else %}
-    ike=aes128gcm16-sha2_256-prfsha256-ecp256!
-    esp=aes128gcm16-sha2_256-ecp256!
+    ike=aes128gcm16-sha2_256-prfsha256-ecp256,aes256-sha2_256-prfsha256-ecp256!
+    esp=aes128gcm16-sha2_256-ecp256,aes256-sha2_256-ecp256!
 {% endif %}
 
     left=%any


### PR DESCRIPTION
Do we want to make yet another condition for cipher selection for Ubuntu or just support this unconditionally? I've just added it to the cipher list for now. 

Looks like libcharon doesn't enable any AES GCM ciphers by default and opts to enable Camellia CCM ciphers instead (export restrictions? idk). 

See #263 