### PR TITLE
Remove algo_params

### DIFF
--- a/roles/vpn/tasks/openssl.yml
+++ b/roles/vpn/tasks/openssl.yml
@@ -44,7 +44,7 @@
     shell: >
       {{ openssl_bin }} ecparam -name prime256v1 -out ecparams/prime256v1.pem &&
       {{ openssl_bin }} req -utf8 -new
-      -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }}
+      -newkey ec:ecparams/prime256v1.pem
       -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName={{ subjectAltName }}"))
       -keyout private/cakey.pem
       -out cacert.pem -x509 -days 3650
@@ -71,7 +71,7 @@
   - name: Build the server pair
     shell: >
       {{ openssl_bin }} req -utf8 -new
-      -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }}
+      -newkey ec:ecparams/prime256v1.pem
       -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName={{ subjectAltName }}"))
       -keyout private/{{ IP_subject_alt_name }}.key
       -out reqs/{{ IP_subject_alt_name }}.req -nodes
@@ -93,7 +93,7 @@
   - name: Build the client's pair
     shell: >
       {{ openssl_bin }} req -utf8 -new
-      -newkey {{ algo_params | default('ec:ecparams/prime256v1.pem') }}
+      -newkey ec:ecparams/prime256v1.pem
       -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName=DNS:{{ item }}"))
       -keyout private/{{ item }}.key
       -out reqs/{{ item }}.req -nodes


### PR DESCRIPTION
`algo_params` used for passing RSA keys setting previously.
Removed in https://github.com/trailofbits/algo/commit/451394100db4cbb93d9d13345c54747e3146ccaa.