### PR TITLE
disable dpd #430

### DIFF
--- a/roles/vpn/templates/ipsec.conf.j2
+++ b/roles/vpn/templates/ipsec.conf.j2
@@ -1,11 +1,11 @@
 config setup
-    uniqueids = never # allow multiple connections per user
+    uniqueids = replace
     charondebug="ike 2, knl 2, cfg 2, net 2, esp 2, dmn 2,  mgr 2"
 
 conn %default
     fragmentation=yes
     rekey=no
-    dpdaction=clear
+    dpdaction=none
     keyexchange=ikev2
     compress=yes
     dpddelay=35s


### PR DESCRIPTION
There's a subtle bug in strongSwan 5.3.5 that causes iOS clients to excessively re-associate to the server. This causes unnecessary battery drain, among other things. This can be avoided by disabling dead peer detection, or by upgrading to strongSwan 5.5.1. We chose to disable dpd rather than migrate our entire base install from 16.04 to 17.04.

More information is available in https://github.com/trailofbits/algo/issues/430