### PR TITLE
Display the invocation environment to aid debugging

### DIFF
--- a/algo-showenv.sh
+++ b/algo-showenv.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# Print information about Algo's invocation environment to aid in debugging.
+# This is normally called from Ansible right before a deployment gets underway.
+
+# Skip printing this header if we're just testing with no arguments.
+if [[ $# -gt 0 ]]; then
+    echo ""
+    echo "--> Please include the following block of text when reporting issues:"
+    echo ""
+fi
+
+if [[ ! -f ./algo ]]; then
+    echo "This should be run from the top level Algo directory"
+fi
+
+# Determine the operating system.
+case "$(uname -s)" in
+    Linux)
+        OS="Linux ($(uname -r) $(uname -v))"
+        if [[ -f /etc/os-release ]]; then
+            # shellcheck disable=SC1091
+            # I hope this isn't dangerous.
+            . /etc/os-release
+            if [[ ${PRETTY_NAME} ]]; then
+                OS="${PRETTY_NAME}"
+            elif [[ ${NAME} ]]; then
+                OS="${NAME} ${VERSION}"
+            fi
+        fi
+        STAT="stat -c %y"
+        ;;
+    Darwin)
+        OS="$(sw_vers -productName) $(sw_vers -productVersion)"
+        STAT="stat -f %Sm"
+        ;;
+    *)
+        OS="Unknown"
+        ;;
+esac
+
+# Determine if virtualization is being used with Linux.
+VIRTUALIZED=""
+if [[ -x $(command -v systemd-detect-virt) ]]; then
+    DETECT_VIRT="$(systemd-detect-virt)"
+    if [[ ${DETECT_VIRT} != "none" ]]; then
+        VIRTUALIZED=" (Virtualized: ${DETECT_VIRT})"
+    fi
+fi
+
+echo "Algo running on: ${OS}${VIRTUALIZED}"
+
+# Determine the currentness of the Algo software.
+if [[ -d .git && -x $(command -v git) ]]; then
+    ORIGIN="$(git remote get-url origin)"
+    COMMIT="$(git log --max-count=1 --oneline --no-decorate --no-color)"
+    if [[ ${ORIGIN} == "https://github.com/trailofbits/algo.git" ]]; then
+        SOURCE="clone"
+    else
+        SOURCE="fork"
+    fi
+    echo "Created from git ${SOURCE}. Last commit: ${COMMIT}"
+elif [[ -f LICENSE && ${STAT} ]]; then
+    CREATED="$(${STAT} LICENSE)"
+    echo "ZIP file created: ${CREATED}"
+fi
+
+# The Python version might be useful to know.
+if [[ -x ./env/bin/python ]]; then
+    ./env/bin/python --version 2>&1
+elif [[ -f ./algo ]]; then
+    echo "env/bin/python not found: has 'python -m virtualenv ...' been run?"
+fi
+
+# Just print out all command line arguments, which are expected
+# to be Ansible variables.
+if [[ $# -gt 0 ]]; then
+    echo "Runtime variables:"
+    for VALUE in "$@"; do
+        echo "    ${VALUE}"
+    done
+fi
+
+exit 0

--- a/playbooks/cloud-pre.yml
+++ b/playbooks/cloud-pre.yml
@@ -1,4 +1,19 @@
 ---
+- name: Display the invocation environment
+  local_action:
+    module: shell
+      ./algo-showenv.sh \
+        'algo_provider "{{ algo_provider }}"' \
+        'algo_ondemand_cellular "{{ algo_ondemand_cellular }}"' \
+        'algo_ondemand_wifi "{{ algo_ondemand_wifi }}"' \
+        'algo_ondemand_wifi_exclude "{{ algo_ondemand_wifi_exclude }}"' \
+        'algo_local_dns "{{ algo_local_dns }}"' \
+        'algo_ssh_tunneling "{{ algo_ssh_tunneling }}"' \
+        'algo_windows "{{ algo_windows }}"' \
+        'wireguard_enabled "{{ wireguard_enabled }}"' \
+        'dns_encryption "{{ dns_encryption }}"' \
+        > /dev/tty
+
 - name: Generate the SSH private key
   openssl_privatekey:
     path: "{{ SSH_keys.private }}"


### PR DESCRIPTION
This change adds a script that gets called from Ansible early on during a deployment to print out information intended be helpful when included by a user when reporting an issue. It attempts to detect the operating system and currentness of the Algo software, as well as display various Ansible variables.

Sample output when called from Ansible:
```
TASK [Gathering Facts] *************************************************************************************************
ok: [localhost]

--> Please include the following block of text when submitting issues:

Algo running on: Ubuntu 18.04.1 LTS
Created from git fork. Last commit: 4c70b71 Fix spacing in congrats message (#1104)
Python 2.7.15rc1
Runtime variables:
    algo_provider "digitalocean"
    algo_ondemand_cellular "False"
    algo_ondemand_wifi "True"
    algo_ondemand_wifi_exclude ""
    algo_local_dns "False"
    algo_ssh_tunneling "False"
    algo_windows "False"
    wireguard_enabled "True"
    dns_encryption "True"

TASK [Display the invocation environment] ******************************************************************************
changed: [localhost -> localhost]
```
Sample output when run directly:
```
Algo running on: Mac OS X 10.12.6
ZIP file created: Sep  2 15:26:06 2018
env/bin/python not found: has 'python -m virtualenv ...' been run?
```

I'm not very proficient with Ansible and may not have done everything properly. Please review for correctness.
