### PR TITLE
Increase CA password entropy to 128bit

### DIFF
--- a/roles/vpn/tasks/main.yml
+++ b/roles/vpn/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Generate password for the CA key
   shell: >
-    openssl rand -hex 6
+    openssl rand -hex 16
   register: CA_password
 
 - set_fact:


### PR DESCRIPTION
In PR https://github.com/trailofbits/algo/pull/262 the default CA key password function was changed from:
    < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-12};echo;

Specifically, the old password function has approximately 72 bits of entropy. (probably isn't strong enough for a high valued key). The newer password function has 48 bits of entropy.

Hopefully people are storing these in a password manager, so the length should not make storage more difficult. 

This PR changes the existing password function (OpenSSL rand -hex) to output 16 byte (128 bit) keys.

Other suggestions for a password functions are using diceware or emoji encoding.