### PR TITLE
Configure DNS names for each user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
   - sudo cp -v ~/.ssh/id_rsa.pub $LXC_ROOTFS/root/.ssh/authorized_keys
   - sudo apt-get install build-essential libssl-dev libffi-dev python-dev && sudo pip install -r requirements.txt
   - pip install ansible-lint
+  - pip install netaddr
   - gem install awesome_bot
 
 script:

--- a/config.cfg
+++ b/config.cfg
@@ -47,6 +47,12 @@ CA_PayloadIdentifier: "{{ 700000 | random | to_uuid | upper }}"
 # Block traffic between connected clients
 BetweenClients_DROP: Y
 
+# Used for resolving hosts within the VPN, not connecting to the VPN
+# If BetweenClients_DROP is set to 'N', and the dns_adblocking role is enabled,
+# connected users will be able to communicate with each other using
+# $user.$vpn_domain DNS names
+vpn_domain: algo.internal
+
 congrats:
   common: |
     "#                          Congratulations!                            #"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ apache-libcloud
 six
 pyopenssl
 jinja2==2.8
+netaddr

--- a/roles/dns_adblocking/tasks/main.yml
+++ b/roles/dns_adblocking/tasks/main.yml
@@ -27,6 +27,13 @@
       notify:
         - restart dnsmasq
 
+    - name: VPN hosts file configured
+      template:
+        src: etc.hosts.ipsecclients.j2
+        dest: "{{ config_prefix|default('/') }}etc/hosts.ipsecclients"
+      notify:
+        - restart dnsmasq
+
     - name: Adblock script created
       template:
         src: adblock.sh.j2

--- a/roles/dns_adblocking/templates/dnsmasq.conf.j2
+++ b/roles/dns_adblocking/templates/dnsmasq.conf.j2
@@ -132,6 +132,7 @@ bind-interfaces
 # or if you want it to read another file, as well as /etc/hosts, use
 # this.
 # addn-hosts=/var/lib/dnsmasq/block.hosts
+addn-hosts=/etc/hosts.ipsecclients
 
 # Set this (and domain: see below) if you want to have a domain
 # automatically added to simple names in a hosts-file.

--- a/roles/dns_adblocking/templates/etc.hosts.ipsecclients.j2
+++ b/roles/dns_adblocking/templates/etc.hosts.ipsecclients.j2
@@ -1,0 +1,3 @@
+{% for user in users %}
+{{ vpn_network | ipaddr(loop.index) | ipaddr('address') }} {{ user }}.{{ vpn_domain }}
+{% endfor %}

--- a/roles/dns_adblocking/templates/usr.sbin.dnsmasq.j2
+++ b/roles/dns_adblocking/templates/usr.sbin.dnsmasq.j2
@@ -17,6 +17,7 @@
   /var/lib/dnsmasq/block.hosts r,
   /etc/dnsmasq.d-available/ r,
   /etc/dnsmasq.d-available/* r,
+  /etc/hosts.ipsecclients r,
 
   /usr/sbin/dnsmasq mr,
 

--- a/roles/vpn/templates/client_ipsec.conf.j2
+++ b/roles/vpn/templates/client_ipsec.conf.j2
@@ -21,6 +21,7 @@ conn ikev2-{{ IP_subject_alt_name }}
 
     leftsourceip=%config
     leftauth=pubkey
+    leftid={{ item }}
     leftcert={{ item }}.crt
     leftfirewall=yes
     left=%defaultroute

--- a/roles/vpn/templates/ipsec.conf.j2
+++ b/roles/vpn/templates/ipsec.conf.j2
@@ -1,5 +1,5 @@
 config setup
-    uniqueids=never # allow multiple connections per user
+    uniqueids=replace  # if the same user connects twice, replace the old connection with the new one
     charondebug="ike {{ strongswan_log_level }}, knl {{ strongswan_log_level }}, cfg {{ strongswan_log_level }}, net {{ strongswan_log_level }}, esp {{ strongswan_log_level }}, dmn {{ strongswan_log_level }},  mgr {{ strongswan_log_level }}"
 
 conn %default
@@ -25,14 +25,36 @@ conn %default
     leftsendcert=always
     leftsubnet=0.0.0.0/0,::/0
 
+# Client configs
+# example: https://www.strongswan.org/testing/testresults/ikev2/config-payload/, especially moon.ipsec.conf
+# NOTE: we specify each client config twice, identically except for the rightid parameter
+#       because some clients (e.g. strongswan) send the rightid as "/CN=$user"
+#       while others (e.g. macOS) send the rightid as "$user"
+
+{% for user in users %}
+
+conn AlgoUser-{{ user }}
     right=%any
+    rightid={{ user }}
     rightauth=pubkey
-    rightsourceip={{ vpn_network }},{{ vpn_network_ipv6 }}
+    rightsourceip={{ vpn_network | ipaddr(loop.index) | ipaddr('address') }}
 {% if local_dns is defined and local_dns == "Y" %}
     rightdns={{ local_service_ip }}
 {% else %}
     rightdns={% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support is defined and ipv6_support == "yes" %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {% endif %}
-
-conn ikev2-pubkey
     auto=add
+
+conn AlgoUser-CN{{ user }}
+    right=%any
+    rightid="/CN={{ user }}"
+    rightauth=pubkey
+    rightsourceip={{ vpn_network | ipaddr(loop.index) | ipaddr('address') }}
+{% if local_dns is defined and local_dns == "Y" %}
+    rightdns={{ local_service_ip }}
+{% else %}
+    rightdns={% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support is defined and ipv6_support == "yes" %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+{% endif %}
+    auto=add
+
+{% endfor %}

--- a/roles/vpn/templates/ipsec.conf.j2
+++ b/roles/vpn/templates/ipsec.conf.j2
@@ -25,36 +25,19 @@ conn %default
     leftsendcert=always
     leftsubnet=0.0.0.0/0,::/0
 
-# Client configs
-# example: https://www.strongswan.org/testing/testresults/ikev2/config-payload/, especially moon.ipsec.conf
-# NOTE: we specify each client config twice, identically except for the rightid parameter
-#       because some clients (e.g. strongswan) send the rightid as "/CN=$user"
-#       while others (e.g. macOS) send the rightid as "$user"
+    right=%any
+    rightauth=pubkey
+{% if local_dns is defined and local_dns == "Y" %}
+    rightdns={{ local_service_ip }}
+{% else %}
+    rightdns={% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support is defined and ipv6_support == "yes" %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+{% endif %}
 
 {% for user in users %}
 
 conn AlgoUser-{{ user }}
-    right=%any
     rightid={{ user }}
-    rightauth=pubkey
     rightsourceip={{ vpn_network | ipaddr(loop.index) | ipaddr('address') }}
-{% if local_dns is defined and local_dns == "Y" %}
-    rightdns={{ local_service_ip }}
-{% else %}
-    rightdns={% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support is defined and ipv6_support == "yes" %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
-{% endif %}
-    auto=add
-
-conn AlgoUser-CN{{ user }}
-    right=%any
-    rightid="/CN={{ user }}"
-    rightauth=pubkey
-    rightsourceip={{ vpn_network | ipaddr(loop.index) | ipaddr('address') }}
-{% if local_dns is defined and local_dns == "Y" %}
-    rightdns={{ local_service_ip }}
-{% else %}
-    rightdns={% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support is defined and ipv6_support == "yes" %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
-{% endif %}
     auto=add
 
 {% endfor %}


### PR DESCRIPTION
(NOTE: This wasn't anything I've seen anyone ask for in the issue tracker, but it's something I want for myself, so I figured I'd clean it up and submit it. If there's anything I could do to improve it, I'd be happy to, but if this is too far outside the scope of the project, I understand. There are a few caveats, enumerated at the bottom of the PR.)

In the `dns_adblocking` role, assign each Algo user a domain name, allowing connected users to communicate internally without having to know each other's VPN IP addresses. The user can set this in `config.cfg` as `vpn_domain`.

The server's `ipsec.conf` is also modified, with a connection per-user that sets an IP address based on the order the user appears in the `config.cfg` file.

Finally, a new `/etc/hosts.ipsecclients` file is created on the server, which maps from the IP addresses assigned in `ipsec.conf` to `{{ user }}.{{ vpn_domain }}`. `dnsmasq` is then configured to read that file as a hosts file.

CAVEATS

1. This required one potentially breaking change: disallowing multiple connections from the same Algo user. Instead, new connections replace old ones.

2. I have tested this with strongswan 5.1.1 on Debian 9.3 (stretch), the IPSEC client in macOS 10.13.2, and the IPSEC client in iOS 11.2.5, but I haven't tested with Windows or Android clients.

3. This relies on setting `BetweenClients_DROP` to some falsey value, as well as enabling the `dns_adblocking` role. Because the `BetweenClients_DROP` setting is only settable inside `config.cfg` (and not from the `algo` script), this functionality is only documented in that config file, above the new `vpn_domain` setting.