### PR TITLE
Fix for Hash Sum mismatch during Ubuntu | Install prerequisites

### DIFF
--- a/playbooks/ubuntu.yml
+++ b/playbooks/ubuntu.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Ubuntu | Install prerequisites
-  raw: sleep 10 && sudo apt-get update -qq && sudo apt-get install -qq -y python2.7
+  raw: sleep 10 && sudo rm -rf /var/lib/apt/lists/* && sudo apt-get clean && sudo apt-get update -qq && sudo apt-get install -qq -y python2.7
 
 - name: Ubuntu | Configure defaults
   raw: sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1


### PR DESCRIPTION
apt-get update fails due to hash sum mismatch. This stops ./algo installation going forward.

Fix based on: 
[](https://askubuntu.com/questions/41605/trouble-downloading-packages-list-due-to-a-hash-sum-mismatch-error)