### PR TITLE
Fix spacing in congrats message

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -79,11 +79,11 @@ congrats:
     "#    Config files and certificates are in the ./configs/ directory.    #"
     "#              Go to https://whoer.net/ after connecting               #"
     "#        and ensure that all your traffic passes through the VPN.      #"
-    "#               Local DNS resolver {{ local_service_ip }}              #"
+    "#                     Local DNS resolver {{ local_service_ip }}                    #"
   p12_pass: |
-    "#                The p12 and SSH keys password for new users is {{ p12_export_password }}             #"
+    "#        The p12 and SSH keys password for new users is {{ p12_export_password }}       #"
   ca_key_pass: |
-    "#                  The CA key password is {{ CA_password }}                 #"
+    "#        The CA key password is {{ CA_password }}       #"    
   ssh_access: |
     "#      Shell access: ssh -i {{ ansible_ssh_private_key_file|default(omit) }} {{ ansible_ssh_user|default(omit) }}@{{ ansible_ssh_host|default(omit) }}        #"
 


### PR DESCRIPTION
The spacing of several lines in the congrats message has been off. Here's the congrats output with this fix:
```
ok: [54.85.244.8] => {
    "msg": [
        [
            "\"#                          Congratulations!                            #\"", 
            "\"#                     Your Algo server is running.                     #\"", 
            "\"#    Config files and certificates are in the ./configs/ directory.    #\"", 
            "\"#              Go to https://whoer.net/ after connecting               #\"", 
            "\"#        and ensure that all your traffic passes through the VPN.      #\"", 
            "\"#                     Local DNS resolver 172.16.0.1                    #\"", 
            ""
        ], 
        "    \"#        The p12 and SSH keys password for new users is CR2qzRcA       #\"\n", 
        "    \"#        The CA key password is ed0fd57e7d355af08d12ccdbfd3f5931       #\"\n", 
        "    \"#      Shell access: ssh -i configs/algo.pem ubuntu@54.85.244.8        #\"\n"
    ]
}
```