### PR TITLE
Request to fix Ubuntu 18.04 as a wireguard client.

### DIFF
--- a/playbooks/facts/main.yml
+++ b/playbooks/facts/main.yml
@@ -24,6 +24,7 @@
     module: shell
       openssl rand -hex 16
   become: no
+  ignore_errors: yes
   register: CA_password
 
 - name: Generate p12 export password

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -1,6 +1,6 @@
 [Interface]
-PrivateKey = {{ lookup('file', wireguard_config_path + '/private/' + item.1) }}
 Address = {{ wireguard_network_ipv4['clients_range'] }}.{{ wireguard_network_ipv4['clients_start'] + item.0 + 1 }}/32{% if ipv6_support %},{{ wireguard_network_ipv6['clients_range'] }}{{ wireguard_network_ipv6['clients_start'] + item.0 + 1 }}/{{ wireguard_network_ipv6['prefix'] }}
+PrivateKey = {{ lookup('file', wireguard_config_path + '/private/' + item.1) }}
 {% endif %}
 
 DNS = {{ wireguard_dns_servers }}


### PR DESCRIPTION
This corrects a small issue with the wireguard client.conf.j2 template. For Ubuntu 18.04 clients as tested, it will fix an issue where Ubuntu does not accept the client.conf as a working client configuration. 

Ubuntu 18.04's build of wireguard binaries (wg and wg-quick) expect that the address line in the [Interface] area come before the private key. The following steps will allow a working build of Ubuntu 18.04 as a client:

sudo add-apt-repository ppa:wireguard/wireguard
sudo apt update
sudo apt install wireguard-dkms wireguard-tools

sudo ip link add dev wg0
sudo cp ~/<username.conf|client.conf> /etc/wireguard/wg0.conf #copy the client.conf to /etc/wireguard/wg0.conf
sudo wg-quick wg0 up #brings up the tunnel
sudo wg-quick wg0 down #brings down the tunnel
