### PR TITLE
Systemd Relosved

### DIFF
--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -57,12 +57,15 @@
   tags:
     - always
 
-- name: systemd-networkd enabled and started
+- name: systemd services enabled and started
   systemd:
-    name: systemd-networkd
+    name: "{{ item }}"
     state: started
     enabled: true
     daemon_reload: true
+  with_items:
+    - systemd-networkd
+    - systemd-resolved
   tags:
     - always
 

--- a/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
+++ b/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
@@ -151,7 +151,7 @@ tls_cipher_suite = [49195]
 ## People in China may need to use 114.114.114.114:53 here.
 ## Other popular options include 8.8.8.8 and 1.1.1.1.
 
-fallback_resolver = '1.1.1.1:53'
+fallback_resolver = '127.0.0.53:53'
 
 
 ## Never try to use the system DNS settings; unconditionally use the


### PR DESCRIPTION
Move DNSCrypt proxy `fallback_resolver` to systemd-resolved.
Sometimes 1.1.1.1 is unreachable via 53/udp and prevents dnscrypt proxy from start