### PR TITLE
Use dns_servers in dnsmasq.conf

### DIFF
--- a/roles/dns_adblocking/templates/dnsmasq.conf.j2
+++ b/roles/dns_adblocking/templates/dnsmasq.conf.j2
@@ -88,8 +88,9 @@
 # You can control how dnsmasq talks to a server: this forces
 # queries to 10.1.2.3 to be routed via eth1
 # server=10.1.2.3@eth1
-server=8.8.8.8
-server=8.8.4.4
+{% for host in dns_servers.ipv4 %}
+server={{ host }}
+{% endfor %}
 
 # and this sets the source (ie local) address used to talk to
 # 10.1.2.3 to 192.168.1.1 port 55 (there must be a interface with that


### PR DESCRIPTION
Use the user-configured `dns_servers` value to set upstream DNS servers for dnsmasq when the `dns_adblocking` role is enabled.