### PR TITLE
Split up unattended upgrades

### DIFF
--- a/roles/common/templates/50unattended-upgrades.j2
+++ b/roles/common/templates/50unattended-upgrades.j2
@@ -2,9 +2,6 @@
 Unattended-Upgrade::Allowed-Origins {
     "${distro_id}:${distro_codename}-security";
     "${distro_id}:${distro_codename}-updates";
-{% if wireguard_enabled %}
-    "LP-PPA-wireguard-wireguard:${distro_codename}";
-{% endif %}
 //  "${distro_id}:${distro_codename}-proposed";
 //  "${distro_id}:${distro_codename}-backports";
 };

--- a/roles/dns_encryption/files/50-dnscrypt-proxy-unattended-upgrades
+++ b/roles/dns_encryption/files/50-dnscrypt-proxy-unattended-upgrades
@@ -1,0 +1,4 @@
+// Automatically upgrade packages from these (origin:archive) pairs
+Unattended-Upgrade::Allowed-Origins {
+    "LP-PPA-shevchuk-dnscrypt-proxy:${distro_codename}";
+};

--- a/roles/dns_encryption/tasks/ubuntu.yml
+++ b/roles/dns_encryption/tasks/ubuntu.yml
@@ -8,12 +8,20 @@
   until: result|succeeded
   retries: 10
   delay: 3
-  
+
 - name: Install dnscrypt-proxy
   apt:
     name: dnscrypt-proxy
     state: latest
     update_cache: true
+
+- name: Configure unattended-upgrades
+  copy:
+    src: 50-dnscrypt-proxy-unattended-upgrades
+    dest: /etc/apt/apt.conf.d/50-dnscrypt-proxy-unattended-upgrades
+    owner: root
+    group: root
+    mode: 0644
 
 - block:
   - name: Ubuntu | Unbound profile for apparmor configured

--- a/roles/wireguard/files/50-wireguard-unattended-upgrades
+++ b/roles/wireguard/files/50-wireguard-unattended-upgrades
@@ -1,0 +1,4 @@
+// Automatically upgrade packages from these (origin:archive) pairs
+Unattended-Upgrade::Allowed-Origins {
+    "LP-PPA-wireguard-wireguard:${distro_codename}";
+};

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -14,6 +14,14 @@
     state: present
     update_cache: true
 
+- name: Configure unattended-upgrades
+  copy:
+    src: 50-wireguard-unattended-upgrades
+    dest: /etc/apt/apt.conf.d/50-wireguard-unattended-upgrades
+    owner: root
+    group: root
+    mode: 0644
+
 - name: Ensure the required directories exist
   file:
     dest: "{{ wireguard_config_path }}/{{ item }}"


### PR DESCRIPTION
- Move the unattended upgrades to appropriate roles
- Enables unattended upgrades for dnscrypt-proxy