### PR TITLE
Specify EIP domain

### DIFF
--- a/roles/cloud-ec2/templates/stack.yml.j2
+++ b/roles/cloud-ec2/templates/stack.yml.j2
@@ -187,9 +187,11 @@ Resources:
   ElasticIP:
     Type: AWS::EC2::EIP
     Properties:
+      Domain: vpc
       InstanceId: !Ref EC2Instance
     DependsOn:
       - EC2Instance
+      - VPCGatewayAttachment
 
 Outputs:
   ElasticIP:


### PR DESCRIPTION
CloudFormation throws the error `You must specify an allocation id when mapping an address to a VPC instance` when creating the ElasticIP.

This specifies the EIP's domain as `vpc`, and makes it dependent on the `VPCGatewayAttachment`, per https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip.html.