### PR TITLE
Update algo-showenv.sh to use `/usr/bin/env` in it's hashbang

### DIFF
--- a/algo-showenv.sh
+++ b/algo-showenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Print information about Algo's invocation environment to aid in debugging.
 # This is normally called from Ansible right before a deployment gets underway.


### PR DESCRIPTION
Should allow better cross platform compatibility

## Description
Update the hashbang

## Motivation and Context
I am running a bit of a weird OS ([NixOS](https://nixos.org/)) that doesn't install bash at `/bin/bash`

## How Has This Been Tested?
Successfully installed Algo from an NixOS host.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
