### PR TITLE
IPv6 fixes

### DIFF
--- a/playbooks/facts/main.yml
+++ b/playbooks/facts/main.yml
@@ -10,10 +10,9 @@
     key: "{{ lookup('file', '{{ SSH_keys.public }}') }}"
   tags: [ 'cloud' ]
 
-- name: Enable IPv6
+- name: Check if IPv6 configured
   set_fact:
-    ipv6_support: true
-  when: ansible_default_ipv6.gateway is defined
+    ipv6_support: "{% if ansible_default_ipv6['gateway'] is defined %}true{% else %}false{% endif %}"
 
 - name: Set facts if the deployment in a cloud
   set_fact:

--- a/roles/cloud-azure/tasks/main.yml
+++ b/roles/cloud-azure/tasks/main.yml
@@ -118,7 +118,6 @@
         ansible_python_interpreter: "/usr/bin/python2.7"
         ansible_ssh_private_key_file: "{{ SSH_keys.private }}"
         cloud_provider: azure
-        ipv6_support: no
 
     - set_fact:
         cloud_instance_ip: "{{ ip_address }}"

--- a/roles/cloud-digitalocean/tasks/main.yml
+++ b/roles/cloud-digitalocean/tasks/main.yml
@@ -64,7 +64,6 @@
         do_access_token: "{{ do_token }}"
         do_droplet_id: "{{ do.droplet.id }}"
         cloud_provider: digitalocean
-        ipv6_support: true
 
     - set_fact:
         cloud_instance_ip: "{{ do.droplet.ip_address }}"

--- a/roles/cloud-ec2/tasks/main.yml
+++ b/roles/cloud-ec2/tasks/main.yml
@@ -32,7 +32,6 @@
         ansible_python_interpreter: "/usr/bin/python2.7"
         ansible_ssh_private_key_file: "{{ SSH_keys.private }}"
         cloud_provider: ec2
-        ipv6_support: yes
 
     - set_fact:
         cloud_instance_ip: "{{ stack.stack_outputs.ElasticIP }}"

--- a/roles/cloud-gce/tasks/main.yml
+++ b/roles/cloud-gce/tasks/main.yml
@@ -46,7 +46,6 @@
         ansible_python_interpreter: "/usr/bin/python2.7"
         ansible_ssh_private_key_file: "{{ SSH_keys.private }}"
         cloud_provider: gce
-        ipv6_support: no
 
     - set_fact:
         cloud_instance_ip: "{{ google_vm.instance_data[0].public_ip }}"

--- a/roles/cloud-lightsail/tasks/main.yml
+++ b/roles/cloud-lightsail/tasks/main.yml
@@ -43,7 +43,6 @@
       ansible_python_interpreter: "/usr/bin/python2.7"
       ansible_ssh_private_key_file: "{{ SSH_keys.private }}"
       cloud_provider: lightsail
-      ipv6_support: no
 
   rescue:
   - debug: var=fail_hint

--- a/roles/cloud-openstack/tasks/main.yml
+++ b/roles/cloud-openstack/tasks/main.yml
@@ -78,7 +78,6 @@
       ansible_python_interpreter: "/usr/bin/python2.7"
       ansible_ssh_private_key_file: "{{ SSH_keys.private }}"
       cloud_provider: openstack
-      ipv6_support: omit
 
   rescue:
   - debug: var=fail_hint

--- a/roles/cloud-scaleway/tasks/main.yml
+++ b/roles/cloud-scaleway/tasks/main.yml
@@ -119,7 +119,6 @@
       ansible_python_interpreter: "/usr/bin/python2.7"
       ansible_ssh_private_key_file: "{{ SSH_keys.private }}"
       cloud_provider: scaleway
-      ipv6_support: yes
 
   rescue:
   - debug: var=fail_hint

--- a/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
+++ b/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
@@ -27,7 +27,7 @@
 ## The proxy will automatically pick the fastest, working servers from the list.
 ## Remove the leading # first to enable this; lines starting with # are ignored.
 
-server_names      = ['{{ dns_encryption_provider }}'{% if ipv6_support|d(false)|bool == true and dns_encryption_provider == "cloudflare" %}, '{{ dns_encryption_provider }}-ipv6' {% endif %} ]
+server_names      = ['{{ dns_encryption_provider }}'{% if ipv6_support and dns_encryption_provider == "cloudflare" %}, '{{ dns_encryption_provider }}-ipv6' {% endif %} ]
 
 
 ## List of local addresses and ports to listen to. Can be IPv4 and/or IPv6.
@@ -47,7 +47,7 @@ max_clients = 250
 ipv4_servers = true
 
 # Use servers reachable over IPv6 -- Do not enable if you don't have IPv6 connectivity
-ipv6_servers = {{ ipv6_support|default(false) | bool | lower }}
+ipv6_servers = {{ ipv6_support | bool | lower }}
 
 # Use servers implementing the DNSCrypt protocol
 dnscrypt_servers = true

--- a/roles/vpn/tasks/iptables.yml
+++ b/roles/vpn/tasks/iptables.yml
@@ -19,7 +19,7 @@
     owner: root
     group: root
     mode: 0640
-  when: ipv6_support is defined and ipv6_support == true
+  when: ipv6_support
   with_items:
     - { src: rules.v6.j2, dest: /etc/iptables/rules.v6 }
   notify:

--- a/roles/vpn/tasks/openssl.yml
+++ b/roles/vpn/tasks/openssl.yml
@@ -2,7 +2,7 @@
 - block:
   - name: Set subjectAltName as a fact
     set_fact:
-      subjectAltName: "{{ subjectAltName_IP }}{% if ipv6_support and ansible_default_ipv6 %},IP:{{ ansible_default_ipv6['address'] }}{% endif %}{% if domain and subjectAltName_DNS %},DNS:{{ subjectAltName_DNS }}{% endif %}"
+      subjectAltName: "{{ subjectAltName_IP }}{% if ipv6_support %},IP:{{ ansible_default_ipv6['address'] }}{% endif %}{% if domain and subjectAltName_DNS %},DNS:{{ subjectAltName_DNS }}{% endif %}"
     tags: always
 
   - name: Ensure the pki directory does not exist


### PR DESCRIPTION
- Adds a fact which determines whether IPv6 is actually configured on the system
- Fixes #921 (For some reason DNScrypt-proxy stops handling any requests if IPv6 servers are unreachable)
Skipping IPv6 configuration for Scaleway for now. They don't provide any way to use cloud-init during server creation.