### PR TITLE
Instructions for Ubuntu needed compiler install

### DIFF
--- a/docs/deploy-to-ubuntu.md
+++ b/docs/deploy-to-ubuntu.md
@@ -8,7 +8,7 @@ tl;dr:
 
 ```shell
 sudo apt-get install software-properties-common && sudo apt-add-repository ppa:ansible/ansible
-sudo apt-get update && sudo apt-get install ansible python-pip
+sudo apt-get update && sudo apt-get install ansible python-pip build-essential python-dev
 pip install virtualenv
 pip install --upgrade pip
 git clone https://github.com/trailofbits/algo


### PR DESCRIPTION
build-essential and python-dev are required when compiling pycrypt. Added the necessary packages to the apt-get install line.