### PR TITLE
Add catch-all VPN On Demand Rule

### DIFF
--- a/roles/vpn/templates/mobileconfig.j2
+++ b/roles/vpn/templates/mobileconfig.j2
@@ -52,6 +52,10 @@
                     <key>URLStringProbe</key>
                       <string>http://captive.apple.com/hotspot-detect.html</string>
                   </dict>
+                  <dict>
+                    <key>Action</key>
+                      <string>Disconnect</string>
+                  </dict>
                 </array>
 {% else %}
 {% endif %}


### PR DESCRIPTION
If a user is not connected to a trusted Wi-Fi network or if the
URLStringProbe fails none of the existing dictionaries match.

According to the Apple Configuration Profile Reference[1] section "VPN
Payload > On Demand Rules Dictionary Keys" a default behavior for
unknown networks with no matching criteria should always be set as the
last dictionary in the array. The current default behavior is to allow a
connection to occur, but this behavior is not guaranteed.

Tear down the VPN connection and do not reconnect on demand as long as
the catch-all dictionary matches to guarantee the default behavior and
more specifically allow users to access captive portals.

\[1\]: [https://developer.apple.com/library/content/featuredarticles/iPhoneConfigurationProfileRef/Introduction/Introduction.html](https://developer.apple.com/library/content/featuredarticles/iPhoneConfigurationProfileRef/Introduction/Introduction.html)