### PR TITLE
SSH tunneling fixes

### DIFF
--- a/roles/ssh_tunneling/tasks/main.yml
+++ b/roles/ssh_tunneling/tasks/main.yml
@@ -31,40 +31,26 @@
         groups: algo
         home: '/var/jail/{{ item }}'
         createhome: yes
-        generate_ssh_key: yes
+        generate_ssh_key: false
         shell: /bin/false
-        ssh_key_type: ecdsa
-        ssh_key_bits: 256
-        ssh_key_comment: '{{ item }}@{{ IP_subject_alt_name }}'
-        ssh_key_passphrase: "{{ p12_export_password }}"
-        update_password: on_create
         state: present
         append: yes
       with_items: "{{ users }}"
       tags: update-users
 
     - name: The authorized keys file created
-      file:
-        src: '/var/jail/{{ item }}/.ssh/id_ecdsa.pub'
-        dest: '/var/jail/{{ item }}/.ssh/authorized_keys'
-        owner: "{{ item }}"
-        group: "{{ item }}"
-        state: link
+      authorized_key:
+        user: "{{ item }}"
+        key: "{{ lookup('file', 'configs/' + IP_subject_alt_name + '/pki/public/' + item + '.pub') }}"
+        state: present
+        manage_dir: true
+        exclusive: true
       with_items: "{{ users }}"
       tags: update-users
 
     - name: Generate SSH fingerprints
       shell: ssh-keyscan {{ IP_subject_alt_name }} 2>/dev/null
       register: ssh_fingerprints
-
-    - name: Fetch users SSH private keys
-      fetch:
-        src: '/var/jail/{{ item }}/.ssh/id_ecdsa'
-        dest: configs/{{ IP_subject_alt_name }}/{{ item }}.ssh.pem
-        flat: yes
-        mode: "0600"
-      with_items: "{{ users }}"
-      tags: update-users
 
     - name: Fetch the known_hosts file
       local_action:
@@ -83,20 +69,21 @@
       tags: update-users
       with_items: "{{ users }}"
 
-    - name: SSH | Get active system users
-      shell: >
-        getent group algo | cut -f4 -d: | sed "s/,/\n/g"
-      register: valid_users
+    - name: Get active users
+      getent:
+        database: group
+        key: algo
+        split: ':'
       tags: update-users
 
-    - name: SSH | Delete non-existing users
+    - name: Delete non-existing users
       user:
         name: "{{ item }}"
         state: absent
         remove: yes
         force: yes
       when: item not in users
-      with_items: "{{ valid_users.stdout_lines | default('null') }}"
+      with_items: "{{ getent_group['algo'][2].split(',') }}"
       tags: update-users
   rescue:
     - debug: var=fail_hint

--- a/roles/vpn/defaults/main.yml
+++ b/roles/vpn/defaults/main.yml
@@ -34,6 +34,7 @@ ipv6_support: false
 dns_encryption: true
 domain: false
 subjectAltName_IP: "IP:{{ IP_subject_alt_name }}"
+subjectAltName_USER: "{% if '@' in item %}email:{{ item }}{% else %}DNS:{{ item }}{% endif %}"
 openssl_bin: openssl
 strongswan_enabled_plugins:
   - aes

--- a/roles/vpn/tasks/main.yml
+++ b/roles/vpn/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - block:
-    - name: Ensure that the strongswan group exist
-      group: name=strongswan state=present
-
-    - name: Ensure that the strongswan user exist
-      user: name=strongswan group=strongswan state=present
+    - name: Include WireGuard role
+      include_role:
+        name: wireguard
+      tags: wireguard
+      when: wireguard_enabled and ansible_distribution == 'Ubuntu'
 
     - include_tasks: ubuntu.yml
       when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'

--- a/roles/vpn/tasks/openssl.yml
+++ b/roles/vpn/tasks/openssl.yml
@@ -16,12 +16,14 @@
       dest: "configs/{{ IP_subject_alt_name }}/pki/{{ item }}"
       state: directory
       recurse: yes
+      mode: '0700'
     with_items:
       - ecparams
       - certs
       - crl
       - newcerts
       - private
+      - public
       - reqs
 
   - name: Ensure the files exist
@@ -42,6 +44,7 @@
 
   - name: Build the CA pair
     shell: >
+      umask 077;
       {{ openssl_bin }} ecparam -name secp384r1 -out ecparams/secp384r1.pem &&
       {{ openssl_bin }} req -utf8 -new
       -newkey ec:ecparams/secp384r1.pem
@@ -70,6 +73,7 @@
 
   - name: Build the server pair
     shell: >
+      umask 077;
       {{ openssl_bin }} req -utf8 -new
       -newkey ec:ecparams/secp384r1.pem
       -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName={{ subjectAltName }}"))
@@ -92,9 +96,10 @@
 
   - name: Build the client's pair
     shell: >
+      umask 077;
       {{ openssl_bin }} req -utf8 -new
       -newkey ec:ecparams/secp384r1.pem
-      -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName=DNS:{{ item }}"))
+      -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName={{ subjectAltName_USER }}"))
       -keyout private/{{ item }}.key
       -out reqs/{{ item }}.req -nodes
       -passin pass:"{{ CA_password }}"
@@ -102,7 +107,7 @@
       {{ openssl_bin }} ca -utf8
       -in reqs/{{ item }}.req
       -out certs/{{ item }}.crt
-      -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName=DNS:{{ item }}"))
+      -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName={{ subjectAltName_USER }}"))
       -days 3650 -batch
       -passin pass:"{{ CA_password }}"
       -subj "/CN={{ item }}" &&
@@ -113,8 +118,24 @@
       executable: bash
     with_items: "{{ users }}"
 
+  - name: Create links for the private keys
+    file:
+      src: "pki/private/{{ item }}.key"
+      dest: "configs/{{ IP_subject_alt_name }}/{{ item }}.ssh.pem"
+      state: link
+      force: true
+    with_items: "{{ users }}"
+
+  - name: Build openssh public keys
+    openssl_publickey:
+      path:  "configs/{{ IP_subject_alt_name }}/pki/public/{{ item }}.pub"
+      privatekey_path: "configs/{{ IP_subject_alt_name }}/pki/private/{{ item }}.key"
+      format: OpenSSH
+    with_items: "{{ users }}"
+
   - name: Build the client's p12
     shell: >
+      umask 077;
       {{ openssl_bin }} pkcs12
       -in certs/{{ item }}.crt
       -inkey private/{{ item }}.key
@@ -149,7 +170,7 @@
   - name: Revoke non-existing users
     shell: >
       {{ openssl_bin }} ca -gencrl
-      -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName=DNS:{{ item }}"))
+      -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName={{ subjectAltName_USER }}"))
       -passin pass:"{{ CA_password }}"
       -revoke certs/{{ item }}.crt
       -out crl/{{ item }}.crt

--- a/roles/vpn/templates/strongswan.conf.j2
+++ b/roles/vpn/templates/strongswan.conf.j2
@@ -10,7 +10,7 @@ charon {
 		include strongswan.d/charon/*.conf
 	}
 	user = strongswan
-	group = strongswan
+	group = nogroup
 {% if ansible_distribution == 'FreeBSD' %}
 	filelog {
 	  /var/log/charon.log {

--- a/server.yml
+++ b/server.yml
@@ -16,14 +16,14 @@
     - role: dns_adblocking
       when: algo_local_dns
       tags: dns_adblocking
-    - role: ssh_tunneling
-      when: algo_ssh_tunneling
-      tags: ssh_tunneling
     - role: wireguard
       when: wireguard_enabled
       tags: wireguard
     - role: vpn
       tags: vpn
+    - role: ssh_tunneling
+      when: algo_ssh_tunneling
+      tags: ssh_tunneling
 
   post_tasks:
     - block:

--- a/users.yml
+++ b/users.yml
@@ -60,13 +60,13 @@
 
   roles:
     - role: common
-    - role: ssh_tunneling
-      when: algo_ssh_tunneling
     - role: wireguard
       tags: [ 'vpn', 'wireguard' ]
       when: wireguard_enabled
     - role: vpn
       tags: vpn
+    - role: ssh_tunneling
+      when: algo_ssh_tunneling
 
   post_tasks:
     - block:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds an option to specify email in usernames
- Disables storing ssh private keys on the server for ssh tunneling
- Fixes permissions in the config directory
- From now StrongSwan runs under the default user space `strongswan:nogroup` instead of custom `strongswan:strongswan`

## Motivation and Context
Fixes #1018
SSH tunneling: Previously Algo generated ssh private keys on the server side and fetched them to the local machine. From now the same VPN keys (locally generated) will be used for SSH tunneling
Permissions in the config directory weren't restricted from anyone

## How Has This Been Tested?
Deployed to digitalocean, connected to IPsec, wireguard and ssh tunnel from macos, update-users worked as well

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
