### PR TITLE
Removed ssh_public_key variable for AWS. Fix for Issue #773

### DIFF
--- a/algo
+++ b/algo
@@ -281,7 +281,7 @@ Enter the number of your desired region:
   esac
 
   ROLES="ec2 vpn cloud"
-  EXTRA_VARS="aws_access_key=$aws_access_key aws_secret_key=$aws_secret_key aws_server_name=$aws_server_name ssh_public_key=$ssh_public_key region=$region"
+  EXTRA_VARS="aws_access_key=$aws_access_key aws_secret_key=$aws_secret_key aws_server_name=$aws_server_name region=$region"
 }
 
 lightsail () {

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -87,7 +87,6 @@ Required variables:
 - aws_access_key
 - aws_secret_key
 - aws_server_name
-- ssh_public_key
 - region
 
 Possible options for `region`:


### PR DESCRIPTION
Removed requirement for ssh_public_key variable requirement from https://github.com/trailofbits/algo/blob/master/docs/deploy-from-ansible.md 

Removed ssh_public_key variable from https://github.com/trailofbits/algo/blob/02427910de8f6765c91ac5084e8712ded7dbe78c/algo

Fix for Issue #773 