### PR TITLE
bug in the gce_net module

### DIFF
--- a/roles/cloud-gce/tasks/main.yml
+++ b/roles/cloud-gce/tasks/main.yml
@@ -12,9 +12,9 @@
 
     - name: Network configured
       gce_net:
-        name: "algo-{{ server_name }}"
-        fwname: "algo-{{ server_name }}-fw"
-        allowed: "udp:500,4500;tcp:22;icmp"
+        name: "algo-net-{{ server_name }}"
+        fwname: "algo-net-{{ server_name }}-fw"
+        allowed: "udp:500,4500;tcp:22"
         state: "present"
         mode: auto
         src_range: 0.0.0.0/0


### PR DESCRIPTION
Quick fix for #616 
> When updating an existing firewall rule an error occurs if the allowed list includes a protocol without a port, e.g. icmp.

We definitely need to play with Ansible 2.3. I will send a PR soon.

Fixed #616