### PR TITLE
Use gateway ip address for wireguard interface

### DIFF
--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -1,5 +1,5 @@
 [Interface]
-Address = {{ wireguard_network_ipv4['subnet'] }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['gateway'] }}/{{ wireguard_network_ipv6['prefix'] }}
+Address = {{ wireguard_network_ipv4['gateway'] }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['gateway'] }}/{{ wireguard_network_ipv6['prefix'] }}
 {% endif %}
 
 ListenPort = {{ wireguard_port }}


### PR DESCRIPTION
It looks like the ipv4 address of the wireguard interface is based on the wrong key. This has the effect of wg0 using .0 instead of .1. The ipv6 address uses .1 and services default to .1 also, so I figure we want to be consistent.

## Description
Change wg0 interface address from `wireguard_network_ipv4['subnet']` to `wireguard_network_ipv4['gateway']`

## Motivation and Context
Fix an error of intent. Gateways should default to .1.

## How Has This Been Tested?
- Ran Ansible against existing ec2 instance
- Verified that wg0 address changes 
- Clients not impacted

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
