### PR TITLE
Add an unattended reboot option

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -56,6 +56,15 @@ dns_servers:
 # IP address for the local dns resolver
 local_service_ip: 172.16.0.1
 
+# Your Algo server will automatically install security updates. Some updates
+# require a reboot to take effect but your Algo server will not reboot itself
+# automatically unless you change 'enabled' below from 'false' to 'true', in
+# which case a reboot will take place if necessary at the time specified (as
+# HH:MM) in the time zone of your Algo server. The default time zone is UTC.
+unattended_reboot:
+  enabled: false
+  time: 06:00
+
 pkcs12_PayloadCertificateUUID: "{{ 900000 | random | to_uuid | upper }}"
 VPN_PayloadIdentifier: "{{ 800000 | random | to_uuid | upper }}"
 CA_PayloadIdentifier: "{{ 700000 | random | to_uuid | upper }}"

--- a/roles/common/tasks/unattended-upgrades.yml
+++ b/roles/common/tasks/unattended-upgrades.yml
@@ -19,3 +19,11 @@
     owner: root
     group: root
     mode: 0644
+
+- name: Unattended reboots configured
+  template:
+    src: 60unattended-reboot.j2
+    dest: /etc/apt/apt.conf.d/60unattended-reboot
+    owner: root
+    group: root
+    mode: 0644

--- a/roles/common/templates/60unattended-reboot.j2
+++ b/roles/common/templates/60unattended-reboot.j2
@@ -1,0 +1,2 @@
+Unattended-Upgrade::Automatic-Reboot "{{ unattended_reboot.enabled|lower }}";
+Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_reboot.time }}";


### PR DESCRIPTION
Allows the user to optionally enable the server to reboot itself at a designated time if required due to unattended upgrades.
