### PR TITLE
Windows 10 -PfsGroup None --> -PfsGroup ECP256

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Your VPN is now installed and ready to use.
 If you want to perform these steps by hand, you will need to import the user certificate to the Personal certificate store, add an IKEv2 connection in the network settings, then activate stronger ciphers on it via the following PowerShell script:
 
 ```powershell
-Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo" -AuthenticationTransformConstants GCMAES128 -CipherTransformConstants GCMAES128 -EncryptionMethod AES128 -IntegrityCheckMethod SHA384 -DHGroup ECP256 -PfsGroup none
+Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo" -AuthenticationTransformConstants GCMAES128 -CipherTransformConstants GCMAES128 -EncryptionMethod AES128 -IntegrityCheckMethod SHA384 -DHGroup ECP256 -PfsGroup ECP256
 ```
 
 ### Linux Network Manager Clients (e.g., Ubuntu, Debian, or Fedora Desktop)

--- a/roles/vpn/templates/client_windows.ps1.j2
+++ b/roles/vpn/templates/client_windows.ps1.j2
@@ -1,3 +1,3 @@
 certutil -f -p {{ easyrsa_p12_export_password }} -importpfx .\{{ item }}.p12
 Add-VpnConnection -name "Algo VPN {{ IP_subject_alt_name }} IKEv2" -ServerAddress "{{ IP_subject_alt_name }}" -TunnelType IKEv2 -AuthenticationMethod MachineCertificate -EncryptionLevel Required
-Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo VPN {{ IP_subject_alt_name }} IKEv2" -AuthenticationTransformConstants GCMAES128 -CipherTransformConstants GCMAES128 -EncryptionMethod AES128 -IntegrityCheckMethod SHA384 -DHGroup ECP256 -PfsGroup none
+Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo VPN {{ IP_subject_alt_name }} IKEv2" -AuthenticationTransformConstants GCMAES128 -CipherTransformConstants GCMAES128 -EncryptionMethod AES128 -IntegrityCheckMethod SHA384 -DHGroup ECP256 -PfsGroup ECP256


### PR DESCRIPTION
Fixes broken tunnel when rekey (CREATE_CHILD_SA request [ N(REKEY_SA) SA No TSi TSr KE ]) occurs (on my Windows 10 1703 build 15063.138 Creator's Update system this is ~every 57 minutes)