### PR TITLE
DigitalOcean - Add cleanup step for SSH key

### DIFF
--- a/roles/cloud-digitalocean/tasks/main.yml
+++ b/roles/cloud-digitalocean/tasks/main.yml
@@ -103,31 +103,31 @@
         - "{{ do_droplets.json.droplets }}"
 
     - block:
-      - name: "Delete the new Algo SSH key"
-        digital_ocean:
-          state: absent
-          command: ssh
-          api_token: "{{ do_token }}"
-          name: "{{ SSH_keys.comment }}"
-        register: ssh_keys
-        until: ssh_keys.changed != true
-        retries: 10
-        delay: 1
+        - name: "Delete the new Algo SSH key"
+          digital_ocean:
+            state: absent
+            command: ssh
+            api_token: "{{ do_token }}"
+            name: "{{ SSH_keys.comment }}"
+          register: ssh_keys
+          until: ssh_keys.changed != true
+          retries: 10
+          delay: 1
 
-    rescue:
-      - name: Collect the fail error
-        digital_ocean:
-          state: absent
-          command: ssh
-          api_token: "{{ do_token }}"
-          name: "{{ SSH_keys.comment }}"
-        register: ssh_keys
-        ignore_errors: yes
+      rescue:
+        - name: Collect the fail error
+          digital_ocean:
+            state: absent
+            command: ssh
+            api_token: "{{ do_token }}"
+            name: "{{ SSH_keys.comment }}"
+          register: ssh_keys
+          ignore_errors: yes
 
-      - debug: var=ssh_keys
+        - debug: var=ssh_keys
 
-      - fail:
-          msg: "Please, ensure that your API token is not read-only."
+        - fail:
+            msg: "Please, ensure that your API token is not read-only."
   rescue:
     - debug: var=fail_hint
       tags: always

--- a/roles/cloud-digitalocean/tasks/main.yml
+++ b/roles/cloud-digitalocean/tasks/main.yml
@@ -101,6 +101,33 @@
         line: "{{ item.networks.v4[0].ip_address }}"
       with_items:
         - "{{ do_droplets.json.droplets }}"
+
+    - block:
+      - name: "Delete the new Algo SSH key"
+        digital_ocean:
+          state: absent
+          command: ssh
+          api_token: "{{ do_token }}"
+          name: "{{ SSH_keys.comment }}"
+        register: ssh_keys
+        until: ssh_keys.changed != true
+        retries: 10
+        delay: 1
+
+    rescue:
+      - name: Collect the fail error
+        digital_ocean:
+          state: absent
+          command: ssh
+          api_token: "{{ do_token }}"
+          name: "{{ SSH_keys.comment }}"
+        register: ssh_keys
+        ignore_errors: yes
+
+      - debug: var=ssh_keys
+
+      - fail:
+          msg: "Please, ensure that your API token is not read-only."
   rescue:
     - debug: var=fail_hint
       tags: always


### PR DESCRIPTION
Currently, SSH keys are only deleted prior to uploading a new one. If you are using them with dynamic names though (configurable in config file), you will end up cluttering your DigitalOcean account with SSH keys that will never been delete. 

This is mostly just a copy paste of the delete step, but at the end of the cloud-digitalocean task to act as cleanup.