### PR TITLE
WireGuard: disable SaveConfig, update-users fix

### DIFF
--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -4,7 +4,7 @@ Address = {{ wireguard_network_ipv4['subnet'] }}/{{ wireguard_network_ipv4['pref
 
 ListenPort = {{ wireguard_port }}
 PrivateKey = {{ lookup('file', wireguard_config_path + '/private/' + IP_subject_alt_name) }}
-SaveConfig = true
+SaveConfig = false
 Table = off
 
 {% for u in users %}

--- a/users.yml
+++ b/users.yml
@@ -55,6 +55,7 @@
 
   roles:
     - { role: ssh_tunneling, tags: always, when: ssh_tunneling_enabled is defined and ssh_tunneling_enabled == "y" }
+    - { role: wireguard, tags: [ 'vpn', 'wireguard' ], when: wireguard_enabled }
     - { role: vpn }
 
   post_tasks:


### PR DESCRIPTION
- Disables SaveConfig. SaveConfig totally breaks the idea of configuration management and it breaks update-users
- WireGuard update-users fix. Mentioned in https://github.com/trailofbits/algo/issues/980#issuecomment-393720561