### PR TITLE
Add html helper for Android

### DIFF
--- a/docs/client-android.md
+++ b/docs/client-android.md
@@ -2,10 +2,10 @@
 
 ## Installation via profiles
 
-1. [Install the strongSwan VPN Client](https://play.google.com/store/apps/details?id=org.strongswan.android) (Android 4+)
-2. Copy your `android_{username}.sswan` and `android_{username}_helper.html` to your phone's internal storage
-3. Open the helper file in a browser (Google Chrome works well)
-4. Click on the link. It opens the StrongSwan app in order to import the certificates and configure VPN.
+1. [Install the strongSwan VPN Client](https://play.google.com/store/apps/details?id=org.strongswan.android).
+2. Copy `android_{username}.sswan` and `android_{username}_helper.html` to your phone's internal storage.
+3. Open the helper file in a browser (e.g., Google Chrome).
+4. Click on the link. It opens the StrongSwan app and configures the VPN with your profile.
 
 ## Manual installation
 

--- a/docs/client-android.md
+++ b/docs/client-android.md
@@ -1,5 +1,14 @@
 # Android client setup
 
+## Installation via profiles
+
+1. [Install the strongSwan VPN Client](https://play.google.com/store/apps/details?id=org.strongswan.android) (Android 4+)
+2. Copy your `android_{username}.sswan` and `android_{username}_helper.html` to your phone's internal storage
+3. Open the helper file in a browser (Google Chrome works well)
+4. Click on the link. It opens the StrongSwan app in order to import the certificates and configure VPN.
+
+## Manual installation
+
 **NOTE:** If you are a Project Fi user, you must disable WiFi Assistant before continuing. See the [strongSwan documentation](https://wiki.strongswan.org/projects/strongswan/wiki/AndroidVPNClient) for details.
 
 | Instruction | Screenshot(s) |

--- a/roles/vpn/tasks/client_configs.yml
+++ b/roles/vpn/tasks/client_configs.yml
@@ -27,12 +27,22 @@
 - name: Build the strongswan app android config
   template:
     src: sswan.j2
-    dest: configs/{{ IP_subject_alt_name }}/{{ item.0 }}.sswan
+    dest: configs/{{ IP_subject_alt_name }}/android_{{ item.0 }}.sswan
     mode: 0600
   become: no
   with_together:
     - "{{ users }}"
     - "{{ PayloadContent.results }}"
+  no_log: True
+
+- name: Build the android helper html
+  template:
+    src: android_html_helper.j2
+    dest: configs/{{ IP_subject_alt_name }}/android_{{ item.0 }}_helper.html
+    mode: 0600
+  become: no
+  with_together:
+    - "{{ users }}"
   no_log: True
 
 - name: Build the client ipsec config file

--- a/roles/vpn/templates/android_html_helper.j2
+++ b/roles/vpn/templates/android_html_helper.j2
@@ -1,0 +1,1 @@
+<a href="android_{{ item.0 }}.sswan" type="application/vnd.strongswan.profile">{{ item.0 }}</a>


### PR DESCRIPTION
The only way I found with less headache to open a sswan profile and configure Algo on android devices.
Algo generates 2 files: [sswan](https://wiki.strongswan.org/projects/strongswan/wiki/AndroidVPNClientProfiles) profile and helper html file with a link to the profile with the certain MIME type.

Fixes #280