### PR TITLE
Don't download minisig dnscrypt release

### DIFF
--- a/roles/dns_encryption/tasks/freebsd.yml
+++ b/roles/dns_encryption/tasks/freebsd.yml
@@ -34,7 +34,7 @@
     force: true
   with_items: "{{ dnscrypt_proxy_latest['json']['assets'] }}"
   no_log: true
-  when: '"freebsd_amd64" in item.name'
+  when: '"freebsd_amd64" in item.name and not item.name.endswith("minisig")'
   notify: restart dnscrypt-proxy
 
 - name: FreeBSD | Extract the latest archive


### PR DESCRIPTION
When installing on FreeBSD, I ran into an issue where a minisig of dnscrypt was being downloaded rather than the actual release. This patch resolved it for me.