### PR TITLE
Only enable ChaCha cipher

### DIFF
--- a/roles/security/templates/sshd_config.j2
+++ b/roles/security/templates/sshd_config.j2
@@ -41,9 +41,12 @@ PrintMotd no
 PrintLastLog yes
 
 # Use only modern host keys
+HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 
 # Use only modern ciphers
-KexAlgorithms curve25519-sha256@libssh.org
-Ciphers chacha20-poly1305@openssh.com
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp256
+Ciphers chacha20-poly1305@openssh.com,aes128-gcm@openssh.com
+MACs hmac-sha2-256-etm@openssh.com
+HostKeyAlgorithms ssh-ed25519,ecdsa-sha2-nistp256
+# PubkeyAcceptedKeyTypes accept anything

--- a/roles/security/templates/sshd_config.j2
+++ b/roles/security/templates/sshd_config.j2
@@ -41,14 +41,9 @@ PrintMotd no
 PrintLastLog yes
 
 # Use only modern host keys
-HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 
 # Use only modern ciphers
-KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
-# TODO: I haven't seen anyone review these yet
-# HostKeyAlgorithms ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519
-# TODO: I haven't seen anyone review these yet
-# PubkeyAcceptedKeyTypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519
+KexAlgorithms curve25519-sha256@libssh.org
+Ciphers chacha20-poly1305@openssh.com
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com


### PR DESCRIPTION
See https://stribika.github.io/2015/01/04/secure-secure-shell.html for some good ideas.

I would not enable ECDSA. Most up to date clients should now support chacha/ed25519. If need be, we can add back some RSA as fallback.