### PR TITLE
Document AWS disk encryption flag in config.cfg

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -103,6 +103,12 @@ cloud_providers:
   digitalocean:
     size: s-1vcpu-1gb
     image: "ubuntu-18-04-x64"
+  # Change the encrypted flag to "true" to enable AWS volume encryption, for encryption of data at rest.
+  # Warning: the Algo script will take approximately 6 minutes longer to complete.
+  # Also note that the documented AWS minimum permissions aren't sufficient. 
+  # You will have to edit the AWS user policy documented at 
+  # https://github.com/trailofbits/algo/blob/master/docs/cloud-amazon-ec2.md to also allow "ec2:CopyImage". 
+  # See https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage-edit.html
   ec2:
     encrypted: false
     size: t2.micro


### PR DESCRIPTION
This is to better document the "encryption" flag for those who are interested in full disk encryption on AWS. Recently on running the script, I also found the [minimum necessary permissions documented](https://github.com/trailofbits/algo/blob/master/docs/deploy-from-ansible.md) weren't enough; "ec2:CopyImage" is also required. Not sure if you'd rather have this documented in the AWS docs instead, and not sure if you want "ec2:CopyImage" added to the default minimum required permissions. I can do either if you'd prefer.