### PR TITLE
Exclude CA from P12

### DIFF
--- a/roles/vpn/tasks/openssl.yml
+++ b/roles/vpn/tasks/openssl.yml
@@ -117,7 +117,6 @@
       -export
       -name {{ item }}
       -out private/{{ item }}.p12
-      -certfile cacert.pem
       -passout pass:"{{ easyrsa_p12_export_password }}"
     args:
       chdir: "configs/{{ IP_subject_alt_name }}/pki/"

--- a/roles/vpn/templates/client_windows.ps1.j2
+++ b/roles/vpn/templates/client_windows.ps1.j2
@@ -1,6 +1,7 @@
 
 function AddAlgoVPN {
   certutil -f -importpfx .\{{ item }}.p12
+  certutil -addstore root .\cacert.pem
   Add-VpnConnection -name "Algo VPN {{ IP_subject_alt_name }} IKEv2" -ServerAddress "{{ IP_subject_alt_name }}" -TunnelType IKEv2 -AuthenticationMethod MachineCertificate -EncryptionLevel Required
   Set-VpnConnectionIPsecConfiguration -ConnectionName "Algo VPN {{ IP_subject_alt_name }} IKEv2" -AuthenticationTransformConstants GCMAES128 -CipherTransformConstants GCMAES128 -EncryptionMethod AES128 -IntegrityCheckMethod SHA384 -DHGroup ECP256 -PfsGroup ECP256  -Force
 }


### PR DESCRIPTION
Excludes the CA certificate from P12 containers and adds a line to add the CA to the windows root store.

Fixes #828