### PR TITLE
fix requirements.txt SecretStorage version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 setuptools>=11.3
+SecretStorage < 3
 ansible[azure]==2.4.3
 dopy==0.3.5
 boto>=2.5


### PR DESCRIPTION
Related to issue #887. Latest SecretStorage build requires Python '>=3.5' but Algo is running on Python 2