### PR TITLE
Add GCP Los Angeles Region (us-west2)

### DIFF
--- a/algo
+++ b/algo
@@ -435,49 +435,52 @@ Name the vpn server:
     8. Western US              (Oregon A)
     9. Western US              (Oregon B)
     10. Western US             (Oregon C)
-    11. Eastern US             (Northern Virginia A)
-    12. Eastern US             (Northern Virginia B)
-    13. Eastern US             (Northern Virginia C)
-    14. Eastern US             (South Carolina B)
-    15. Eastern US             (South Carolina C)
-    16. Eastern US             (South Carolina D)
-    17. South America East     (São Paulo A)
-    18. South America East     (São Paulo B)
-    19. South America East     (São Paulo C)
-    20. Northern Europe        (Hamina A)
-    21. Northern Europe        (Hamina B)
-    22. Northern Europe        (Hamina C)
-    23. Western Europe         (Belgium B)
-    24. Western Europe         (Belgium C)
-    25. Western Europe         (Belgium D)
-    26. Western Europe         (London A)
-    27. Western Europe         (London B)
-    28. Western Europe         (London C)
-    29. Western Europe         (Frankfurt A)
-    30. Western Europe         (Frankfurt B)
-    31. Western Europe         (Frankfurt C)
-    32. Western Europe         (Netherlands A)
-    33. Western Europe         (Netherlands B)
-    34. Western Europe         (Netherlands C)
-    35. South Asia             (Mumbai A)
-    36. South Asia             (Mumbai B)
-    37. South Asia             (Mumbai C)
-    38. Southeast Asia         (Singapore A)
-    39. Southeast Asia         (Singapore B)
-    40. Southeast Asia         (Singapore C)
-    41. East Asia              (Taiwan A)
-    42. East Asia              (Taiwan B)
-    43. East Asia              (Taiwan C)
-    44. Northeast Asia         (Tokyo A)
-    45. Northeast Asia         (Tokyo B)
-    46. Northeast Asia         (Tokyo C)
-    47. Australia              (Sydney A)
-    48. Australia              (Sydney B)
-    49. Australia              (Sydney C)
+    11. Western US             (Los Angeles A)
+    12. Western US             (Los Angeles B)
+    13. Western US             (Los Angeles C)
+    14. Eastern US             (Northern Virginia A)
+    15. Eastern US             (Northern Virginia B)
+    16. Eastern US             (Northern Virginia C)
+    17. Eastern US             (South Carolina B)
+    18. Eastern US             (South Carolina C)
+    19. Eastern US             (South Carolina D)
+    20. South America East     (São Paulo A)
+    21. South America East     (São Paulo B)
+    22. South America East     (São Paulo C)
+    23. Northern Europe        (Hamina A)
+    24. Northern Europe        (Hamina B)
+    25. Northern Europe        (Hamina C)
+    26. Western Europe         (Belgium B)
+    27. Western Europe         (Belgium C)
+    28. Western Europe         (Belgium D)
+    29. Western Europe         (London A)
+    30. Western Europe         (London B)
+    31. Western Europe         (London C)
+    32. Western Europe         (Frankfurt A)
+    33. Western Europe         (Frankfurt B)
+    34. Western Europe         (Frankfurt C)
+    35. Western Europe         (Netherlands A)
+    36. Western Europe         (Netherlands B)
+    37. Western Europe         (Netherlands C)
+    38. South Asia             (Mumbai A)
+    39. South Asia             (Mumbai B)
+    40. South Asia             (Mumbai C)
+    41. Southeast Asia         (Singapore A)
+    42. Southeast Asia         (Singapore B)
+    43. Southeast Asia         (Singapore C)
+    44. East Asia              (Taiwan A)
+    45. East Asia              (Taiwan B)
+    46. East Asia              (Taiwan C)
+    47. Northeast Asia         (Tokyo A)
+    48. Northeast Asia         (Tokyo B)
+    49. Northeast Asia         (Tokyo C)
+    50. Australia              (Sydney A)
+    51. Australia              (Sydney B)
+    52. Australia              (Sydney C)
 
-Please choose the number of your zone. Press enter for default (#20) zone.
-[20]: " -r region
-  region=${region:-20}
+Please choose the number of your zone. Press enter for default (#26) zone.
+[26]: " -r region
+  region=${region:-26}
 
   case "$region" in
     1)  zone="northamerica-northeast1-a" ;;
@@ -490,45 +493,48 @@ Please choose the number of your zone. Press enter for default (#20) zone.
     8)  zone="us-west1-a" ;;
     9)  zone="us-west1-b" ;;
     10) zone="us-west1-c" ;;
-    11) zone="us-east4-a" ;;
-    12) zone="us-east4-b" ;;
-    13) zone="us-east4-c" ;;
-    14) zone="us-east1-b" ;;
-    15) zone="us-east1-c" ;;
-    16) zone="us-east1-d" ;;
-    17) zone="southamerica-east1-a" ;;
-    18) zone="southamerica-east1-b" ;;
-    19) zone="southamerica-east1-c" ;;
-    20) zone="europe-north1-a" ;;
-    21) zone="europe-north1-b" ;;
-    22) zone="europe-north1-c" ;;
-    23) zone="europe-west1-b" ;;
-    24) zone="europe-west1-c" ;;
-    25) zone="europe-west1-d" ;;
-    26) zone="europe-west2-a" ;;
-    27) zone="europe-west2-b" ;;
-    28) zone="europe-west2-c" ;;
-    29) zone="europe-west3-a" ;;
-    30) zone="europe-west3-b" ;;
-    31) zone="europe-west3-c" ;;
-    32) zone="europe-west4-a" ;;
-    33) zone="europe-west4-b" ;;
-    34) zone="europe-west4-c" ;;
-    35) zone="asia-south1-a" ;;
-    36) zone="asia-south1-b" ;;
-    37) zone="asia-south1-c" ;;
-    38) zone="asia-southeast1-a" ;;
-    39) zone="asia-southeast1-b" ;;
-    40) zone="asia-southeast1-c" ;;
-    41) zone="asia-east1-a" ;;
-    42) zone="asia-east1-b" ;;
-    43) zone="asia-east1-c" ;;
-    44) zone="asia-northeast1-a" ;;
-    45) zone="asia-northeast1-b" ;;
-    46) zone="asia-northeast1-c" ;;
-    47) zone="australia-southeast1-a" ;;
-    48) zone="australia-southeast1-b" ;;
-    49) zone="australia-southeast1-c" ;;
+    11) zone="us-west2-a" ;;
+    12) zone="us-west2-b" ;;
+    13) zone="us-west2-c" ;;
+    14) zone="us-east4-a" ;;
+    15) zone="us-east4-b" ;;
+    16) zone="us-east4-c" ;;
+    17) zone="us-east1-b" ;;
+    18) zone="us-east1-c" ;;
+    19) zone="us-east1-d" ;;
+    20) zone="southamerica-east1-a" ;;
+    21) zone="southamerica-east1-b" ;;
+    22) zone="southamerica-east1-c" ;;
+    23) zone="europe-north1-a" ;;
+    24) zone="europe-north1-b" ;;
+    25) zone="europe-north1-c" ;;
+    26) zone="europe-west1-b" ;;
+    27) zone="europe-west1-c" ;;
+    28) zone="europe-west1-d" ;;
+    29) zone="europe-west2-a" ;;
+    30) zone="europe-west2-b" ;;
+    31) zone="europe-west2-c" ;;
+    32) zone="europe-west3-a" ;;
+    33) zone="europe-west3-b" ;;
+    34) zone="europe-west3-c" ;;
+    35) zone="europe-west4-a" ;;
+    36) zone="europe-west4-b" ;;
+    37) zone="europe-west4-c" ;;
+    38) zone="asia-south1-a" ;;
+    39) zone="asia-south1-b" ;;
+    40) zone="asia-south1-c" ;;
+    41) zone="asia-southeast1-a" ;;
+    42) zone="asia-southeast1-b" ;;
+    43) zone="asia-southeast1-c" ;;
+    44) zone="asia-east1-a" ;;
+    45) zone="asia-east1-b" ;;
+    46) zone="asia-east1-c" ;;
+    47) zone="asia-northeast1-a" ;;
+    48) zone="asia-northeast1-b" ;;
+    49) zone="asia-northeast1-c" ;;
+    50) zone="australia-southeast1-a" ;;
+    51) zone="australia-southeast1-b" ;;
+    52) zone="australia-southeast1-c" ;;
   esac
 
   ROLES="gce vpn cloud"

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -188,6 +188,9 @@ Possible options for `zone`:
 - us-west1-a
 - us-west1-b
 - us-west1-c
+- us-west2-a
+- us-west2-b
+- us-west2-c
 - us-central1-a
 - us-central1-b
 - us-central1-c


### PR DESCRIPTION
- Added 1 new region (us-west2) with 3 new zones (a, b, c)
- Changed the default region back to europe-west1-b (see https://github.com/trailofbits/algo/pull/957)
- See https://cloud.google.com/compute/docs/regions-zones/ for new zone documentation