### PR TITLE
Use openssl to generate better quality p12_export_password

### DIFF
--- a/playbooks/facts/main.yml
+++ b/playbooks/facts/main.yml
@@ -27,9 +27,17 @@
   become: no
   register: CA_password
 
+- name: Generate p12 export password
+  local_action:
+    module: shell
+      openssl rand -hex 4
+  become: no
+  register: p12_export_password_generated
+  when: p12_export_password is not defined
+
 - name: Define password facts
   set_fact:
-    easyrsa_p12_export_password: "{{ p12_export_password|default((ansible_date_time.iso8601_basic|sha1|to_uuid).split('-')[0]) }}"
+    easyrsa_p12_export_password: "{{ p12_export_password|default(p12_export_password_generated.stdout) }}"
     easyrsa_CA_password: "{{ CA_password.stdout }}"
 
 - name: Define the commonName


### PR DESCRIPTION
We're already doing it this way for CA_password, and ansible's to_uuid is problematic as it uses uuid v5 under the hood (#654)