### PR TITLE
Scaleway: enable ipv6 and switch to local boot

### DIFF
--- a/roles/cloud-scaleway/tasks/main.yml
+++ b/roles/cloud-scaleway/tasks/main.yml
@@ -74,6 +74,8 @@
           name: "{{ algo_server_name }}"
           image: "{{ image_id }}"
           commercial_type: "{{cloud_providers.scaleway.size }}"
+          enable_ipv6: true
+          boot_type: local
           tags:
             - Environment:Algo
             - AUTHORIZED_KEY={{ lookup('file', SSH_keys.public)|regex_replace(' ', '_') }}


### PR DESCRIPTION
- Enables IPv6 on Scaleway
- Adds local boot on scaleway
- Fixes #966