### PR TITLE
Update PPA for dnscrypt-proxy to 'bionic'

### DIFF
--- a/roles/dns_encryption/tasks/ubuntu.yml
+++ b/roles/dns_encryption/tasks/ubuntu.yml
@@ -2,7 +2,7 @@
 - name: Add the repository
   apt_repository:
     state: present
-    codename: artful
+    codename: bionic
     repo: ppa:shevchuk/dnscrypt-proxy
   register: result
   until: result|succeeded


### PR DESCRIPTION
This should keep the PPA for dnscrypt-proxy in sync with Ubuntu 18.04.