### PR TITLE
Return NXDOMAIN instead of IP

### DIFF
--- a/roles/dns_adblocking/tasks/main.yml
+++ b/roles/dns_adblocking/tasks/main.yml
@@ -41,11 +41,10 @@
         minute: 10
         hour: 2
         job: /usr/local/sbin/adblock.sh
-        user: dnsmasq
+        user: root
 
     - name: Update adblock hosts
-      shell: >
-        sudo -u dnsmasq "/usr/local/sbin/adblock.sh"
+      command: /usr/local/sbin/adblock.sh
 
     - meta: flush_handlers
 

--- a/roles/dns_adblocking/templates/adblock.sh.j2
+++ b/roles/dns_adblocking/templates/adblock.sh.j2
@@ -1,15 +1,11 @@
 #!/bin/sh
 # Block ads, malware, etc..
 
-# Redirect endpoint
-ENDPOINT_IP4="0.0.0.0"
-ENDPOINT_IP6="::"
-IPV6="Y"
 TEMP=`mktemp`
 TEMP_SORTED=`mktemp`
 DNSMASQ_WHITELIST="/var/lib/dnsmasq/white.list"
 DNSMASQ_BLACKLIST="/var/lib/dnsmasq/black.list"
-DNSMASQ_BLOCKHOSTS="/var/lib/dnsmasq/block.hosts"
+DNSMASQ_BLOCKHOSTS="{{ config_prefix|default('/') }}etc/dnsmasq.d/block.hosts.conf"
 BLOCKLIST_URLS="{% for url in adblock_lists %}{{ url }} {% endfor %}"
 
 #Delete the old block.hosts to make room for the updates
@@ -18,18 +14,18 @@ rm -f $DNSMASQ_BLOCKHOSTS
 echo 'Downloading hosts lists...'
 #Download and process the files needed to make the lists (enable/add more, if you want)
 for url in $BLOCKLIST_URLS; do
-  wget --timeout=2 --tries=3 -qO- "$url" | awk -v r="$ENDPOINT_IP4" '{sub(/^(0.0.0.0|127.0.0.1)/, r)} $0 ~ "^"r' >> "$TEMP"
+  wget --timeout=2 --tries=3 -qO- "$url" | grep -Ev "(localhost)" | grep -Ew "(0.0.0.0|127.0.0.1)" | awk '{sub(/\r$/,"");print $2}'  >> "$TEMP"
 done
 
 #Add black list, if non-empty
 if [ -s "$DNSMASQ_BLACKLIST" ]
 then
     echo 'Adding blacklist...'
-    awk -v r="$ENDPOINT_IP4" '/^[^#]/ { print r,$1 }' $DNSMASQ_BLACKLIST >> "$TEMP"
+    cat $DNSMASQ_BLACKLIST >> "$TEMP"
 fi
 
 #Sort the download/black lists
-awk '{sub(/\r$/,"");print $1,$2}' "$TEMP"|sort -u > "$TEMP_SORTED"
+awk '/^[^#]/ { print "local=/" $1 "/" }' "$TEMP" | sort -u > "$TEMP_SORTED"
 
 #Filter (if applicable)
 if [ -s "$DNSMASQ_WHITELIST" ]
@@ -40,14 +36,6 @@ then
     egrep -v "^[[:space:]]*$" $DNSMASQ_WHITELIST | awk '/^[^#]/ {sub(/\r$/,"");print $1}' | grep -vf - "$TEMP_SORTED" > $DNSMASQ_BLOCKHOSTS
 else
     cat "$TEMP_SORTED" > $DNSMASQ_BLOCKHOSTS
-fi
-
-if [ "$IPV6" = "Y" ]
-then
-    safe_pattern=$(printf '%s\n' "$ENDPOINT_IP4" | sed 's/[[\.*^$(){}?+|/]/\\&/g')
-    safe_addition=$(printf '%s\n' "$ENDPOINT_IP6" | sed 's/[\&/]/\\&/g')
-    echo 'Adding ipv6 support...'
-    sed -i -re "s/^(${safe_pattern}) (.*)$/\1 \2\n${safe_addition} \2/g" $DNSMASQ_BLOCKHOSTS
 fi
 
 service dnsmasq restart

--- a/roles/dns_adblocking/templates/dnsmasq.conf.j2
+++ b/roles/dns_adblocking/templates/dnsmasq.conf.j2
@@ -27,8 +27,8 @@
 
 # Replies which are not DNSSEC signed may be legitimate, because the domain
 # is unsigned, or may be forgeries. Setting this option tells dnsmasq to
-# check that an unsigned reply is OK, by finding a secure proof that a DS 
-# record somewhere between the root and the domain does not exist. 
+# check that an unsigned reply is OK, by finding a secure proof that a DS
+# record somewhere between the root and the domain does not exist.
 # The cost of setting this is that even queries in unsigned domains will need
 # one or more extra DNS queries to verify.
 #dnssec-check-unsigned
@@ -130,7 +130,7 @@ bind-interfaces
 #no-hosts
 # or if you want it to read another file, as well as /etc/hosts, use
 # this.
-addn-hosts=/var/lib/dnsmasq/block.hosts
+# addn-hosts=/var/lib/dnsmasq/block.hosts
 
 # Set this (and domain: see below) if you want to have a domain
 # automatically added to simple names in a hosts-file.
@@ -185,11 +185,11 @@ addn-hosts=/var/lib/dnsmasq/block.hosts
 #dhcp-range=1234::2, 1234::500, 64, 12h
 
 # Do Router Advertisements, BUT NOT DHCP for this subnet.
-#dhcp-range=1234::, ra-only 
+#dhcp-range=1234::, ra-only
 
 # Do Router Advertisements, BUT NOT DHCP for this subnet, also try and
-# add names to the DNS for the IPv6 address of SLAAC-configured dual-stack 
-# hosts. Use the DHCPv4 lease to derive the name, network segment and 
+# add names to the DNS for the IPv6 address of SLAAC-configured dual-stack
+# hosts. Use the DHCPv4 lease to derive the name, network segment and
 # MAC address and assume that the host will also have an
 # IPv6 address calculated using the SLAAC algorithm.
 #dhcp-range=1234::, ra-names
@@ -212,9 +212,9 @@ addn-hosts=/var/lib/dnsmasq/block.hosts
 #dhcp-range=1234::, ra-stateless, ra-names
 
 # Do router advertisements for all subnets where we're doing DHCPv6
-# Unless overridden by ra-stateless, ra-names, et al, the router 
+# Unless overridden by ra-stateless, ra-names, et al, the router
 # advertisements will have the M and O bits set, so that the clients
-# get addresses and configuration from DHCPv6, and the A bit reset, so the 
+# get addresses and configuration from DHCPv6, and the A bit reset, so the
 # clients don't use SLAAC addresses.
 #enable-ra
 
@@ -287,11 +287,11 @@ addn-hosts=/var/lib/dnsmasq/block.hosts
 # any machine with Ethernet address starting 11:22:33:
 #dhcp-host=11:22:33:*:*:*,set:red
 
-# Give a fixed IPv6 address and name to client with 
+# Give a fixed IPv6 address and name to client with
 # DUID 00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2
 # Note the MAC addresses CANNOT be used to identify DHCPv6 clients.
 # Note also the they [] around the IPv6 address are obligatory.
-#dhcp-host=id:00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2, fred, [1234::5] 
+#dhcp-host=id:00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2, fred, [1234::5]
 
 # Ignore any clients which are not specified in dhcp-host lines
 # or /etc/ethers. Equivalent to ISC "deny unknown-clients".
@@ -347,7 +347,7 @@ addn-hosts=/var/lib/dnsmasq/block.hosts
 # Send DHCPv6 option. Note [] around IPv6 addresses.
 #dhcp-option=option6:dns-server,[1234::77],[1234::88]
 
-# Send DHCPv6 option for nameservers as the machine running 
+# Send DHCPv6 option for nameservers as the machine running
 # dnsmasq and another.
 #dhcp-option=option6:dns-server,[::],[1234::88]
 
@@ -659,11 +659,11 @@ addn-hosts=/var/lib/dnsmasq/block.hosts
 
 # Include another lot of configuration options.
 #conf-file=/etc/dnsmasq.more.conf
-#conf-dir=/etc/dnsmasq.d
+conf-dir=/etc/dnsmasq.d
 
 # Include all the files in a directory except those ending in .bak
 #conf-dir=/etc/dnsmasq.d,.bak
 
 # Include all files in a directory which end in .conf
-#conf-dir=/etc/dnsmasq.d/,*.conf
+# conf-dir=/etc/dnsmasq.d/,*.conf
 #


### PR DESCRIPTION
Some browsers (eg. Safari) stop loading pages if the element with ads can't be loaded. 
To return NFDOMAIN instead of IP (0.0.0.0 or 127.0.0.1) helps us avoid such situations and unnecessary requests.
Instead of using additional hosts file with `$IP $DOMAIN` I suggest to use additional config file with `local=/$DOMAIN/` which will return NXDOMAIN