### PR TITLE
Set default value for GCE to mentioned value (14)

### DIFF
--- a/algo
+++ b/algo
@@ -330,7 +330,7 @@ Name the vpn server:
     24. Northeast Asia  (Tokyo C)
 Please choose the number of your zone. Press enter for default (#14) zone.
 [14]: " -r region
-  region=${region:-8}
+  region=${region:-14}
 
   case "$region" in
     1) zone="us-west1-a" ;;


### PR DESCRIPTION
The default value for GCE mentions region 14, however in the algo script 8 is provided when no region is put in. 

This closes #593 