### PR TITLE
Extra line and better DNS configuration for WireGuard

### DIFF
--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -89,7 +89,6 @@
       - iptables-persistent
       - cgroup-tools
       - openssl
-      - resolvconf
     sysctl:
       - item: net.ipv4.ip_forward
         value: 1

--- a/roles/dns_encryption/handlers/main.yml
+++ b/roles/dns_encryption/handlers/main.yml
@@ -4,6 +4,7 @@
     daemon_reload: true
 
 - name: restart dnscrypt-proxy
-  service:
+  systemd:
     name: dnscrypt-proxy
     state: restarted
+    daemon_reload: true

--- a/roles/dns_encryption/tasks/ubuntu.yml
+++ b/roles/dns_encryption/tasks/ubuntu.yml
@@ -42,5 +42,4 @@
       [Service]
       AmbientCapabilities=CAP_NET_BIND_SERVICE
   notify:
-   - daemon-reload
    - restart dnscrypt-proxy

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -16,3 +16,9 @@ wireguard_network_ipv6:
 wireguard_vpn_network: "{{ wireguard_network_ipv4['subnet'] }}/{{ wireguard_network_ipv4['prefix'] }}"
 wireguard_vpn_network_ipv6: "{{ wireguard_network_ipv6['subnet'] }}/{{ wireguard_network_ipv6['prefix'] }}"
 easyrsa_reinit_existent: false
+wireguard_dns_servers: >-
+  {% if local_dns|default(false)|bool or dns_encryption|default(false)|bool == true %}
+  {{ local_service_ip }}
+  {% else %}
+  {% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
+  {% endif %}

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -2,7 +2,8 @@
 PrivateKey = {{ lookup('file', wireguard_config_path + '/private/' + item.1) }}
 Address = {{ wireguard_network_ipv4['clients_range'] }}.{{ wireguard_network_ipv4['clients_start'] + item.0 + 1 }}/32{% if ipv6_support %},{{ wireguard_network_ipv6['clients_range'] }}{{ wireguard_network_ipv6['clients_start'] + item.0 + 1 }}/{{ wireguard_network_ipv6['prefix'] }}
 {% endif %}
-DNS = {{ local_service_ip }}
+
+DNS = {{ wireguard_dns_servers }}
 
 [Peer]
 PublicKey = {{ lookup('file', wireguard_config_path + '/public/' + IP_subject_alt_name) }}

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -2,7 +2,6 @@
 Address = {{ wireguard_network_ipv4['subnet'] }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['gateway'] }}/{{ wireguard_network_ipv6['prefix'] }}
 {% endif %}
 
-DNS = {{ local_service_ip }}
 ListenPort = {{ wireguard_port }}
 PrivateKey = {{ lookup('file', wireguard_config_path + '/private/' + IP_subject_alt_name) }}
 SaveConfig = true


### PR DESCRIPTION
- Adds an extra line after the if statement. Jinja2 trims such blocks by default in Ansible. Fixes #965
- More appropriate way to configure DNS servers
- Removes `DNS` option from the wireguard server config
- Fixes dnscrypt-proxy restart