### PR TITLE
Remove duplicate dict key (enable_ipv6)

### DIFF
--- a/roles/cloud-scaleway/tasks/main.yml
+++ b/roles/cloud-scaleway/tasks/main.yml
@@ -79,7 +79,6 @@
           tags:
             - Environment:Algo
             - AUTHORIZED_KEY={{ lookup('file', SSH_keys.public)|regex_replace(' ', '_') }}
-          enable_ipv6: true
         status_code: 201
         body_format: json
       register: algo_instance


### PR DESCRIPTION
Warning in yaml file:
` [WARNING]: While constructing a mapping from /root/algo/roles/cloud-scaleway/tasks/main.yml, line 73, column 11, found a duplicate dict key (enable_ipv6). Using last defined value only.`