### PR TITLE
Fixes for #491 - Naming in mobileconfig, powershell, and AWS EC2

### DIFF
--- a/algo
+++ b/algo
@@ -102,8 +102,8 @@ $ADDITIONAL_PROMPT
   read -p "
 
 Name the vpn server:
-[algo]: " -r azure_server_name
-  azure_server_name=${azure_server_name:-algo}
+[algo]: " -r algo_server_name
+  algo_server_name=${algo_server_name:-algo}
 
   read -p "
 
@@ -181,7 +181,7 @@ Enter the number of your desired region:
   esac
 
   ROLES="azure vpn cloud"
-  EXTRA_VARS="azure_secret=$azure_secret azure_tenant=$azure_tenant azure_client_id=$azure_client_id azure_subscription_id=$azure_subscription_id azure_server_name=$azure_server_name ssh_public_key=$ssh_public_key region=$region"
+  EXTRA_VARS="azure_secret=$azure_secret azure_tenant=$azure_tenant azure_client_id=$azure_client_id azure_subscription_id=$azure_subscription_id algo_server_name=$algo_server_name ssh_public_key=$ssh_public_key region=$region"
 }
 
 digitalocean () {
@@ -193,8 +193,8 @@ $ADDITIONAL_PROMPT
   read -p "
 
 Name the vpn server:
-[algo.local]: " -r do_server_name
-  do_server_name=${do_server_name:-algo.local}
+[algo.local]: " -r algo_server_name
+  algo_server_name=${algo_server_name:-algo.local}
 
   read -p "
 
@@ -232,7 +232,7 @@ Enter the number of your desired region:
   esac
 
 ROLES="digitalocean vpn cloud"
-EXTRA_VARS="do_access_token=$do_access_token do_server_name=$do_server_name do_region=$do_region"
+EXTRA_VARS="do_access_token=$do_access_token algo_server_name=$algo_server_name do_region=$do_region"
 }
 
 ec2 () {
@@ -251,8 +251,8 @@ $ADDITIONAL_PROMPT
 read -p "
 
 Name the vpn server:
-[algo]: " -r aws_server_name
-  aws_server_name=${aws_server_name:-algo}
+[algo]: " -r algo_server_name
+  algo_server_name=${algo_server_name:-algo}
 
   read -p "
 
@@ -298,7 +298,7 @@ Enter the number of your desired region:
   esac
 
   ROLES="ec2 vpn cloud"
-  EXTRA_VARS="aws_access_key=$aws_access_key aws_secret_key=$aws_secret_key aws_server_name=$aws_server_name region=$region"
+  EXTRA_VARS="aws_access_key=$aws_access_key aws_secret_key=$aws_secret_key algo_server_name=$algo_server_name region=$region"
 }
 
 lightsail () {
@@ -419,8 +419,8 @@ Enter the local path to your credentials JSON file (https://support.google.com/c
   read -p "
 
 Name the vpn server:
-[algo]: " -r server_name
-  server_name=${server_name:-algo}
+[algo]: " -r algo_server_name
+  algo_server_name=${algo_server_name:-algo}
 
   read -p "
 
@@ -506,7 +506,7 @@ Please choose the number of your zone. Press enter for default (#14) zone.
   esac
 
   ROLES="gce vpn cloud"
-  EXTRA_VARS="credentials_file=$credentials_file gce_server_name=$server_name ssh_public_key=$ssh_public_key zone=$zone max_mss=1316"
+  EXTRA_VARS="credentials_file=$credentials_file algo_server_name=$algo_server_name ssh_public_key=$ssh_public_key zone=$zone max_mss=1316"
 }
 
 non_cloud () {

--- a/docs/cloud-do.md
+++ b/docs/cloud-do.md
@@ -82,6 +82,6 @@ If you are using Ansible to deploy to DigitalOcean, you will need to pass the AP
 
 For example,
 
-    ansible-playbook deploy.yml -t digitalocean,vpn,cloud -e 'do_access_token=my_secret_token do_server_name=algo.local do_region=ams2
+    ansible-playbook deploy.yml -t digitalocean,vpn,cloud -e 'do_access_token=my_secret_token algo_server_name=algo.local do_region=ams2
     
 Where "my_secret_token" is your API Token.

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -11,7 +11,7 @@ You can deploy Algo non-interactively by running the Ansible playbooks directly 
 Here is a full example for DigitalOcean:
 
 ```shell
-ansible-playbook deploy.yml -t digitalocean,vpn,cloud -e 'do_access_token=my_secret_token do_server_name=algo.local do_region=ams2'
+ansible-playbook deploy.yml -t digitalocean,vpn,cloud -e 'do_access_token=my_secret_token algo_server_name=algo.local do_region=ams2'
 ```
 
 ### Ansible roles
@@ -62,7 +62,7 @@ ansible-playbook deploy.yml -t local,vpn --skip-tags iptables -e 'server_ip=172.
 Required variables:
 
 - do_access_token
-- do_server_name
+- algo_server_name
 - do_region
 
 Possible options for `do_region`:
@@ -86,7 +86,7 @@ Required variables:
 
 - aws_access_key
 - aws_secret_key
-- aws_server_name
+- algo_server_name
 - region
 
 Possible options for `region`:
@@ -179,7 +179,7 @@ Additional tags:
 Required variables:
 
 - credentials_file
-- gce_server_name
+- algo_server_name
 - ssh_public_key
 - zone
 

--- a/roles/cloud-azure/tasks/main.yml
+++ b/roles/cloud-azure/tasks/main.yml
@@ -82,7 +82,7 @@
         resource_group: "{{ resource_group }}"
         admin_username: ubuntu
         virtual_network: algo_net
-        name: "{{ azure_server_name }}"
+        name: "{{ algo_server_name }}"
         ssh_password_enabled: false
         vm_size: "{{ cloud_providers.azure.size }}"
         tags:

--- a/roles/cloud-digitalocean/tasks/main.yml
+++ b/roles/cloud-digitalocean/tasks/main.yml
@@ -44,7 +44,7 @@
       digital_ocean:
         state: present
         command: droplet
-        name: "{{ do_server_name }}"
+        name: "{{ algo_server_name }}"
         region_id: "{{ do_region }}"
         size_id: "{{ cloud_providers.digitalocean.size }}"
         image_id: "{{ cloud_providers.digitalocean.image }}"

--- a/roles/cloud-ec2/files/stack.yml
+++ b/roles/cloud-ec2/files/stack.yml
@@ -19,7 +19,7 @@ Resources:
       InstanceTenancy: default
       Tags:
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
         - Key: Environment
           Value: Algo
 
@@ -36,7 +36,7 @@ Resources:
         - Key: Environment
           Value: Algo
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
 
   Subnet:
     Type: AWS::EC2::Subnet
@@ -47,7 +47,7 @@ Resources:
         - Key: Environment
           Value: Algo
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
       VpcId: !Ref VPC
 
   VPCGatewayAttachment:
@@ -64,7 +64,7 @@ Resources:
         - Key: Environment
           Value: Algo
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
 
   Route:
     Type: AWS::EC2::Route
@@ -134,7 +134,7 @@ Resources:
           CidrIp: 0.0.0.0/0
       Tags:
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
         - Key: Environment
           Value: Algo
 
@@ -189,7 +189,7 @@ Resources:
             cfn-signal -e $? --stack ${AWS::StackName} --resource EC2Instance --region ${AWS::Region}
       Tags:
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
         - Key: Environment
           Value: Algo
 

--- a/roles/cloud-ec2/tasks/main.yml
+++ b/roles/cloud-ec2/tasks/main.yml
@@ -2,7 +2,7 @@
     - set_fact:
         access_key: "{{ aws_access_key | default(lookup('env','AWS_ACCESS_KEY_ID'), true) }}"
         secret_key: "{{ aws_secret_key | default(lookup('env','AWS_SECRET_ACCESS_KEY'), true) }}"
-        stack_name: "{{ aws_server_name | replace('.', '-') }}"
+        stack_name: "{{ algo_server_name | replace('.', '-') }}"
 
     - name: Locate official AMI for region
       ec2_ami_find:

--- a/roles/cloud-gce/tasks/main.yml
+++ b/roles/cloud-gce/tasks/main.yml
@@ -9,7 +9,7 @@
     - set_fact:
         service_account_email: "{{ credentials_file_lookup.client_email | default(lookup('env','GCE_EMAIL')) }}"
         project_id: "{{ credentials_file_lookup.project_id | default(lookup('env','GCE_PROJECT')) }}"
-        server_name: "{{ gce_server_name | replace('_', '-') }}"
+        server_name: "{{ algo_server_name | replace('_', '-') }}"
 
     - name: Network configured
       gce_net:

--- a/roles/vpn/templates/client_windows.ps1.j2
+++ b/roles/vpn/templates/client_windows.ps1.j2
@@ -79,7 +79,12 @@ Save the embedded CA cert and encrypted user PKCS12 file.
 $ErrorActionPreference = "Stop"
 
 $VpnServerAddress = "{{ IP_subject_alt_name }}"
-$VpnName = "Algo VPN {{ IP_subject_alt_name }} IKEv2"
+{% set vpn_server_name = algo_server_name %}
+{% if (algo_server_name == 'algo') or (algo_server_name == 'algo.local') %}
+    {% set vpn_server_name = 'Algo VPN '+IP_subject_alt_name+' IKEv2' %}
+{% else %}
+{% endif %}
+$VpnName = "{{ vpn_server_name }}"
 $VpnUser = "{{ item.0 }}"
 $CaCertificateBase64 = "{{ PayloadContentCA }}"
 $UserPkcs12Base64 = "{{ item.1.stdout }}"

--- a/roles/vpn/templates/mobileconfig.j2
+++ b/roles/vpn/templates/mobileconfig.j2
@@ -7,6 +7,11 @@
         <dict>
             <key>IKEv2</key>
             <dict>
+{% set vpn_user_defined_name = algo_server_name %}
+{% if (algo_server_name == 'algo') or (algo_server_name == 'algo.local') %}
+    {% set vpn_user_defined_name = IP_subject_alt_name %}
+{% else %}
+{% endif %}
 {% if (OnDemandEnabled_WIFI is defined and OnDemandEnabled_WIFI == 'Y') or (OnDemandEnabled_Cellular is defined and OnDemandEnabled_Cellular == 'Y') %}
               <key>OnDemandEnabled</key>
                 <integer>1</integer>
@@ -129,7 +134,7 @@
                 <integer>0</integer>
             </dict>
             <key>UserDefinedName</key>
-            <string>Algo VPN {{ IP_subject_alt_name }} IKEv2</string>
+            <string>{{ vpn_user_defined_name }}</string>
             <key>VPNType</key>
             <string>IKEv2</string>
         </dict>
@@ -175,7 +180,7 @@
         </dict>
     </array>
     <key>PayloadDisplayName</key>
-    <string>{{ IP_subject_alt_name }} IKEv2</string>
+    <string>{{ vpn_user_defined_name }}</string>
     <key>PayloadIdentifier</key>
     <string>donut.local.{{ 500000 | random | to_uuid | upper }}</string>
     <key>PayloadRemovalDisallowed</key>


### PR DESCRIPTION
Normalized the various cloud_server_name entries to just
algo_server_name. Integrated algo_server_name into the mobileconfig
template as well as powershell. If a default name is provided, the 
original behavior of IP_subject_alt_name will be used to avoid conflicts. 
Also updated the Name tag in the cloudformation template to utilize the 
StackName (which is based on the algo_server_name).