### PR TITLE
Improve Ubuntu Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Install strongSwan, then copy the included ipsec_user.conf, ipsec_user.secrets, 
 5. `sudo ipsec up <conn-name>`: start the ipsec tunnel
 6. `sudo ipsec down <conn-name>`: shutdown the ipsec tunnel
 
+Note: If you encounter an error such as `configured DH group ECP_256 not supported`, try installing `strongswan-plugin-openssl`. Per [StrongSwan Documentation](https://wiki.strongswan.org/projects/strongswan/wiki/IKEv2CipherSuites), this DH group is supported by the openssl plugin.
+
 ### Other Devices
 
 Depending on the platform, you may need one or multiple of the following files.
@@ -191,7 +193,6 @@ The Algo VPN server now contains only the users listed in the `config.cfg` file.
 -- [The Register](https://twitter.com/TheRegister/status/825076303657177088)
 
 > Algo is really easy and secure.
-
 -- [the grugq](https://twitter.com/thegrugq/status/786249040228786176)
 
 > I played around with Algo VPN, a set of scripts that let you set up a VPN in the cloud in very little time, even if you don’t know much about development. I’ve got to say that I was quite impressed with Trail of Bits’ approach.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo" -AuthenticationTransf
 8. `sudo ipsec up <conn-name>`: start the ipsec tunnel
 9. `sudo ipsec down <conn-name>`: shutdown the ipsec tunnel
 
+## LAN Passthrough
+
+To enable your device to access other devices on the LAN, add the following to `/etc/ipsec.conf`, replacing `192.168.1.1/24` with whatever subnet your LAN uses:
+
+    conn lan-passthrough
+    leftsubnet=192.168.1.1/24
+    rightsubnet=192.168.1.1/24
+    authby=never # No authentication necessary
+    type=pass # passthrough
+    auto=route # no need to ipsec up lan-passthrough - it will just work
+
 ### Other Devices
 
 Depending on the platform, you may need one or multiple of the following files.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo" -AuthenticationTransf
 #### Ubuntu Server 16.04 example
 
 1. Install Strongswan: `sudo apt-get install strongswan strongswan-plugin-openssl` Plugin required per [StrongSwan Documentation](https://wiki.strongswan.org/projects/strongswan/wiki/IKEv2CipherSuites), as the ECP_256 DH group is supported by the openssl plugin.
-2. `/etc/ipsec.d/certs`: copy `user.crt` here from `algo-master/configs/<name>/pki/certs/`.
+2. `/etc/ipsec.d/certs`: copy `user.crt` here from `algo-master/configs/<name>/pki/certs`.
 3. `/etc/ipsec.d/private`: copy `user.key` here from `algo-master/configs/<name>/pki/private`.
 4. `/etc/ipsec.d/cacerts`: copy `cacert.pem` here from `algo-master/configs/<name>/cacert.pem`.
 5. `/etc/ipsec.secrets`: add your `user.key` to the list, e.g. `xx.xxx.xx.xxx : ECDSA user.key`, like in `ipsec_user.secrets` but matching the `user.key` filename.

--- a/README.md
+++ b/README.md
@@ -130,18 +130,17 @@ Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo" -AuthenticationTransf
 
 ### Linux strongSwan Clients (e.g., OpenWRT, Ubuntu Server, etc.)
 
-Install strongSwan, then copy the included ipsec_user.conf, ipsec_user.secrets, user.crt (user certificate), and user.key (private key) files to your client device. These will require customization based on your exact use case. These files were originally generated with a point-to-point OpenWRT-based VPN in mind.
-
 #### Ubuntu Server 16.04 example
 
-1. `/etc/ipsec.d/certs`: copy `user.crt` here
-2. `/etc/ipsec.d/private`: copy `user.key` here
-3. `/etc/ipsec.secrets`: add your `user.key` to the list, e.g. `xx.xxx.xx.xxx : ECDSA user.key`
-4. `/etc/ipsec.conf`: add the connection from `ipsec_user.conf` and update the value for `leftcert`
-5. `sudo ipsec up <conn-name>`: start the ipsec tunnel
-6. `sudo ipsec down <conn-name>`: shutdown the ipsec tunnel
-
-Note: If you encounter an error such as `configured DH group ECP_256 not supported`, try installing `strongswan-plugin-openssl`. Per [StrongSwan Documentation](https://wiki.strongswan.org/projects/strongswan/wiki/IKEv2CipherSuites), this DH group is supported by the openssl plugin.
+1. Install Strongswan: `sudo apt-get install strongswan strongswan-plugin-openssl` Plugin required per [StrongSwan Documentation](https://wiki.strongswan.org/projects/strongswan/wiki/IKEv2CipherSuites), as the ECP_256 DH group is supported by the openssl plugin.
+2. `/etc/ipsec.d/certs`: copy `user.crt` here
+3. `/etc/ipsec.d/private`: copy `user.key` here
+4. `/etc/ipsec.secrets`: add your `user.key` to the list, e.g. `xx.xxx.xx.xxx : ECDSA user.key`, like in `ipsec_user.secrets` but matching the `user.key` filename.
+5. `/etc/ipsec.conf`: add the connection from `ipsec_user.conf` and update the value for `leftcert` to match the `user.crt` filename.
+6. `/etc/ipsec.d/cacerts`: copy `cacert.pem` here
+7. `sudo ipsec restart`: pick up config changes
+8. `sudo ipsec up <conn-name>`: start the ipsec tunnel
+9. `sudo ipsec down <conn-name>`: shutdown the ipsec tunnel
 
 ### Other Devices
 

--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo" -AuthenticationTransf
 #### Ubuntu Server 16.04 example
 
 1. Install Strongswan: `sudo apt-get install strongswan strongswan-plugin-openssl` Plugin required per [StrongSwan Documentation](https://wiki.strongswan.org/projects/strongswan/wiki/IKEv2CipherSuites), as the ECP_256 DH group is supported by the openssl plugin.
-2. `/etc/ipsec.d/certs`: copy `user.crt` here
-3. `/etc/ipsec.d/private`: copy `user.key` here
-4. `/etc/ipsec.secrets`: add your `user.key` to the list, e.g. `xx.xxx.xx.xxx : ECDSA user.key`, like in `ipsec_user.secrets` but matching the `user.key` filename.
-5. `/etc/ipsec.conf`: add the connection from `ipsec_user.conf` and update the value for `leftcert` to match the `user.crt` filename.
-6. `/etc/ipsec.d/cacerts`: copy `cacert.pem` here
+2. `/etc/ipsec.d/certs`: copy `user.crt` here from `algo-master/configs/<name>/pki/certs/`.
+3. `/etc/ipsec.d/private`: copy `user.key` here from `algo-master/configs/<name>/pki/private`.
+4. `/etc/ipsec.d/cacerts`: copy `cacert.pem` here from `algo-master/configs/<name>/cacert.pem`.
+5. `/etc/ipsec.secrets`: add your `user.key` to the list, e.g. `xx.xxx.xx.xxx : ECDSA user.key`, like in `ipsec_user.secrets` but matching the `user.key` filename.
+6. `/etc/ipsec.conf`: add the connection from `ipsec_user.conf` and update the value for `leftcert` to match the `user.crt` filename.
 7. `sudo ipsec restart`: pick up config changes
 8. `sudo ipsec up <conn-name>`: start the ipsec tunnel
 9. `sudo ipsec down <conn-name>`: shutdown the ipsec tunnel


### PR DESCRIPTION
Added left out steps and a common pitfall (lack of openssl plugin), removing the initial Linux instructions as they no longer add much value.