### PR TITLE
skip virtualenv check if already activated

### DIFF
--- a/algo
+++ b/algo
@@ -2,13 +2,16 @@
 
 set -e
 
-ACTIVATE_SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/env/bin/activate"
-if [ -f "$ACTIVATE_SCRIPT" ]
+if [ -z ${VIRTUAL_ENV+x} ]
 then
-	source $ACTIVATE_SCRIPT
-else
-	echo "$ACTIVATE_SCRIPT not found.  Did you follow documentation to install dependencies?"
-	exit 1
+	ACTIVATE_SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/env/bin/activate"
+	if [ -f "$ACTIVATE_SCRIPT" ]
+	then
+		source $ACTIVATE_SCRIPT
+	else
+		echo "$ACTIVATE_SCRIPT not found.  Did you follow documentation to install dependencies?"
+		exit 1
+	fi
 fi
 
 SKIP_TAGS="_null encrypted"


### PR DESCRIPTION
This allows the user to choose their virtualenv method, e.g. [Pipenv](https://docs.pipenv.org/) while still being friendly for those not familiar with virtual environments.

Pipenv (and other virtual environment management tools) may create the environment somewhere other than inside the project directory.

Note that this solution may be insufficient if the project ever uses Python 3 and supports [venv](https://docs.python.org/3/library/venv.html); we may need to use a Python-based solution then, e.g. https://stackoverflow.com/a/42580137