### PR TITLE
Explicitly allow traffic between clients if enabled

### DIFF
--- a/roles/vpn/templates/rules.v4.j2
+++ b/roles/vpn/templates/rules.v4.j2
@@ -69,10 +69,11 @@ COMMIT
 # Accept DNS traffic to the local DNS resolver
 -A INPUT -d {{ local_service_ip }} -p udp --dport 53 -j ACCEPT
 
-{% if BetweenClients_DROP is defined and BetweenClients_DROP == "Y" %}
 # Drop traffic between VPN clients
--A FORWARD -s {{ vpn_network }}{% if wireguard_enabled %},{{ wireguard_vpn_network }}{% endif %} -d {{ vpn_network }}{% if wireguard_enabled %},{{ wireguard_vpn_network }}{% endif %} -j DROP
+{% if BetweenClients_DROP is defined and BetweenClients_DROP == "Y" %}
+{% set BetweenClientsPolicy = "DROP" %}
 {% endif %}
+-A FORWARD -s {{ vpn_network }}{% if wireguard_enabled %},{{ wireguard_vpn_network }}{% endif %} -d {{ vpn_network }}{% if wireguard_enabled %},{{ wireguard_vpn_network }}{% endif %} -j {{ BetweenClientsPolicy | default("ACCEPT") }}
 
 # Forward any packet that's part of an established connection
 -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT

--- a/roles/vpn/templates/rules.v6.j2
+++ b/roles/vpn/templates/rules.v6.j2
@@ -84,9 +84,12 @@ COMMIT
 # Accept DNS traffic to the local DNS resolver
 -A INPUT -d fcaa::1 -p udp --dport 53 -j ACCEPT
 
+# Drop traffic between VPN clients
 {% if BetweenClients_DROP is defined and BetweenClients_DROP == "Y" %}
--A FORWARD -s {{ vpn_network_ipv6 }}{% if wireguard_enabled %},{{ wireguard_vpn_network_ipv6 }}{% endif %} -d {{ vpn_network_ipv6 }}{% if wireguard_enabled %},{{ wireguard_vpn_network_ipv6 }}{% endif %} -j DROP
+{% set BetweenClientsPolicy = "DROP" %}
 {% endif %}
+-A FORWARD -s {{ vpn_network_ipv6 }}{% if wireguard_enabled %},{{ wireguard_vpn_network_ipv6 }}{% endif %} -d {{ vpn_network_ipv6 }}{% if wireguard_enabled %},{{ wireguard_vpn_network_ipv6 }}{% endif %} -j {{ BetweenClientsPolicy | default("ACCEPT") }}
+
 -A FORWARD -j ICMPV6-CHECK
 -A FORWARD -p tcp --dport 445 -j DROP
 -A FORWARD -p udp -m multiport --ports 137,138 -j DROP


### PR DESCRIPTION
If `BetweenClients_DROP` is set to `false` no rules created and traffic is restricted by the following rules
Fixes #1027 #679