### PR TITLE
Use dummy1 instead of lo:100 on Linux

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -15,10 +15,13 @@
     ifconfig lo100 inet6 FCAA::1/64; echo $?
 
 - name: load dummy
-  shell: modprobe dummy
+  modprobe:
+    name: dummy
+    state: present
+    params: 'numdummies=2'
 
 - name: add dummy
-  shell: ip link add dummy100 type dummy
+  shell: ip link add dummy1 type dummy || /bin/true
 
 - name: restart dummy
-  shell: ifdown --force dummy100 && ifup dummy100
+  shell: ifdown --force dummy1 && ifup dummy1

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -7,12 +7,18 @@
 - name: flush routing cache
   shell: echo 1 > /proc/sys/net/ipv4/route/flush
 
-- name: restart loopback
-  shell: ifdown lo:100 && ifup lo:100
-
 - name: restart loopback bsd
   shell: >
     ifconfig lo100 destroy || true &&
     ifconfig lo100 create &&
     ifconfig lo100 inet {{ local_service_ip }} netmask 255.255.255.255 &&
     ifconfig lo100 inet6 FCAA::1/64; echo $?
+
+- name: load dummy
+  shell: modprobe dummy
+
+- name: add dummy
+  shell: ip link add dummy100 type dummy
+
+- name: restart dummy
+  shell: ifdown --force dummy100 && ifup dummy100

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -44,17 +44,21 @@
   tags:
     - cloud
 
-- name: Loopback for services configured
-  template: src=10-loopback-services.cfg.j2 dest=/etc/network/interfaces.d/10-loopback-services.cfg
+- name: Dummy interface for services configured
+  template: src=10-dummy-services.cfg.j2 dest=/etc/network/interfaces.d/10-dummy-services.cfg
   notify:
-    - restart loopback
+    - load dummy
+    - add dummy
+    - restart dummy
   tags:
     - always
 
-- name: Loopback included into the network config
-  lineinfile: dest=/etc/network/interfaces line='source /etc/network/interfaces.d/10-loopback-services.cfg' state=present
+- name: Dummy interface included into the network config
+  lineinfile: dest=/etc/network/interfaces line='source /etc/network/interfaces.d/10-dummy-services.cfg' state=present
   notify:
-    - restart loopback
+    - load dummy
+    - add dummy
+    - restart dummy
   tags:
     - always
 

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -44,6 +44,18 @@
   tags:
     - cloud
 
+- name: Use dummy module on startup
+  lineinfile: dest=/etc/modules-load.d/modules.conf line='dummy' state=present create=yes
+  tags:
+    - always
+
+- name: Configure 2 dummies
+  lineinfile: dest=/etc/modprobe.d/dummy.conf line='options dummy numdummies=2' state=present create=yes
+  notify:
+    - load dummy
+  tags:
+    - always
+
 - name: Dummy interface for services configured
   template: src=10-dummy-services.cfg.j2 dest=/etc/network/interfaces.d/10-dummy-services.cfg
   notify:

--- a/roles/common/templates/10-dummy-services.cfg.j2
+++ b/roles/common/templates/10-dummy-services.cfg.j2
@@ -1,9 +1,9 @@
-auto dummy100
-iface dummy100 inet static
+auto dummy1
+iface dummy1 inet static
 	address {{ local_service_ip }}
 	netmask 255.255.255.255
 
-iface dummy100 inet6 static
+iface dummy1 inet6 static
         address FCAA::1
         netmask 64
         autoconf 0

--- a/roles/common/templates/10-dummy-services.cfg.j2
+++ b/roles/common/templates/10-dummy-services.cfg.j2
@@ -1,9 +1,9 @@
-auto lo:100
-iface lo:100 inet static
+auto dummy100
+iface dummy100 inet static
 	address {{ local_service_ip }}
 	netmask 255.255.255.255
 
-iface lo:100 inet6 static
+iface dummy100 inet6 static
         address FCAA::1
         netmask 64
         autoconf 0


### PR DESCRIPTION
A dummy interface is better than using loopback for routing packets to/from.