### PR TITLE
correct configs_prefix vars in client tasks

### DIFF
--- a/roles/client/tasks/systems/CentOS.yml
+++ b/roles/client/tasks/systems/CentOS.yml
@@ -3,4 +3,4 @@
 - set_fact:
     prerequisites:
       - epel-release
-    configs_prefix: /etc/strongswan/
+    configs_prefix: /etc/strongswan

--- a/roles/client/tasks/systems/Debian.yml
+++ b/roles/client/tasks/systems/Debian.yml
@@ -2,4 +2,4 @@
 
 - set_fact:
     prerequisites: []
-    configs_prefix: /etc/
+    configs_prefix: /etc

--- a/roles/client/tasks/systems/Fedora.yml
+++ b/roles/client/tasks/systems/Fedora.yml
@@ -3,4 +3,4 @@
 - set_fact:
     prerequisites:
       - libselinux-python
-    configs_prefix: /etc/strongswan/
+    configs_prefix: /etc/strongswan

--- a/roles/client/tasks/systems/Ubuntu.yml
+++ b/roles/client/tasks/systems/Ubuntu.yml
@@ -2,4 +2,4 @@
 
 - set_fact:
     prerequisites: []
-    configs_prefix: /etc/
+    configs_prefix: /etc


### PR DESCRIPTION
This PR introduces a change in the `configs_prefix` var value of the following client tasks:

* `roles/client/tasks/systems/CentOS.yml`
* `roles/client/tasks/systems/Debian.yml`
* `roles/client/tasks/systems/Fedora.yml`
* `roles/client/tasks/systems/Ubuntu.yml`

This to correct the constructed path to the strongswan config, this currently contain a double `//`, one from the `configs_prefix` var value and one from the task itself. 

**Output before change**

Note the `//` (double) at the end of `/etc/strongswan`.

````
TASK [client : Include additional ipsec config] ********************************
changed: [localhost] => (item={u'dest': u'/etc/strongswan//ipsec.conf', u'line': u'include ipsec.1.2.3.4.conf'})
changed: [localhost] => (item={u'dest': u'/etc/strongswan//ipsec.secrets', u'line': u'include ipsec.1.2.3.4.secrets'})

TASK [client : Setup the certificates and keys] ********************************
changed: [localhost] => (item={u'dest': u'/etc/strongswan//ipsec.d/certs/user-name.crt', u'src': u'configs/1.2.3.4/pki/certs/user-name.crt'})
changed: [localhost] => (item={u'dest': u'/etc/strongswan//ipsec.d/cacerts/1.2.3.4.pem', u'src': u'configs/1.2.3.4/pki/cacert.pem'})
changed: [localhost] => (item={u'dest': u'/etc/strongswan//ipsec.d/private/user-name.key', u'src': u'configs/1.2.3.4/pki/private/user-name.key'})
````

**Output after change**

Note the `/` (single) at the end of `/etc/strongswan`.

````
TASK [client : Include additional ipsec config] ********************************
ok: [localhost] => (item={u'dest': u'/etc/strongswan/ipsec.conf', u'line': u'include ipsec.1.2.3.4.conf'})
ok: [localhost] => (item={u'dest': u'/etc/strongswan/ipsec.secrets', u'line': u'include ipsec.1.2.3.4.secrets'})

TASK [client : Setup the certificates and keys] ********************************
ok: [localhost] => (item={u'dest': u'/etc/strongswan/ipsec.d/certs/user-name.crt', u'src': u'configs/1.2.3.4/pki/certs/user-name.crt'})
ok: [localhost] => (item={u'dest': u'/etc/strongswan/ipsec.d/cacerts/1.2.3.4.pem', u'src': u'configs/1.2.3.4/pki/cacert.pem'})
ok: [localhost] => (item={u'dest': u'/etc/strongswan/ipsec.d/private/user-name.key', u'src': u'configs/1.2.3.4/pki/private/user-name.key'})
````
Granted, this should not cause any actual issues to my knowledge, but it could down the line.

I opted to alter the var value rather than changing the task as the later is more readable with the `/`.