### PR TITLE
Workaround for ubuntu repositories

### DIFF
--- a/roles/dns_encryption/tasks/ubuntu.yml
+++ b/roles/dns_encryption/tasks/ubuntu.yml
@@ -4,7 +4,11 @@
     state: present
     codename: artful
     repo: ppa:shevchuk/dnscrypt-proxy
-
+  register: result
+  until: result|succeeded
+  retries: 10
+  delay: 3
+  
 - name: Install dnscrypt-proxy
   apt:
     name: dnscrypt-proxy

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -3,6 +3,10 @@
   apt_repository:
     repo: ppa:wireguard/wireguard
     state: present
+  register: result
+  until: result|succeeded
+  retries: 10
+  delay: 3
 
 - name: WireGuard installed
   apt:


### PR DESCRIPTION
- Adds a do-until loop for the apt_repository tasks. Sometimes it fails due to reasons beyond our control. Fixes #1014 