### PR TITLE
Run dnsmasq as the dnsmasq user

### DIFF
--- a/roles/dns_adblocking/tasks/main.yml
+++ b/roles/dns_adblocking/tasks/main.yml
@@ -8,9 +8,6 @@
     - name: Dnsmasq installed
       package: name=dnsmasq
 
-    - name: Ensure that the dnsmasq user exists
-      user: name=dnsmasq groups=nogroup append=yes state=present
-
     - name: The dnsmasq directory created
       file: dest=/var/lib/dnsmasq state=directory mode=0755 owner=dnsmasq group=nogroup
 

--- a/roles/dns_adblocking/tasks/main.yml
+++ b/roles/dns_adblocking/tasks/main.yml
@@ -8,7 +8,7 @@
     - name: Dnsmasq installed
       package: name=dnsmasq
 
-    - name: Ensure that the dnsmasq user exist
+    - name: Ensure that the dnsmasq user exists
       user: name=dnsmasq groups=nogroup append=yes state=present
 
     - name: The dnsmasq directory created

--- a/roles/dns_adblocking/templates/dnsmasq.conf.j2
+++ b/roles/dns_adblocking/templates/dnsmasq.conf.j2
@@ -103,7 +103,7 @@ server={{ host }}
 
 # If you want dnsmasq to change uid and gid to something other
 # than the default, edit the following lines.
-user=nobody
+user=dnsmasq
 group=nogroup
 
 # If you want dnsmasq to listen for DHCP and DNS requests only on


### PR DESCRIPTION
This change lets dnsmasq run as user "dnsmasq" instead of "nobody".
Remove the task that checks whether the dnsmasq user exists.