### PR TITLE
cleaner syntax for local actions

### DIFF
--- a/playbooks/local.yml
+++ b/playbooks/local.yml
@@ -1,16 +1,23 @@
 ---
 
 - name: Generate the SSH private key
-  local_action: shell echo -e  'n' | ssh-keygen -b 2048 -C {{ SSH_keys.comment }} -t rsa -f {{ SSH_keys.private }} -q -N ""
+  shell: >
+    echo -e  'n' |
+    ssh-keygen -b 2048 -C {{ SSH_keys.comment }}
+    -t rsa -f {{ SSH_keys.private }} -q -N ""
   args:
     creates: "{{ SSH_keys.private }}"
 
 - name: Generate the SSH public key
-  local_action: shell echo `ssh-keygen -y -f {{ SSH_keys.private }}` {{ SSH_keys.comment }} > {{ SSH_keys.public }}
+  shell: >
+    echo `ssh-keygen -y -f {{ SSH_keys.private }}` {{ SSH_keys.comment }}
+    > {{ SSH_keys.public }}
   changed_when: false
 
 - name: Change mode for the SSH private key
-  local_action: file path={{ SSH_keys.private }} mode=0600
+  file:
+    path: "{{ SSH_keys.private }}"
+    mode: 0600
 
 - name: Ensure the dynamic inventory exists
   blockinfile:

--- a/playbooks/local_ssh.yml
+++ b/playbooks/local_ssh.yml
@@ -1,14 +1,12 @@
 ---
 
 - name: Ensure the local ssh directory is exist
-  local_action:
-    module: file
-    path: "~/.ssh/"
+  file:
+    path: ~/.ssh/
     state: directory
 
 - name: Copy the algo ssh key to the local ssh directory
-  local_action:
-    module: copy
+  copy:
     src: "{{ SSH_keys.private }}"
     dest: ~/.ssh/algo.pem
     mode: '0600'

--- a/playbooks/post.yml
+++ b/playbooks/post.yml
@@ -1,8 +1,7 @@
 ---
 
 - name: Wait until SSH becomes ready...
-  local_action:
-    module: wait_for
+  wait_for:
     port: 22
     host: "{{ cloud_instance_ip }}"
     search_regex: "OpenSSH"

--- a/roles/vpn/tasks/client_configs.yml
+++ b/roles/vpn/tasks/client_configs.yml
@@ -1,8 +1,7 @@
 ---
 
 - name: Register p12 PayloadContent
-  local_action: >
-    shell cat private/{{ item }}.p12 | base64
+  shell: cat private/{{ item }}.p12 | base64
   register:  PayloadContent
   become: no
   args:
@@ -15,8 +14,7 @@
     PayloadContentCA: "{{ lookup('file' , 'configs/{{ IP_subject_alt_name }}/pki/cacert.pem')|b64encode }}"
 
 - name: Build the mobileconfigs
-  local_action:
-    module: template
+  template:
     src: mobileconfig.j2
     dest: configs/{{ IP_subject_alt_name }}/{{ item.0 }}.mobileconfig
     mode: 0600
@@ -27,8 +25,7 @@
   no_log: True
 
 - name: Build the strongswan app android config
-  local_action:
-    module: template
+  template:
     src: sswan.j2
     dest: configs/{{ IP_subject_alt_name }}/{{ item.0 }}.sswan
     mode: 0600
@@ -39,8 +36,7 @@
   no_log: True
 
 - name: Build the client ipsec config file
-  local_action:
-    module: template
+  template:
     src: client_ipsec.conf.j2
     dest: configs/{{ IP_subject_alt_name }}/ipsec_{{ item }}.conf
     mode: 0600
@@ -49,8 +45,7 @@
     - "{{ users }}"
 
 - name: Build the client ipsec secret file
-  local_action:
-    module: template
+  template:
     src: client_ipsec.secrets.j2
     dest: configs/{{ IP_subject_alt_name }}/ipsec_{{ item }}.secrets
     mode: 0600
@@ -59,8 +54,7 @@
     - "{{ users }}"
 
 - name: Build the windows client powershell script
-  local_action:
-    module: template
+  template:
     src: client_windows.ps1.j2
     dest: configs/{{ IP_subject_alt_name }}/windows_{{ item }}.ps1
     mode: 0600
@@ -69,8 +63,7 @@
   with_items: "{{ users }}"
 
 - name: Restrict permissions for the local private directories
-  local_action:
-    module: file
+  file:
     path: "{{ item }}"
     state: directory
     mode: 0700

--- a/roles/vpn/tasks/main.yml
+++ b/roles/vpn/tasks/main.yml
@@ -24,6 +24,7 @@
       tags: update-users
     - include: distribute_keys.yml
     - include: client_configs.yml
+      delegate_to: localhost
       tags: update-users
 
     - meta: flush_handlers

--- a/roles/vpn/tasks/openssl.yml
+++ b/roles/vpn/tasks/openssl.yml
@@ -37,9 +37,15 @@
       dest: "configs/{{ IP_subject_alt_name }}/pki/openssl.cnf"
 
   - name: Build the CA pair
-    shell: |
+    shell: >
       openssl ecparam -name prime256v1 -out ecparams/prime256v1.pem &&
-      openssl req -utf8 -new -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }} -config openssl.cnf -keyout private/cakey.pem -out cacert.pem -x509 -days 3650 -batch -passout pass:"{{ easyrsa_CA_password }}" &&
+      openssl req -utf8 -new
+      -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }}
+      -config openssl.cnf
+      -keyout private/cakey.pem
+      -out cacert.pem -x509 -days 3650
+      -batch
+      -passout pass:"{{ easyrsa_CA_password }}" &&
       touch {{ IP_subject_alt_name }}_ca_generated
     args:
       chdir: "configs/{{ IP_subject_alt_name }}/pki/"
@@ -60,9 +66,20 @@
       creates: serial_generated
 
   - name: Build the server pair
-    shell: |
-      openssl req -utf8 -new -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }} -config openssl.cnf -keyout private/{{ IP_subject_alt_name }}.key -out reqs/{{ IP_subject_alt_name }}.req -nodes -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ IP_subject_alt_name }}" -batch &&
-      openssl ca -utf8 -in reqs/{{ IP_subject_alt_name }}.req -out certs/{{ IP_subject_alt_name }}.crt -config openssl.cnf -days 3650 -batch -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ IP_subject_alt_name }}" &&
+    shell: >
+      openssl req -utf8 -new
+      -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }}
+      -config openssl.cnf
+      -keyout private/{{ IP_subject_alt_name }}.key
+      -out reqs/{{ IP_subject_alt_name }}.req -nodes
+      -passin pass:"{{ easyrsa_CA_password }}"
+      -subj "/CN={{ IP_subject_alt_name }}" -batch &&
+      openssl ca -utf8
+      -in reqs/{{ IP_subject_alt_name }}.req
+      -out certs/{{ IP_subject_alt_name }}.crt
+      -config openssl.cnf -days 3650 -batch
+      -passin pass:"{{ easyrsa_CA_password }}"
+      -subj "/CN={{ IP_subject_alt_name }}" &&
       touch certs/{{ IP_subject_alt_name }}_crt_generated
     args:
       chdir: "configs/{{ IP_subject_alt_name }}/pki/"
@@ -71,9 +88,20 @@
       subjectAltName: "DNS:{{ IP_subject_alt_name }},IP:{{ IP_subject_alt_name }}"
 
   - name: Build the client's pair
-    shell: |
-      openssl req -utf8 -new -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }} -config openssl.cnf -keyout private/{{ item }}.key -out reqs/{{ item }}.req -nodes -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ item }}" -batch &&
-      openssl ca -utf8 -in reqs/{{ item }}.req -out certs/{{ item }}.crt -config openssl.cnf -days 3650 -batch -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ item }}" &&
+    shell: >
+      openssl req -utf8 -new
+      -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }}
+      -config openssl.cnf
+      -keyout private/{{ item }}.key
+      -out reqs/{{ item }}.req -nodes
+      -passin pass:"{{ easyrsa_CA_password }}"
+      -subj "/CN={{ item }}" -batch &&
+      openssl ca -utf8
+      -in reqs/{{ item }}.req
+      -out certs/{{ item }}.crt
+      -config openssl.cnf -days 3650 -batch
+      -passin pass:"{{ easyrsa_CA_password }}"
+      -subj "/CN={{ item }}" &&
       touch certs/{{ item }}_crt_generated
     args:
       chdir: "configs/{{ IP_subject_alt_name }}/pki/"
@@ -84,7 +112,8 @@
 
   - name: Build the client's p12
     shell: >
-      openssl pkcs12 -in certs/{{ item }}.crt
+      openssl pkcs12
+      -in certs/{{ item }}.crt
       -inkey private/{{ item }}.key
       -export
       -name {{ item }}
@@ -104,7 +133,7 @@
       - "{{ users }}"
 
   - name: Get active users
-    shell: |
+    shell: >
       grep ^V index.txt |
       grep -v "{{ IP_subject_alt_name }}" |
       awk '{print $5}' |
@@ -114,12 +143,19 @@
     register: valid_certs
 
   - name: Revoke non-existing users
-    shell: |
-        openssl ca -config openssl.cnf -passin pass:"{{ easyrsa_CA_password }}" -revoke certs/{{ item }}.crt &&
-        openssl ca -gencrl -config openssl.cnf -passin pass:"{{ easyrsa_CA_password }}" -revoke certs/{{ item }}.crt -out crl/{{ item }}.crt
-        touch crl/{{ item }}_revoked
+    shell: >
+      openssl ca
+      -config openssl.cnf
+      -passin pass:"{{ easyrsa_CA_password }}"
+      -revoke certs/{{ item }}.crt &&
+      openssl ca -gencrl
+      -config openssl.cnf
+      -passin pass:"{{ easyrsa_CA_password }}"
+      -revoke certs/{{ item }}.crt
+      -out crl/{{ item }}.crt
+      touch crl/{{ item }}_revoked
     args:
-      chdir: "configs/{{ IP_subject_alt_name }}/pki/"
+      chdir: configs/{{ IP_subject_alt_name }}/pki/
       creates: crl/{{ item }}_revoked
     environment:
       subjectAltName: "DNS:{{ item }}"

--- a/roles/vpn/tasks/openssl.yml
+++ b/roles/vpn/tasks/openssl.yml
@@ -1,141 +1,133 @@
 ---
 
-- name: Ensure the pki directory does not exist
-  local_action:
-    module: file
-    dest: configs/{{ IP_subject_alt_name }}/pki
-    state: absent
-  become: no
-  when: easyrsa_reinit_existent == True
+- block:
+  - name: Ensure the pki directory does not exist
+    file:
+      dest: configs/{{ IP_subject_alt_name }}/pki
+      state: absent
+    when: easyrsa_reinit_existent == True
 
-- name: Ensure the pki directories exist
-  local_action:
-    module: file
-    dest: "configs/{{ IP_subject_alt_name }}/pki/{{ item }}"
-    state: directory
-    recurse: yes
-  become: no
-  with_items:
-    - ecparams
-    - certs
-    - crl
-    - newcerts
-    - private
-    - reqs
+  - name: Ensure the pki directories exist
+    file:
+      dest: "configs/{{ IP_subject_alt_name }}/pki/{{ item }}"
+      state: directory
+      recurse: yes
+    with_items:
+      - ecparams
+      - certs
+      - crl
+      - newcerts
+      - private
+      - reqs
 
-- name: Ensure the files exist
-  local_action:
-    module: file
-    dest: "configs/{{ IP_subject_alt_name }}/pki/{{ item }}"
-    state: touch
-  become: no
-  with_items:
-    - ".rnd"
-    - "private/.rnd"
-    - "index.txt"
-    - "index.txt.attr"
-    - "serial"
+  - name: Ensure the files exist
+    file:
+      dest: "configs/{{ IP_subject_alt_name }}/pki/{{ item }}"
+      state: touch
+    with_items:
+      - ".rnd"
+      - "private/.rnd"
+      - "index.txt"
+      - "index.txt.attr"
+      - "serial"
 
-- name: Generate the openssl server configs
-  local_action:
-    module: template
-    src: openssl.cnf.j2
-    dest: "configs/{{ IP_subject_alt_name }}/pki/openssl.cnf"
-  become: no
+  - name: Generate the openssl server configs
+    template:
+      src: openssl.cnf.j2
+      dest: "configs/{{ IP_subject_alt_name }}/pki/openssl.cnf"
 
-- name: Build the CA pair
-  local_action: >
-    shell openssl ecparam -name prime256v1 -out ecparams/prime256v1.pem &&
+  - name: Build the CA pair
+    shell: |
+      openssl ecparam -name prime256v1 -out ecparams/prime256v1.pem &&
       openssl req -utf8 -new -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }} -config openssl.cnf -keyout private/cakey.pem -out cacert.pem -x509 -days 3650 -batch -passout pass:"{{ easyrsa_CA_password }}" &&
       touch {{ IP_subject_alt_name }}_ca_generated
-  become: no
-  args:
-    chdir: "configs/{{ IP_subject_alt_name }}/pki/"
-    creates: "{{ IP_subject_alt_name }}_ca_generated"
-  environment:
-    subjectAltName: "DNS:{{ IP_subject_alt_name }},IP:{{ IP_subject_alt_name }}"
+    args:
+      chdir: "configs/{{ IP_subject_alt_name }}/pki/"
+      creates: "{{ IP_subject_alt_name }}_ca_generated"
+    environment:
+      subjectAltName: "DNS:{{ IP_subject_alt_name }},IP:{{ IP_subject_alt_name }}"
 
-- name: Copy the CA certificate
-  local_action:
-    module: copy
-    src: "configs/{{ IP_subject_alt_name }}/pki/cacert.pem"
-    dest: "configs/{{ IP_subject_alt_name }}/cacert.pem"
-    mode: 0600
-  become: no
+  - name: Copy the CA certificate
+    copy:
+      src: "configs/{{ IP_subject_alt_name }}/pki/cacert.pem"
+      dest: "configs/{{ IP_subject_alt_name }}/cacert.pem"
+      mode: 0600
 
-- name: Generate the serial number
-  local_action: >
-    shell echo 01 > serial &&
-      touch serial_generated
-  become: no
-  args:
-    chdir: "configs/{{ IP_subject_alt_name }}/pki/"
-    creates: serial_generated
+  - name: Generate the serial number
+    shell: echo 01 > serial && touch serial_generated
+    args:
+      chdir: "configs/{{ IP_subject_alt_name }}/pki/"
+      creates: serial_generated
 
-- name: Build the server pair
-  local_action: >
-    shell openssl req -utf8 -new -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }} -config openssl.cnf -keyout private/{{ IP_subject_alt_name }}.key -out reqs/{{ IP_subject_alt_name }}.req -nodes -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ IP_subject_alt_name }}" -batch &&
-    openssl ca -utf8 -in reqs/{{ IP_subject_alt_name }}.req -out certs/{{ IP_subject_alt_name }}.crt -config openssl.cnf -days 3650 -batch -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ IP_subject_alt_name }}" &&
-    touch certs/{{ IP_subject_alt_name }}_crt_generated
-  become: no
-  args:
-    chdir: "configs/{{ IP_subject_alt_name }}/pki/"
-    creates: certs/{{ IP_subject_alt_name }}_crt_generated
-  environment:
-    subjectAltName: "DNS:{{ IP_subject_alt_name }},IP:{{ IP_subject_alt_name }}"
+  - name: Build the server pair
+    shell: |
+      openssl req -utf8 -new -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }} -config openssl.cnf -keyout private/{{ IP_subject_alt_name }}.key -out reqs/{{ IP_subject_alt_name }}.req -nodes -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ IP_subject_alt_name }}" -batch &&
+      openssl ca -utf8 -in reqs/{{ IP_subject_alt_name }}.req -out certs/{{ IP_subject_alt_name }}.crt -config openssl.cnf -days 3650 -batch -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ IP_subject_alt_name }}" &&
+      touch certs/{{ IP_subject_alt_name }}_crt_generated
+    args:
+      chdir: "configs/{{ IP_subject_alt_name }}/pki/"
+      creates: certs/{{ IP_subject_alt_name }}_crt_generated
+    environment:
+      subjectAltName: "DNS:{{ IP_subject_alt_name }},IP:{{ IP_subject_alt_name }}"
 
-- name: Build the client's pair
-  local_action: >
-   shell openssl req -utf8 -new -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }} -config openssl.cnf -keyout private/{{ item }}.key -out reqs/{{ item }}.req -nodes -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ item }}" -batch &&
+  - name: Build the client's pair
+    shell: |
+      openssl req -utf8 -new -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }} -config openssl.cnf -keyout private/{{ item }}.key -out reqs/{{ item }}.req -nodes -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ item }}" -batch &&
       openssl ca -utf8 -in reqs/{{ item }}.req -out certs/{{ item }}.crt -config openssl.cnf -days 3650 -batch -passin pass:"{{ easyrsa_CA_password }}" -subj "/CN={{ item }}" &&
       touch certs/{{ item }}_crt_generated
-  become: no
-  args:
-    chdir: "configs/{{ IP_subject_alt_name }}/pki/"
-    creates: certs/{{ item }}_crt_generated
-  environment:
-    subjectAltName: "DNS:{{ item }}"
-  with_items: "{{ users }}"
+    args:
+      chdir: "configs/{{ IP_subject_alt_name }}/pki/"
+      creates: certs/{{ item }}_crt_generated
+    environment:
+      subjectAltName: "DNS:{{ item }}"
+    with_items: "{{ users }}"
 
-- name: Build the client's p12
-  local_action: >
-    shell openssl pkcs12 -in certs/{{ item }}.crt -inkey private/{{ item }}.key -export -name {{ item }} -out private/{{ item }}.p12 -certfile cacert.pem -passout pass:"{{ easyrsa_p12_export_password }}"
-  become: no
-  args:
-    chdir: "configs/{{ IP_subject_alt_name }}/pki/"
-  with_items: "{{ users }}"
+  - name: Build the client's p12
+    shell: >
+      openssl pkcs12 -in certs/{{ item }}.crt
+      -inkey private/{{ item }}.key
+      -export
+      -name {{ item }}
+      -out private/{{ item }}.p12
+      -certfile cacert.pem
+      -passout pass:"{{ easyrsa_p12_export_password }}"
+    args:
+      chdir: "configs/{{ IP_subject_alt_name }}/pki/"
+    with_items: "{{ users }}"
 
-- name: Copy the p12 certificates
-  local_action:
-    module: copy
-    src: "configs/{{ IP_subject_alt_name }}/pki/private/{{ item }}.p12"
-    dest: "configs/{{ IP_subject_alt_name }}/{{ item }}.p12"
-    mode: 0600
-  become: no
-  with_items:
-    - "{{ users }}"
+  - name: Copy the p12 certificates
+    copy:
+      src: "configs/{{ IP_subject_alt_name }}/pki/private/{{ item }}.p12"
+      dest: "configs/{{ IP_subject_alt_name }}/{{ item }}.p12"
+      mode: 0600
+    with_items:
+      - "{{ users }}"
 
-- name: Get active users
-  local_action: >
-    shell grep ^V index.txt | grep -v "{{ IP_subject_alt_name }}" | awk '{print $5}' | sed 's/\/CN=//g'
-  become: no
-  args:
-    chdir: "configs/{{ IP_subject_alt_name }}/pki/"
-  register: valid_certs
+  - name: Get active users
+    shell: |
+      grep ^V index.txt |
+      grep -v "{{ IP_subject_alt_name }}" |
+      awk '{print $5}' |
+      sed 's/\/CN=//g'
+    args:
+      chdir: "configs/{{ IP_subject_alt_name }}/pki/"
+    register: valid_certs
 
-- name: Revoke non-existing users
-  local_action: >
-    shell openssl ca -config openssl.cnf -passin pass:"{{ easyrsa_CA_password }}" -revoke certs/{{ item }}.crt &&
-      openssl ca -gencrl -config openssl.cnf -passin pass:"{{ easyrsa_CA_password }}" -revoke certs/{{ item }}.crt -out crl/{{ item }}.crt
-      touch crl/{{ item }}_revoked
+  - name: Revoke non-existing users
+    shell: |
+        openssl ca -config openssl.cnf -passin pass:"{{ easyrsa_CA_password }}" -revoke certs/{{ item }}.crt &&
+        openssl ca -gencrl -config openssl.cnf -passin pass:"{{ easyrsa_CA_password }}" -revoke certs/{{ item }}.crt -out crl/{{ item }}.crt
+        touch crl/{{ item }}_revoked
+    args:
+      chdir: "configs/{{ IP_subject_alt_name }}/pki/"
+      creates: crl/{{ item }}_revoked
+    environment:
+      subjectAltName: "DNS:{{ item }}"
+    when: item not in users
+    with_items: "{{ valid_certs.stdout_lines }}"
+
+  delegate_to: localhost
   become: no
-  args:
-    chdir: "configs/{{ IP_subject_alt_name }}/pki/"
-    creates: crl/{{ item }}_revoked
-  environment:
-    subjectAltName: "DNS:{{ item }}"
-  when: item not in users
-  with_items: "{{ valid_certs.stdout_lines }}"
 
 - name: Copy the revoked certificates to the vpn server
   copy:


### PR DESCRIPTION
Good evening! :)

The use of the 'local_action' module is often less clean, as it makes code look very different, while the only thing that you want different is the host on which it runs. It's therefore cleaner to use "delegate_to: localhost", which can also be used on a higher level (includes/blocks) to make it even cleaner.

What do you think?