### PR TITLE
Use default nameservers which given by the provider instead of googles

### DIFF
--- a/roles/dns_adblocking/templates/dnsmasq.conf.j2
+++ b/roles/dns_adblocking/templates/dnsmasq.conf.j2
@@ -88,7 +88,7 @@
 # You can control how dnsmasq talks to a server: this forces
 # queries to 10.1.2.3 to be routed via eth1
 # server=10.1.2.3@eth1
-{% for host in dns_servers.ipv4 %}
+{% for host in ansible_dns['nameservers']|default(dns_servers['ipv4']) %}
 server={{ host }}
 {% endfor %}
 

--- a/roles/vpn/templates/ipsec.conf.j2
+++ b/roles/vpn/templates/ipsec.conf.j2
@@ -31,7 +31,7 @@ conn %default
 {% if local_dns is defined and local_dns == "Y" %}
     rightdns={{ local_service_ip }}
 {% else %}
-    rightdns={% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support is defined and ipv6_support == "yes" %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+    rightdns={% for host in ansible_dns['nameservers']|default(dns_servers['ipv4']) %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}
 {% endif %}
 
 conn ikev2-pubkey


### PR DESCRIPTION
It would be more appropriate to use the name servers which are given by the provider and already configured in the system instead of the ones in the config.
Fixes #806 