### PR TITLE
Add additional delay for ec2 instance prior to ssh

### DIFF
--- a/playbooks/post.yml
+++ b/playbooks/post.yml
@@ -12,6 +12,6 @@
 
 - name: A short pause, in order to be sure the instance is ready
   pause:
-    seconds: 10
+    seconds: 20
 
 - include: local_ssh.yml

--- a/roles/cloud-ec2/tasks/main.yml
+++ b/roles/cloud-ec2/tasks/main.yml
@@ -62,10 +62,6 @@
         line: "{{ item.public_ip_address }}"
       with_items:
         - "{{ algo_instances.instances }}"
-
-    - name: Extra wait time for ec2 instance to be ready
-      pause:
-        seconds: 20
   rescue:
     - debug: var=fail_hint
       tags: always

--- a/roles/cloud-ec2/tasks/main.yml
+++ b/roles/cloud-ec2/tasks/main.yml
@@ -62,6 +62,10 @@
         line: "{{ item.public_ip_address }}"
       with_items:
         - "{{ algo_instances.instances }}"
+
+    - name: Extra wait time for ec2 instance to be ready
+      pause:
+        seconds: 20
   rescue:
     - debug: var=fail_hint
       tags: always


### PR DESCRIPTION
Intermittently (in my experience, 5 out of 6 tries), algo attempts to connect to the ec2 instance before the public key is added by CloudFormation.

The following error is thrown:
```fatal: [x.x.x.x]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Warning: Permanently added 'x.x.x.x' (ECDSA) to the list of known hosts.\r\nPermission denied (publickey).\r\n", "unreachable": true}```

Note, this does not appear to be related to the ssh directory permission error (https://github.com/trailofbits/algo/issues/321).

As indicated by https://github.com/trailofbits/algo/issues/429#issuecomment-295076148, a redeploy typically solves this.

By adding an additional 20 second delay prior to executing the `uname -a` in `playbooks/post.yml`, this error has ceased for me.

**I admit that this is an inelegant solution.** I've been unsuccessful in getting the `raw:` command to continue when an unreachable state is triggered.