### PR TITLE
Add linters to our CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,15 @@ install:
   - sudo mkdir -vm 0700 $LXC_ROOTFS/root/.ssh/
   - sudo cp -v ~/.ssh/id_rsa.pub $LXC_ROOTFS/root/.ssh/authorized_keys
   - sudo apt-get install build-essential libssl-dev libffi-dev python-dev && sudo pip install -r requirements.txt
+  - pip install ansible-lint
 
 before_script:
   - gem install awesome_bot
 
 script:
   - awesome_bot --allow-dupe --skip-save-results *.md docs/*.md --white-list paypal.com,do.co,microsoft.com,https://github.com/trailofbits/algo/archive/master.zip,https://github.com/trailofbits/algo/issues/new
+#  - shellcheck algo
+#  - ansible-lint deploy.yml users.yml deploy_client.yml
   - ansible-playbook deploy.yml --syntax-check
   - ansible-playbook deploy.yml -t local,vpn,dns,ssh_tunneling,security,tests -e "server_ip=$LXC_IP server_user=root IP_subject_alt_name=$LXC_IP local_dns=Y"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ install:
 
 before_script:
   - gem install awesome_bot
-  - awesome_bot --allow-dupe --skip-save-results *.md docs/*.md --white-list paypal.com,do.co,microsoft.com,https://github.com/trailofbits/algo/archive/master.zip,https://github.com/trailofbits/algo/issues/new
 
 script:
+  - awesome_bot --allow-dupe --skip-save-results *.md docs/*.md --white-list paypal.com,do.co,microsoft.com,https://github.com/trailofbits/algo/archive/master.zip,https://github.com/trailofbits/algo/issues/new
   - ansible-playbook deploy.yml --syntax-check
   - ansible-playbook deploy.yml -t local,vpn,dns,ssh_tunneling,security,tests -e "server_ip=$LXC_IP server_user=root IP_subject_alt_name=$LXC_IP local_dns=Y"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,16 @@ install:
   - sudo cp -v ~/.ssh/id_rsa.pub $LXC_ROOTFS/root/.ssh/authorized_keys
   - sudo apt-get install build-essential libssl-dev libffi-dev python-dev && sudo pip install -r requirements.txt
 
+before_script:
+  - gem install awesome_bot
+  - awesome_bot --allow-dupe --skip-save-results *.md docs/*.md --white-list paypal.com,do.co,microsoft.com,https://github.com/trailofbits/algo/archive/master.zip,https://github.com/trailofbits/algo/issues/new
+
 script:
   - ansible-playbook deploy.yml --syntax-check
   - ansible-playbook deploy.yml -t local,vpn,dns,ssh_tunneling,security,tests -e "server_ip=$LXC_IP server_user=root IP_subject_alt_name=$LXC_IP local_dns=Y"
 
 after_script:
   - ./tests/update-users.sh
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     - lxc-templates
     - expect-dev
     - debootstrap
+    - shellcheck
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Algo VPN
 
-[![TravisCI Status](https://travis-ci.org/trailofbits/algo.svg?branch=master)](https://travis-ci.org/trailofbits/algo)
+[![TravisCI Status](https://api.travis-ci.org/trailofbits/algo.svg?branch=master)](https://travis-ci.org/trailofbits/algo)
 [![Slack Status](https://empireslacking.herokuapp.com/badge.svg)](https://empireslacking.herokuapp.com)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/fold_left.svg?style=social&label=Follow%20%40AlgoVPN)](https://twitter.com/AlgoVPN)
 [![Flattr](https://button.flattr.com/flattr-badge-large.png)](https://flattr.com/submit/auto?fid=kxw60j&url=https%3A%2F%2Fgithub.com%2Ftrailofbits%2Falgo)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,7 @@
 
 ## Has Algo been audited?
 
-No. This project is under [active development](https://github.com/trailofbits/algo/projects/1). We're happy to [accept and fix issues](https://github.com/trailofbits/algo/issues) as they are identified. Use Algo at your own risk. If you find a security issue of any severity, please [contact us on Slack](https://empireslacking.herokuapp.com).
+No. This project is under active development. We're happy to [accept and fix issues](https://github.com/trailofbits/algo/issues) as they are identified. Use Algo at your own risk. If you find a security issue of any severity, please [contact us on Slack](https://empireslacking.herokuapp.com).
 
 ## Why aren't you using Tor?
 
@@ -26,7 +26,7 @@ I would, but I don't know of any [suitable ones](https://github.com/trailofbits/
 
 ## Why aren't you using OpenVPN?
 
-OpenVPN does not have out-of-the-box client support on any major desktop or mobile operating system. This introduces user experience issues and requires the user to [update](https://www.exploit-db.com/exploits/34037/) and [maintain](https://www.exploit-db.com/exploits/20485/) the software themselves. OpenVPN depends on the security of [TLS](https://tools.ietf.org/html/rfc7457), both the [protocol](http://arstechnica.com/security/2016/08/new-attack-can-pluck-secrets-from-1-of-https-traffic-affects-top-sites/) and its [implementations](http://arstechnica.com/security/2014/04/confirmed-nasty-heartbleed-bug-exposes-openvpn-private-keys-too/), and we simply trust the server less due to [past](https://sweet32.info/) [security](https://github.com/ValdikSS/openvpn-fix-dns-leak-plugin/blob/master/README.md) [incidents](https://www.exploit-db.com/exploits/34879/).
+OpenVPN does not have out-of-the-box client support on any major desktop or mobile operating system. This introduces user experience issues and requires the user to [update](https://www.exploit-db.com/exploits/34037/) and [maintain](https://www.exploit-db.com/exploits/20485/) the software themselves. OpenVPN depends on the security of [TLS](https://tools.ietf.org/html/rfc7457), both the [protocol](https://arstechnica.com/security/2016/08/new-attack-can-pluck-secrets-from-1-of-https-traffic-affects-top-sites/) and its [implementations](https://arstechnica.com/security/2014/04/confirmed-nasty-heartbleed-bug-exposes-openvpn-private-keys-too/), and we simply trust the server less due to [past](https://sweet32.info/) [security](https://github.com/ValdikSS/openvpn-fix-dns-leak-plugin/blob/master/README.md) [incidents](https://www.exploit-db.com/exploits/34879/).
 
 ## Why aren't you using Alpine Linux, OpenBSD, or HardenedBSD?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,8 +36,6 @@ You have not agreed to the Xcode license agreements, please run 'xcodebuild -lic
     No working compiler found, or bogus compiler options
     passed to the compiler from Python's distutils module.
     See the error messages above.
-    (If they are about -mno-fused-madd and you are on OS/X 10.8,
-    see http://stackoverflow.com/questions/22313407/ .)
 
 ----------------------------------------
 Cleaning up...


### PR DESCRIPTION
I added a few linters to our CI. awesome_bot checks for issues in the documentation, shellcheck in the main `algo` shell script, and ansible-lint in all the Ansible playbooks. Shellcheck and ansible-lint are currently disabled because we have a lot of minor issues to fix.