### PR TITLE
Increase the default size of the SSH key.

### DIFF
--- a/playbooks/local.yml
+++ b/playbooks/local.yml
@@ -3,7 +3,7 @@
 - name: Generate the SSH private key
   shell: >
     echo -e  'n' |
-    ssh-keygen -b 2048 -C {{ SSH_keys.comment }}
+    ssh-keygen -b 4096 -C {{ SSH_keys.comment }}
     -t rsa -f {{ SSH_keys.private }} -q -N ""
   args:
     creates: "{{ SSH_keys.private }}"

--- a/roles/vpn/templates/openssl.cnf.j2
+++ b/roles/vpn/templates/openssl.cnf.j2
@@ -52,7 +52,7 @@ emailAddress		= optional
 # Easy-RSA request handling
 # We key off $DN_MODE to determine how to format the DN
 [ req ]
-default_bits		= 2048
+default_bits		= 4096
 default_keyfile 	= privkey.pem
 default_md		= sha256
 distinguished_name	= cn_only


### PR DESCRIPTION
The default SSH key size in 2048. Increasing this to 4096 to match
current best practice guidance.