### PR TITLE
Multi-line virtualenv setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ The easiest way to get an Algo server running is to let it set up a _new_ virtua
 
 4. **Install Algo's remaining dependencies.** Use the same Terminal window as the previous step and run:
     ```bash
-    $ python -m virtualenv --python=`which python2` env && source env/bin/activate && python -m pip install -U pip && python -m pip install -r requirements.txt
+    $ python -m virtualenv --python=`which python2` env &&
+        source env/bin/activate &&
+        python -m pip install -U pip &&
+        python -m pip install -r requirements.txt
     ```
     On macOS, you may be prompted to install `cc`. You should press accept if so.
 


### PR DESCRIPTION
Changed the single-line virtualenv setup script into multi-line one. Should be equivalent to what it was before, and now viewable/copy-able without scrolling.

Didn't setup/run shellcheck, but I just introduced new-lines after `&&` anyway, which doesn't change anything.