### PR TITLE
Update adblock.sh for systemd to fix issue #735

### DIFF
--- a/roles/dns_adblocking/templates/adblock.sh.j2
+++ b/roles/dns_adblocking/templates/adblock.sh.j2
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Block ads, malware, etc..
 
-TEMP=`mktemp`
-TEMP_SORTED=`mktemp`
+TEMP="$(mktemp)"
+TEMP_SORTED="$(mktemp)"
 DNSMASQ_WHITELIST="/var/lib/dnsmasq/white.list"
 DNSMASQ_BLACKLIST="/var/lib/dnsmasq/black.list"
 DNSMASQ_BLOCKHOSTS="{{ config_prefix|default('/') }}etc/dnsmasq.d/block.hosts.conf"

--- a/roles/dns_adblocking/templates/adblock.sh.j2
+++ b/roles/dns_adblocking/templates/adblock.sh.j2
@@ -38,6 +38,8 @@ else
     cat "$TEMP_SORTED" > $DNSMASQ_BLOCKHOSTS
 fi
 
-service dnsmasq restart
+echo 'Restarting dnsmasq service...'
+#Restart the dnsmasq service
+systemctl restart dnsmasq.service
 
 exit 0

--- a/roles/dns_adblocking/templates/adblock.sh.j2
+++ b/roles/dns_adblocking/templates/adblock.sh.j2
@@ -33,7 +33,7 @@ then
     #Filter the blacklist, suppressing whitelist matches
     #  This is relatively slow =-(
     echo 'Filtering white list...'
-    egrep -v "^[[:space:]]*$" $DNSMASQ_WHITELIST | awk '/^[^#]/ {sub(/\r$/,"");print $1}' | grep -vf - "$TEMP_SORTED" > $DNSMASQ_BLOCKHOSTS
+    grep -v -E "^[[:space:]]*$" $DNSMASQ_WHITELIST | awk '/^[^#]/ {sub(/\r$/,"");print $1}' | grep -vf - "$TEMP_SORTED" > $DNSMASQ_BLOCKHOSTS
 else
     cat "$TEMP_SORTED" > $DNSMASQ_BLOCKHOSTS
 fi


### PR DESCRIPTION
Currently adblock.sh fails on line 41 when is called from the cron job because of the lack of PATH for `/usr/sbin/` that is where `service` is located. But `service dnsmasq restart` is the Upstart way to restart a service, since Ubuntu 16.04.3 use systemd the best option IMO is to use `systemctl restart dnsmasq.service`, `systemctl` command is located in `/bin` that currently is the PATH for adblock.sh when is called from the cron job, so no other modification is needed.

Also I updated the script following the recommendations of shellcheck to fix https://github.com/koalaman/shellcheck/wiki/SC2006
https://github.com/koalaman/shellcheck/wiki/SC2196

PS: The fix for #735 is in the first commit and the shellcheck improvements are in separated commits just in case.