### PR TITLE
Added missing minimum policy actions.

### DIFF
--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -157,7 +157,9 @@ Additional tags:
                 "ec2:DescribeSecurityGroups",
                 "ec2:AuthorizeSecurityGroupIngress",
                 "ec2:RunInstances",
-                "ec2:DescribeInstances"
+                "ec2:DescribeInstances",
+                "ec2:AllocateAddress",
+                "ec2:DescribeAddresses"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
Going through the installation process it appears that you're missing the following calls: `ec2:describeAddresses` and `ec2:allocateAddress`. This change fixes that.