### PR TITLE
renamed localhost group to fix duplicate in naming group/host

### DIFF
--- a/inventory
+++ b/inventory
@@ -1,2 +1,2 @@
-[localhost]
+[local]
 localhost ansible_connection=local ansible_python_interpreter=python


### PR DESCRIPTION
Ansible warns that both the group and the host in the 'inventory'-file are similarly named. This leads to Ansible not being able to distinguish between the group and the host. While this is not a big issue, it's not so nice.