### PR TITLE
Update minimum required AWS permissions

### DIFF
--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -113,6 +113,7 @@ Additional variables:
             "Action": [
                 "ec2:DescribeImages",
                 "ec2:DescribeKeyPairs",
+                "ec2:DescribeRegions",
                 "ec2:ImportKeyPair"
             ],
             "Resource": [


### PR DESCRIPTION
Ansible2.5 allows Algo to directly ask AWS for the region list, rather than have it hardcoded and updated manually. Updated the documented minimum required permissions to include "DescribeRegions". Fix for #1079, but people will have to update their existing user permissions manually.