### PR TITLE
DNS encryption

### DIFF
--- a/algo
+++ b/algo
@@ -40,7 +40,7 @@ read -p "
 Do you want to install a DNS resolver on this VPN server, to block ads while surfing?
 [y/N]: " -r dns_enabled
 dns_enabled=${dns_enabled:-n}
-if [[ "$dns_enabled" =~ ^(y|Y)$ ]]; then ROLES+=" dns"; fi
+if [[ "$dns_enabled" =~ ^(y|Y)$ ]]; then ROLES+=" dns"; EXTRA_VARS+=" local_dns=true"; fi
 
 read -p "
 Do you want each user to have their own account for SSH tunneling?

--- a/config.cfg
+++ b/config.cfg
@@ -29,13 +29,20 @@ adblock_lists:
  - "https://www.malwaredomainlist.com/hostslist/hosts.txt"
  - "https://hosts-file.net/ad_servers.txt"
 
+# Enalbe DNS encryption. Use dns_encrypted_provider to specify the provider. If false dns_servers should be specified
+dns_encryption: true
+
+# Possible values: google, cloudflare
+dns_encryption_provider: cloudflare
+
+# DNS servers which will be used if dns_encryption disabled
 dns_servers:
   ipv4:
-    - 8.8.8.8
-    - 8.8.4.4
+    - 1.1.1.1
+    - 1.0.0.1
   ipv6:
-    - 2001:4860:4860::8888
-    - 2001:4860:4860::8844
+    - 2606:4700:4700::1111
+    - 2606:4700:4700::1001
 
 # IP address for the local dns resolver
 local_service_ip: 172.16.0.1

--- a/deploy.yml
+++ b/deploy.yml
@@ -63,7 +63,7 @@
           tags: always
 
   roles:
-    - { role: dns_adblocking, tags: ['dns', 'adblock' ] }
+    - { role: dns_adblocking, tags: [ 'dns', 'adblock' ] }
     - { role: ssh_tunneling, tags: [ 'ssh_tunneling' ] }
     - { role: vpn, tags: [ 'vpn' ] }
 

--- a/docs/client-linux.md
+++ b/docs/client-linux.md
@@ -64,7 +64,7 @@ In this example we'll assume the IP of our Algo VPN server is `1.2.3.4` and the 
     * Certificate: `cacert.pem` found at `/path/to/algo/configs/1.2.3.4/cacert.pem`
   * Client:
     * Authentication: *Certificate/Private key*
-    * Certificate: `user-name.crt` found at `/path/to/algo/configs/1.2.3.4/pki/certs/user-name.crt` 
+    * Certificate: `user-name.crt` found at `/path/to/algo/configs/1.2.3.4/pki/certs/user-name.crt`
     * Private key: `user-name.key` found at `/path/to/algo/configs/1.2.3.4/pki/private/user-name.key`
   * Options:
     * Check *Request an inner IP address*, connection will fail without this option

--- a/docs/setup-roles.md
+++ b/docs/setup-roles.md
@@ -20,6 +20,9 @@
 * **DNS-based Adblocking**
   * Install the [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) local resolver with a blacklist for advertising domains
   * Constrains dnsmasq with AppArmor and cgroups CPU and memory limitations
+* **DNS encryption**
+  * Install [dnscrypt-proxy](https://github.com/jedisct1/dnscrypt-proxy)
+  * Constrains dingo with AppArmor and cgroups CPU and memory limitations
 * **SSH Tunneling**
   * Adds a restricted `algo` group with no shell access and limited SSH forwarding options
   * Creates one limited, local account per user and an SSH public key for each

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -2,7 +2,15 @@
 - name: Cloud only tasks
   block:
   - name: Install software updates
-    apt: update_cache=yes upgrade=dist
+    apt:
+      update_cache: true
+      install_recommends: true
+      upgrade: dist
+
+  - name: Upgrade the ca certificates
+    apt:
+      name: ca-certificates
+      state: latest
 
   - name: Check if reboot is required
     shell: >

--- a/roles/dns_adblocking/meta/main.yml
+++ b/roles/dns_adblocking/meta/main.yml
@@ -2,3 +2,6 @@
 
 dependencies:
   - { role: common, tags: common }
+  - role: dns_encryption
+    tags: dns_encryption
+    when: dns_encryption == true

--- a/roles/dns_adblocking/tasks/freebsd.yml
+++ b/roles/dns_adblocking/tasks/freebsd.yml
@@ -2,3 +2,11 @@
 
 - name: FreeBSD / HardenedBSD | Enable dnsmasq
   lineinfile: dest=/etc/rc.conf regexp=^dnsmasq_enable= line='dnsmasq_enable="YES"'
+
+- name: The dnsmasq additional directories created
+  file:
+    dest: "{{ item }}"
+    state: directory
+    mode: '0755'
+  with_items:
+    - "{{ config_prefix|default('/') }}etc/dnsmasq.d"

--- a/roles/dns_adblocking/tasks/main.yml
+++ b/roles/dns_adblocking/tasks/main.yml
@@ -3,7 +3,7 @@
 
     - name: The DNS tag is defined
       set_fact:
-        local_dns: Y
+        local_dns: true
 
     - name: Dnsmasq installed
       package: name=dnsmasq

--- a/roles/dns_adblocking/tasks/ubuntu.yml
+++ b/roles/dns_adblocking/tasks/ubuntu.yml
@@ -7,13 +7,13 @@
     owner: root
     group: root
     mode: 0600
-  when: apparmor_enabled is defined and apparmor_enabled == true
+  when: apparmor_enabled|default(false)|bool == true
   notify:
     - restart dnsmasq
 
 - name: Ubuntu | Enforce the dnsmasq AppArmor policy
   shell: aa-enforce usr.sbin.dnsmasq
-  when: apparmor_enabled is defined and apparmor_enabled == true
+  when: apparmor_enabled|default(false)|bool == true
   tags: ['apparmor']
 
 - name: Ubuntu | Ensure that the dnsmasq service directory exist

--- a/roles/dns_adblocking/templates/dnsmasq.conf.j2
+++ b/roles/dns_adblocking/templates/dnsmasq.conf.j2
@@ -88,9 +88,13 @@ no-resolv
 # You can control how dnsmasq talks to a server: this forces
 # queries to 10.1.2.3 to be routed via eth1
 # server=10.1.2.3@eth1
+{% if dns_encryption|default(false)|bool == true %}
+server={{ local_service_ip }}#5353
+{% else %}
 {% for host in dns_servers.ipv4 %}
 server={{ host }}
 {% endfor %}
+{% endif %}
 
 # and this sets the source (ie local) address used to talk to
 # 10.1.2.3 to 192.168.1.1 port 55 (there must be a interface with that
@@ -660,7 +664,7 @@ bind-interfaces
 
 # Include another lot of configuration options.
 #conf-file=/etc/dnsmasq.more.conf
-conf-dir=/etc/dnsmasq.d
+conf-dir={{ config_prefix|default('/') }}etc/dnsmasq.d/,*.conf
 
 # Include all the files in a directory except those ending in .bak
 #conf-dir=/etc/dnsmasq.d,.bak

--- a/roles/dns_encryption/defaults/main.yml
+++ b/roles/dns_encryption/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+listen_port: "{% if local_dns|d(false)|bool == true %}5353{% else %}53{% endif %}"
+# the version used if the latest unavailable (in case of Github API rate limited)
+dnscrypt_proxy_version: 2.0.10
+apparmor_enabled: true
+dns_encryption: true
+dns_encryption_provider: "*"

--- a/roles/dns_encryption/files/apparmor.profile.dnscrypt-proxy
+++ b/roles/dns_encryption/files/apparmor.profile.dnscrypt-proxy
@@ -1,0 +1,23 @@
+#include <tunables/global>
+
+/usr/sbin/dnscrypt-proxy {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/openssl>
+
+  capability chown,
+  capability dac_override,
+  capability net_bind_service,
+  capability setgid,
+  capability setuid,
+  capability sys_resource,
+
+  /etc/dnscrypt-proxy.toml r,
+  /etc/ld.so.cache r,
+  /usr/sbin/dnscrypt-proxy mr,
+  /usr/share/dnscrypt-proxy/dnscrypt-resolvers.csv r,
+  /usr/local/lib/{@{multiarch}/,}libldns.so* mr,
+  /usr/local/lib/{@{multiarch}/,}libsodium.so* mr,
+  /run/dnscrypt-proxy.pid rw,
+  /run/systemd/notify rw,
+}

--- a/roles/dns_encryption/files/rc.dnscrypt-proxy.sh
+++ b/roles/dns_encryption/files/rc.dnscrypt-proxy.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# PROVIDE: dnscrypt-proxy
+# REQUIRE: LOGIN
+# BEFORE:  securelevel
+# KEYWORD: shutdown
+
+# Add the following lines to /etc/rc.conf to enable `dnscrypt-proxy':
+#
+# dnscrypt_proxy_enable="YES"
+# dnscrypt_proxy_flags="<set as needed>"
+#
+# See rsync(1) for rsyncd_flags
+#
+
+. /etc/rc.subr
+
+name="dnscrypt-proxy"
+rcvar=dnscrypt_proxy_enable
+load_rc_config "$name"
+pidfile="/var/run/$name.pid"
+start_cmd=dnscrypt_proxy_start
+stop_postcmd=dnscrypt_proxy_stop
+
+: ${dnscrypt_proxy_enable="NO"}
+: ${dnscrypt_proxy_flags="-config /usr/local/etc/dnscrypt-proxy/dnscrypt-proxy.toml"}
+
+dnscrypt_proxy_start() {
+  echo "Starting dnscrypt-proxy..."
+  touch ${pidfile}
+  /usr/sbin/daemon -cS -T dnscrypt-proxy -p ${pidfile} /usr/dnscrypt-proxy/freebsd-amd64/dnscrypt-proxy ${dnscrypt_proxy_flags}
+}
+
+dnscrypt_proxy_stop() {
+  [ -f ${pidfile} ] && rm ${pidfile}
+}
+
+run_rc_command "$1"

--- a/roles/dns_encryption/handlers/main.yml
+++ b/roles/dns_encryption/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: daemon reload
+  systemd:
+    daemon_reload: true
+
+- name: restart dnscrypt-proxy
+  service:
+    name: dnscrypt-proxy
+    state: restarted

--- a/roles/dns_encryption/meta/main.yml
+++ b/roles/dns_encryption/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: common
+    tags: common

--- a/roles/dns_encryption/tasks/freebsd.yml
+++ b/roles/dns_encryption/tasks/freebsd.yml
@@ -1,0 +1,51 @@
+---
+- name: FreeBSD | Ensure that the required directories exist
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ config_prefix|default('/') }}etc/dnscrypt-proxy/"
+    - /usr/dnscrypt-proxy/
+
+- name: Required tools installed
+  package:
+    name: gtar
+
+- name: FreeBSD | Retrive the latest versions
+  uri:
+    url: https://api.github.com/repos/jedisct1/dnscrypt-proxy/releases/latest
+  register: dnscrypt_proxy_latest
+  ignore_errors: true
+
+- name: FreeBSD | Set default dnscrypt-proxy assets
+  set_fact:
+    dnscrypt_proxy_latest:
+      json:
+        assets:
+          - name: "dnscrypt-proxy-freebsd_amd64-{{ dnscrypt_proxy_version }}.tar.gz"
+            browser_download_url: "https://github.com/jedisct1/dnscrypt-proxy/releases/download/{{ dnscrypt_proxy_version }}/dnscrypt-proxy-freebsd_amd64-{{ dnscrypt_proxy_version }}.tar.gz"
+  when: dnscrypt_proxy_latest.failed
+
+- name: FreeBSD | Download the latest archive
+  get_url:
+    url: "{{ item['browser_download_url'] }}"
+    dest: "/tmp/dnscrypt-proxy-freebsd_amd64-{{ dnscrypt_proxy_version }}.tar.gz"
+    mode: '0755'
+    force: true
+  with_items: "{{ dnscrypt_proxy_latest['json']['assets'] }}"
+  no_log: true
+  when: '"freebsd_amd64" in item.name'
+  notify: restart dnscrypt-proxy
+
+- name: FreeBSD | Extract the latest archive
+  unarchive:
+    remote_src: true
+    src: /tmp/dnscrypt-proxy-freebsd_amd64-{{ dnscrypt_proxy_version }}.tar.gz
+    dest: /usr/dnscrypt-proxy
+
+- name: FreeBSD | Configure rc script
+  copy:
+    src: rc.dnscrypt-proxy.sh
+    dest: /usr/local/etc/rc.d/dnscrypt-proxy
+    mode: "0755"
+  notify: restart dnscrypt-proxy

--- a/roles/dns_encryption/tasks/main.yml
+++ b/roles/dns_encryption/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Include tasks for Ubuntu
+  include_tasks: ubuntu.yml
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+- name: Include tasks for FreeBSD
+  include_tasks: freebsd.yml
+  when: ansible_distribution == 'FreeBSD'
+
+- name: dnscrypt-proxy configured
+  template:
+    src: dnscrypt-proxy.toml.j2
+    dest: "{{ config_prefix|default('/') }}etc/dnscrypt-proxy/dnscrypt-proxy.toml"
+  notify:
+    - restart dnscrypt-proxy
+
+- name: dnscrypt-proxy enabled and started
+  service:
+    name: dnscrypt-proxy
+    state: started
+    enabled: true
+
+- meta: flush_handlers

--- a/roles/dns_encryption/tasks/ubuntu.yml
+++ b/roles/dns_encryption/tasks/ubuntu.yml
@@ -1,0 +1,48 @@
+---
+- name: Add the repository
+  apt_repository:
+    state: present
+    codename: artful
+    repo: ppa:shevchuk/dnscrypt-proxy
+
+- name: Install dnscrypt-proxy
+  apt:
+    name: dnscrypt-proxy
+    state: latest
+    update_cache: true
+
+- block:
+  - name: Ubuntu | Unbound profile for apparmor configured
+    copy:
+      src: apparmor.profile.dnscrypt-proxy
+      dest: /etc/apparmor.d/usr.sbin.dnscrypt-proxy
+      owner: root
+      group: root
+      mode: 0600
+    notify: restart dnscrypt-proxy
+
+  - name: Ubuntu | Enforce the dnscrypt-proxy AppArmor policy
+    command: aa-enforce usr.sbin.dnscrypt-proxy
+    changed_when: false
+  tags: apparmor
+  when: apparmor_enabled|default(false)|bool == true
+
+- name: Ubuntu | Ensure that the dnscrypt-proxy service directory exist
+  file:
+    path: /etc/systemd/system/dnscrypt-proxy.service.d/
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Ubuntu | Setup the cgroup limitations for dnscrypt-proxy
+  copy:
+    dest: /etc/systemd/system/dnscrypt-proxy.service.d/100-CustomLimitations.conf
+    content: |
+      [Service]
+      MemoryLimit=16777216
+      CPUAccounting=true
+      CPUQuota=5%
+  notify:
+    - daemon-reload
+    - restart dnscrypt-proxy

--- a/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
+++ b/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
@@ -1,0 +1,465 @@
+
+##############################################
+#                                            #
+#        dnscrypt-proxy configuration        #
+#                                            #
+##############################################
+
+## This is an example configuration file.
+## You should adjust it to your needs, and save it as "dnscrypt-proxy.toml"
+##
+## Online documentation is available here: https://dnscrypt.info/doc
+
+
+
+##################################
+#         Global settings        #
+##################################
+
+## List of servers to use
+##
+## Servers from the "public-resolvers" source (see down below) can
+## be viewed here: https://dnscrypt.info/public-servers
+##
+## If this line is commented, all registered servers matching the require_* filters
+## will be used.
+##
+## The proxy will automatically pick the fastest, working servers from the list.
+## Remove the leading # first to enable this; lines starting with # are ignored.
+
+server_names      = ['{{ dns_encryption_provider }}'{% if ipv6_support|d(false)|bool == true and dns_encryption_provider == "cloudflare" %}, '{{ dns_encryption_provider }}-ipv6' {% endif %} ]
+
+
+## List of local addresses and ports to listen to. Can be IPv4 and/or IPv6.
+## Note: When using systemd socket activation, choose an empty set (i.e. [] ).
+
+listen_addresses  = ['{{ local_service_ip }}:{{ listen_port }}']
+
+
+## Maximum number of simultaneous client connections to accept
+
+max_clients = 250
+
+
+## Require servers (from static + remote sources) to satisfy specific properties
+
+# Use servers reachable over IPv4
+ipv4_servers = true
+
+# Use servers reachable over IPv6 -- Do not enable if you don't have IPv6 connectivity
+ipv6_servers = {{ ipv6_support|default(false) | bool | lower }}
+
+# Use servers implementing the DNSCrypt protocol
+dnscrypt_servers = true
+
+# Use servers implementing the DNS-over-HTTPS protocol
+doh_servers = true
+
+
+## Require servers defined by remote sources to satisfy specific properties
+
+# Server must support DNS security extensions (DNSSEC)
+require_dnssec = true
+
+# Server must not log user queries (declarative)
+require_nolog = true
+
+# Server must not enforce its own blacklist (for parental control, ads blocking...)
+require_nofilter = true
+
+
+
+## Always use TCP to connect to upstream servers
+
+force_tcp = false
+
+
+## How long a DNS query will wait for a response, in milliseconds
+
+timeout = 2500
+
+
+## Keepalive for HTTP (HTTPS, HTTP/2) queries, in seconds
+
+keepalive = 30
+
+
+## Load-balancing strategy: 'p2' (default), 'ph', 'fastest' or 'random'
+
+lb_strategy = 'p2'
+
+
+## Log level (0-6, default: 2 - 0 is very verbose, 6 only contains fatal errors)
+
+log_level = 2
+
+
+## log file for the application
+
+# log_file = 'dnscrypt-proxy.log'
+
+
+## Use the system logger (syslog on Unix, Event Log on Windows)
+
+use_syslog = true
+
+
+## Delay, in minutes, after which certificates are reloaded
+
+cert_refresh_delay = 240
+
+
+## DNSCrypt: Create a new, unique key for every single DNS query
+## This may improve privacy but can also have a significant impact on CPU usage
+## Only enable if you don't have a lot of network load
+
+dnscrypt_ephemeral_keys = true
+
+
+## DoH: Disable TLS session tickets - increases privacy but also latency
+
+tls_disable_session_tickets = true
+
+
+## DoH: Use a specific cipher suite instead of the server preference
+## 49199 = TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+## 49195 = TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+## 52392 = TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+## 52393 = TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+##
+## On non-Intel CPUs such as MIPS routers and ARM systems (Android, Raspberry Pi...),
+## the following suite improves performance.
+## This may also help on Intel CPUs running 32-bit operating systems.
+##
+## Keep tls_cipher_suite empty if you have issues fetching sources or
+## connecting to some DoH servers. Google and Cloudflare are fine with it.
+
+tls_cipher_suite = [49195]
+
+
+## Fallback resolver
+## This is a normal, non-encrypted DNS resolver, that will be only used
+## for one-shot queries when retrieving the initial resolvers list, and
+## only if the system DNS configuration doesn't work.
+## No user application queries will ever be leaked through this resolver,
+## and it will not be used after IP addresses of resolvers URLs have been found.
+## It will never be used if lists have already been cached, and if stamps
+## don't include host names without IP addresses.
+## It will not be used if the configured system DNS works.
+## A resolver supporting DNSSEC is recommended. This may become mandatory.
+##
+## People in China may need to use 114.114.114.114:53 here.
+## Other popular options include 8.8.8.8 and 1.1.1.1.
+
+fallback_resolver = '1.1.1.1:53'
+
+
+## Never try to use the system DNS settings; unconditionally use the
+## fallback resolver.
+
+ignore_system_dns = true
+
+
+## Automatic log files rotation
+
+# Maximum log files size in MB
+log_files_max_size = 10
+
+# How long to keep backup files, in days
+log_files_max_age = 7
+
+# Maximum log files backups to keep (or 0 to keep all backups)
+log_files_max_backups = 1
+
+
+
+#########################
+#        Filters        #
+#########################
+
+## Immediately respond to IPv6-related queries with an empty response
+## This makes things faster when there is no IPv6 connectivity, but can
+## also cause reliability issues with some stub resolvers. In
+## particular, enabling this on macOS is not recommended.
+
+block_ipv6 = false
+
+
+
+##################################################################################
+#        Route queries for specific domains to a dedicated set of servers        #
+##################################################################################
+
+## Example map entries (one entry per line):
+## example.com 9.9.9.9
+## example.net 9.9.9.9,8.8.8.8,1.1.1.1
+
+# forwarding_rules = 'forwarding-rules.txt'
+
+
+
+###############################
+#        Cloaking rules       #
+###############################
+
+## Cloaking returns a predefined address for a specific name.
+## In addition to acting as a HOSTS file, it can also return the IP address
+## of a different name. It will also do CNAME flattening.
+##
+## Example map entries (one entry per line)
+## example.com     10.1.1.1
+## www.google.com  forcesafesearch.google.com
+
+# cloaking_rules = 'cloaking-rules.txt'
+
+
+
+###########################
+#        DNS cache        #
+###########################
+
+## Enable a DNS cache to reduce latency and outgoing traffic
+
+cache = true
+
+
+## Cache size
+
+cache_size = 512
+
+
+## Minimum TTL for cached entries
+
+cache_min_ttl = 600
+
+
+## Maximum TTL for cached entries
+
+cache_max_ttl = 86400
+
+
+## TTL for negatively cached entries
+
+cache_neg_ttl = 60
+
+
+
+###############################
+#        Query logging        #
+###############################
+
+## Log client queries to a file
+
+[query_log]
+
+  ## Path to the query log file (absolute, or relative to the same directory as the executable file)
+
+  # file = 'query.log'
+
+
+  ## Query log format (currently supported: tsv and ltsv)
+
+  format = 'tsv'
+
+
+  ## Do not log these query types, to reduce verbosity. Keep empty to log everything.
+
+  # ignored_qtypes = ['DNSKEY', 'NS']
+
+
+
+############################################
+#        Suspicious queries logging        #
+############################################
+
+## Log queries for nonexistent zones
+## These queries can reveal the presence of malware, broken/obsolete applications,
+## and devices signaling their presence to 3rd parties.
+
+[nx_log]
+
+  ## Path to the query log file (absolute, or relative to the same directory as the executable file)
+
+  # file = 'nx.log'
+
+
+  ## Query log format (currently supported: tsv and ltsv)
+
+  format = 'tsv'
+
+
+
+######################################################
+#        Pattern-based blocking (blacklists)        #
+######################################################
+
+## Blacklists are made of one pattern per line. Example of valid patterns:
+##
+##   example.com
+##   =example.com
+##   *sex*
+##   ads.*
+##   ads*.example.*
+##   ads*.example[0-9]*.com
+##
+## Example blacklist files can be found at https://download.dnscrypt.info/blacklists/
+## A script to build blacklists from public feeds can be found in the
+## `utils/generate-domains-blacklists` directory of the dnscrypt-proxy source code.
+
+[blacklist]
+
+  ## Path to the file of blocking rules (absolute, or relative to the same directory as the executable file)
+
+  # blacklist_file = 'blacklist.txt'
+
+
+  ## Optional path to a file logging blocked queries
+
+  # log_file = 'blocked.log'
+
+
+  ## Optional log format: tsv or ltsv (default: tsv)
+
+  # log_format = 'tsv'
+
+
+
+###########################################################
+#        Pattern-based IP blocking (IP blacklists)        #
+###########################################################
+
+## IP blacklists are made of one pattern per line. Example of valid patterns:
+##
+##   127.*
+##   fe80:abcd:*
+##   192.168.1.4
+
+[ip_blacklist]
+
+  ## Path to the file of blocking rules (absolute, or relative to the same directory as the executable file)
+
+  # blacklist_file = 'ip-blacklist.txt'
+
+
+  ## Optional path to a file logging blocked queries
+
+  # log_file = 'ip-blocked.log'
+
+
+  ## Optional log format: tsv or ltsv (default: tsv)
+
+  # log_format = 'tsv'
+
+
+
+######################################################
+#   Pattern-based whitelisting (blacklists bypass)   #
+######################################################
+
+## Whitelists support the same patterns as blacklists
+## If a name matches a whitelist entry, the corresponding session
+## will bypass names and IP filters.
+##
+## Time-based rules are also supported to make some websites only accessible at specific times of the day.
+
+[whitelist]
+
+  ## Path to the file of whitelisting rules (absolute, or relative to the same directory as the executable file)
+
+  # whitelist_file = 'whitelist.txt'
+
+
+  ## Optional path to a file logging whitelisted queries
+
+  # log_file = 'whitelisted.log'
+
+
+  ## Optional log format: tsv or ltsv (default: tsv)
+
+  # log_format = 'tsv'
+
+
+
+##########################################
+#        Time access restrictions        #
+##########################################
+
+## One or more weekly schedules can be defined here.
+## Patterns in the name-based blocklist can optionally be followed with @schedule_name
+## to apply the pattern 'schedule_name' only when it matches a time range of that schedule.
+##
+## For example, the following rule in a blacklist file:
+## *.youtube.* @time-to-sleep
+## would block access to YouTube only during the days, and period of the days
+## define by the 'time-to-sleep' schedule.
+##
+## {after='21:00', before= '7:00'} matches 0:00-7:00 and 21:00-0:00
+## {after= '9:00', before='18:00'} matches 9:00-18:00
+
+[schedules]
+
+  # [schedules.'time-to-sleep']
+  # mon = [{after='21:00', before='7:00'}]
+  # tue = [{after='21:00', before='7:00'}]
+  # wed = [{after='21:00', before='7:00'}]
+  # thu = [{after='21:00', before='7:00'}]
+  # fri = [{after='23:00', before='7:00'}]
+  # sat = [{after='23:00', before='7:00'}]
+  # sun = [{after='21:00', before='7:00'}]
+
+  # [schedules.'work']
+  # mon = [{after='9:00', before='18:00'}]
+  # tue = [{after='9:00', before='18:00'}]
+  # wed = [{after='9:00', before='18:00'}]
+  # thu = [{after='9:00', before='18:00'}]
+  # fri = [{after='9:00', before='17:00'}]
+
+
+
+#########################
+#        Servers        #
+#########################
+
+## Remote lists of available servers
+## Multiple sources can be used simultaneously, but every source
+## requires a dedicated cache file.
+##
+## Refer to the documentation for URLs of public sources.
+##
+## A prefix can be prepended to server names in order to
+## avoid collisions if different sources share the same for
+## different servers. In that case, names listed in `server_names`
+## must include the prefixes.
+##
+## If the `urls` property is missing, cache files and valid signatures
+## must be already present; This doesn't prevent these cache files from
+## expiring after `refresh_delay` hours.
+
+[sources]
+
+  ## An example of a remote source from https://github.com/DNSCrypt/dnscrypt-resolvers
+
+  [sources.'public-resolvers']
+  urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']
+  cache_file = 'public-resolvers.md'
+  minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+  refresh_delay = 72
+  prefix = ''
+
+  ## Another example source, with resolvers censoring some websites not appropriate for children
+  ## This is a subset of the `public-resolvers` list, so enabling both is useless
+
+  #  [sources.'parental-control']
+  #  urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/parental-control.md', 'https://download.dnscrypt.info/resolvers-list/v2/parental-control.md']
+  #  cache_file = 'parental-control.md'
+  #  minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+
+
+
+## Optional, local, static list of additional servers
+## Mostly useful for testing your own servers.
+
+[static]
+
+  # [static.'google']
+  # stamp = 'sdns://AgUAAAAAAAAAAAAOZG5zLmdvb2dsZS5jb20NL2V4cGVyaW1lbnRhbA'

--- a/roles/vpn/meta/main.yml
+++ b/roles/vpn/meta/main.yml
@@ -2,4 +2,6 @@
 
 dependencies:
   - { role: common, tags: common }
-
+  - role: dns_encryption
+    tags: dns_encryption
+    when: dns_encryption == true

--- a/roles/vpn/tasks/freebsd.yml
+++ b/roles/vpn/tasks/freebsd.yml
@@ -24,7 +24,7 @@
     line: "{{ item }}"
     insertbefore: BOF
   with_items:
-    - "options	IPSEC"
+    - "options IPSEC"
     - "options IPSEC_NAT_T"
     - "device	crypto"
   when: rebuild_needed is defined and rebuild_needed == true

--- a/roles/vpn/tasks/ubuntu.yml
+++ b/roles/vpn/tasks/ubuntu.yml
@@ -12,7 +12,7 @@
 
 - name: Ubuntu | Enforcing ipsec with apparmor
   shell: aa-enforce "{{ item }}"
-  when: apparmor_enabled is defined and apparmor_enabled == true
+  when: apparmor_enabled|default(false)|bool == true
   with_items:
     - /usr/lib/ipsec/charon
     - /usr/lib/ipsec/lookip

--- a/roles/vpn/templates/ipsec.conf.j2
+++ b/roles/vpn/templates/ipsec.conf.j2
@@ -28,7 +28,7 @@ conn %default
     right=%any
     rightauth=pubkey
     rightsourceip={{ vpn_network }},{{ vpn_network_ipv6 }}
-{% if local_dns is defined and local_dns == "Y" %}
+{% if local_dns|d(false)|bool == true or dns_encryption|d(false)|bool == true %}
     rightdns={{ local_service_ip }}
 {% else %}
     rightdns={% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support is defined and ipv6_support == "yes" %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}

--- a/tests/local-deploy.sh
+++ b/tests/local-deploy.sh
@@ -2,11 +2,11 @@
 
 set -ex
 
-DEPLOY_ARGS="server_ip=$LXC_IP server_user=root IP_subject_alt_name=$LXC_IP local_dns=Y"
+DEPLOY_ARGS="server_ip=$LXC_IP server_user=root IP_subject_alt_name=$LXC_IP local_dns=true dns_over_https=true apparmor_enabled=false"
 
 if [ "${LXC_NAME}" == "docker" ]
 then
-  docker run -it -v $(pwd)/config.cfg:/algo/config.cfg -v ~/.ssh:/root/.ssh -e "DEPLOY_ARGS=${DEPLOY_ARGS}" travis/algo /bin/sh -c "chown -R 0:0 /root/.ssh && source env/bin/activate && ansible-playbook deploy.yml -t local,vpn,dns,ssh_tunneling,security,tests -e \"${DEPLOY_ARGS}\""
+  docker run -it -v $(pwd)/config.cfg:/algo/config.cfg -v ~/.ssh:/root/.ssh -e "DEPLOY_ARGS=${DEPLOY_ARGS}" travis/algo /bin/sh -c "chown -R 0:0 /root/.ssh && source env/bin/activate && ansible-playbook deploy.yml -t cloud,local,vpn,dns,ssh_tunneling,security,tests,dns_over_https -e \"${DEPLOY_ARGS}\" --skip-tags apparmor"
 else
-  ansible-playbook deploy.yml -t local,vpn,dns,ssh_tunneling,tests -e "${DEPLOY_ARGS}" -vvvv
+  ansible-playbook deploy.yml -t cloud,local,vpn,dns,dns_over_https,ssh_tunneling,tests -e "${DEPLOY_ARGS}" --skip-tags apparmor
 fi


### PR DESCRIPTION
- [dnscrypt-proxy](https://github.com/jedisct1/dnscrypt-proxy) service for supported *BSDs and Ubuntu.
- AppArmor policies and cgroups limits
- CloudFlare DNS over HTTPS enabled by default for all installations
- Fixes #871 