### PR TITLE
Invoke dns encryption from main playbook instead of meta-dependencies

### DIFF
--- a/roles/vpn/meta/main.yml
+++ b/roles/vpn/meta/main.yml
@@ -1,6 +1,1 @@
 ---
-
-dependencies:
-  - role: dns_encryption
-    tags: dns_encryption
-    when: dns_encryption

--- a/server.yml
+++ b/server.yml
@@ -9,6 +9,9 @@
 
   roles:
     - role: common
+    - role: dns_encryption
+      when: dns_encryption
+      tags: dns_encryption
     - role: dns_adblocking
       when: algo_local_dns
       tags: dns_adblocking


### PR DESCRIPTION
Sometimes when deploying to the existing server, the installation may stuck because resolvconf updates the resolv.conf with 127.0.0.1, but dnscrypt-proxy is not ready yet. Install dnscrypt-proxy before dnsmasq fixes this problem.
Mentioned [here](https://github.com/trailofbits/algo/issues/1094#issuecomment-417944192) 