### PR TITLE
GCE correct variable key

### DIFF
--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -180,7 +180,7 @@ Additional tags:
 Required variables:
 
 - credentials_file
-- server_name
+- gce_server_name
 - ssh_public_key
 - zone
 


### PR DESCRIPTION
`server_name` should be `gce_server_name` for Google Compute Engine