### PR TITLE
Create a symlink if deploying to localhost

### DIFF
--- a/server.yml
+++ b/server.yml
@@ -51,6 +51,14 @@
             {% if tests|default(false)|bool %}ca_password: {{ CA_password }}{% endif %}
         become: false
 
+      - name: Create a symlink if deploying to localhost
+        file:
+          src: "{{ IP_subject_alt_name }}"
+          dest: configs/localhost
+          state: link
+          force: true
+        when: inventory_hostname == 'localhost'
+
       - debug:
           msg:
             - "{{ congrats.common.split('\n') }}"


### PR DESCRIPTION
Algo dumps all the config files to `configs/{{ server_ip }}` and it breaks update-users for local deployments. Probably to create a symlink `configs/localhost` is the more sufficient workaround for this.
Fixes #1076