### PR TITLE
Fixes #491 by piping algo_server_name through additional templates

### DIFF
--- a/roles/cloud-ec2/files/stack.yml
+++ b/roles/cloud-ec2/files/stack.yml
@@ -21,7 +21,7 @@ Resources:
       InstanceTenancy: default
       Tags:
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
         - Key: Environment
           Value: Algo
 
@@ -38,7 +38,7 @@ Resources:
         - Key: Environment
           Value: Algo
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
 
   Subnet:
     Type: AWS::EC2::Subnet
@@ -49,7 +49,7 @@ Resources:
         - Key: Environment
           Value: Algo
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
       VpcId: !Ref VPC
 
   VPCGatewayAttachment:
@@ -66,7 +66,7 @@ Resources:
         - Key: Environment
           Value: Algo
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
 
   Route:
     Type: AWS::EC2::Route
@@ -140,7 +140,7 @@ Resources:
           CidrIp: 0.0.0.0/0
       Tags:
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
         - Key: Environment
           Value: Algo
 
@@ -181,7 +181,7 @@ Resources:
             cfn-signal -e $? --stack ${AWS::StackName} --resource EC2Instance --region ${AWS::Region}
       Tags:
         - Key: Name
-          Value: Algo
+          Value: !Ref AWS::StackName
         - Key: Environment
           Value: Algo
 

--- a/roles/cloud-ec2/tasks/cloudformation.yml
+++ b/roles/cloud-ec2/tasks/cloudformation.yml
@@ -1,4 +1,3 @@
----
 - name: Deploy the template
   cloudformation:
     aws_access_key: "{{ access_key }}"

--- a/roles/vpn/templates/client_windows.ps1.j2
+++ b/roles/vpn/templates/client_windows.ps1.j2
@@ -79,7 +79,12 @@ Save the embedded CA cert and encrypted user PKCS12 file.
 $ErrorActionPreference = "Stop"
 
 $VpnServerAddress = "{{ IP_subject_alt_name }}"
-$VpnName = "Algo VPN {{ IP_subject_alt_name }} IKEv2"
+{% if (algo_server_name == 'algo') or (algo_server_name == 'algo.local') %}
+    {% set vpn_server_name = 'Algo VPN '+IP_subject_alt_name+' IKEv2' %}
+{% else %}
+    {% set vpn_server_name = algo_server_name+' VPN' %}
+{% endif %}
+$VpnName = "{{ vpn_server_name }}"
 $VpnUser = "{{ item.0 }}"
 $CaCertificateBase64 = "{{ PayloadContentCA }}"
 $UserPkcs12Base64 = "{{ item.1.stdout }}"

--- a/roles/vpn/templates/mobileconfig.j2
+++ b/roles/vpn/templates/mobileconfig.j2
@@ -1,3 +1,8 @@
+{% if (algo_server_name == 'algo') or (algo_server_name == 'algo.local') %}
+    {% set vpn_server_name = 'Algo VPN '+IP_subject_alt_name+' IKEv2' %}
+{% else %}
+    {% set vpn_server_name = algo_server_name+' VPN' %}
+{% endif %}
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -129,7 +134,7 @@
                 <integer>0</integer>
             </dict>
             <key>UserDefinedName</key>
-            <string>Algo VPN {{ IP_subject_alt_name }} IKEv2</string>
+            <string>{{ vpn_server_name }}</string>
             <key>VPNType</key>
             <string>IKEv2</string>
         </dict>
@@ -175,7 +180,7 @@
         </dict>
     </array>
     <key>PayloadDisplayName</key>
-    <string>{{ IP_subject_alt_name }} IKEv2</string>
+    <string>{{ vpn_server_name }}</string>
     <key>PayloadIdentifier</key>
     <string>donut.local.{{ 500000 | random | to_uuid | upper }}</string>
     <key>PayloadRemovalDisallowed</key>


### PR DESCRIPTION
EC2 Name tag in the cfn stack, VPNName in client_windows.ps1 and the
mobileconfig files all make use of the algo_server_name with a default
of the original Algo VPN naming when the server name is left at default
algo or algo.local.