### PR TITLE
Make documentation on iptables for local installation clearer.

### DIFF
--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -51,6 +51,12 @@ Required variables:
 - server_user
 - IP_subject_alt_name
 
+Note that by default, the iptables rules on your existing server will be overwritten. If you don't want to overwrite the iptables rules, you can use the `--skip-tags iptables` flag, for example:
+
+```shell
+ansible-playbook deploy.yml -t local,vpn --skip-tags iptables -e 'server_ip=172.217.2.238 server_user=algo IP_subject_alt_name=172.217.2.238'
+```
+
 ### Digital Ocean
 
 Required variables:

--- a/docs/deploy-to-ubuntu.md
+++ b/docs/deploy-to-ubuntu.md
@@ -13,4 +13,4 @@ git clone https://github.com/trailofbits/algo
 cd algo && ./algo
 ```
 
-**Warning**: If you run Algo on your existing server, the iptables rules will be overwritten. If you don't want to overwrite the rules, you must deploy via `ansible-playbook` and skip the `iptables` tag as described below.
+**Warning**: If you run Algo on your existing server, the iptables rules will be overwritten. If you don't want to overwrite the rules, you must deploy via `ansible-playbook` and skip the `iptables` tag as described in [deploy-from-ansible.md](deploy-from-ansible.md).


### PR DESCRIPTION
I was looking at the instructions for installing on an existing ubuntu server and found the instructions regarding skipping iptables configuration confusing. This is my draft at a fix. I'm not a very advanced ansible user, so I think the `--skip-tags iptables` needs to be explicit. If not, I can rework the documentation in another pull request.