### PR TITLE
Explicitly create the virtualenv with Python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The easiest way to get an Algo server running is to let it set up a _new_ virtua
 
 4. **Install Algo's remaining dependencies.** Use the same Terminal window as the previous step and run:
     ```bash
-    $ python -m virtualenv env && source env/bin/activate && python -m pip install -U pip && python -m pip install -r requirements.txt
+    $ python -m virtualenv --python=`which python2` env && source env/bin/activate && python -m pip install -U pip && python -m pip install -r requirements.txt
     ```
     On macOS, you may be prompted to install `cc`. You should press accept if so.
 


### PR DESCRIPTION
Those who have Python3 as the default global Python may miss that this project only supports Python2 (I did, myself). I've updated the virtualenv command in the README to create the env with Python2 explicitly.