### PR TITLE
Update dnscrypt-proxy.toml.j2

### DIFF
--- a/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
+++ b/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
@@ -238,9 +238,14 @@ cache_min_ttl = 600
 cache_max_ttl = 86400
 
 
-## TTL for negatively cached entries
+## Minimum TTL for negatively cached entries
 
-cache_neg_ttl = 60
+cache_neg_min_ttl = 60
+
+
+## Maximum TTL for negatively cached entries
+
+cache_neg_max_ttl = 600
 
 
 


### PR DESCRIPTION
Updated dnscrypt-proxy.toml with new options: cache_neg_min_ttl and cache_neg_max_ttl

These new options in Version 2.0.11 are to clamp the negative caching TTL. The repository Algo is using (ppa:shevchuk/dnscrypt-proxy) has updated to this version. These options are now included as default in dnscrypt-proxy.