### PR TITLE
monkey patch problematic dnscrypt-proxy cgroup limits

### DIFF
--- a/roles/dns_encryption/tasks/ubuntu.yml
+++ b/roles/dns_encryption/tasks/ubuntu.yml
@@ -35,14 +35,14 @@
     owner: root
     group: root
 
-- name: Ubuntu | Setup the cgroup limitations for dnscrypt-proxy
-  copy:
-    dest: /etc/systemd/system/dnscrypt-proxy.service.d/100-CustomLimitations.conf
-    content: |
-      [Service]
-      MemoryLimit=16777216
-      CPUAccounting=true
-      CPUQuota=5%
-  notify:
-    - daemon-reload
-    - restart dnscrypt-proxy
+#- name: Ubuntu | Setup the cgroup limitations for dnscrypt-proxy
+#  copy:
+#    dest: /etc/systemd/system/dnscrypt-proxy.service.d/100-CustomLimitations.conf
+#    content: |
+#      [Service]
+#      MemoryLimit=16777216
+#      CPUAccounting=true
+#      CPUQuota=5%
+#  notify:
+#    - daemon-reload
+#    - restart dnscrypt-proxy


### PR DESCRIPTION
dnscrypt-proxy is getting killed by cgroups, causing VMs to stop working after a few minutes of browsing the web. We'll have to profile what an appropriate limit looks like, or deal with this in a different way.