### PR TITLE
Include Algo generated password in Mobileconfig file for Apple device…

### DIFF
--- a/roles/vpn/templates/mobileconfig.j2
+++ b/roles/vpn/templates/mobileconfig.j2
@@ -134,6 +134,8 @@
             <string>IKEv2</string>
         </dict>
         <dict>
+            <key>Password</key>
+            <string>{{ p12_export_password }}</string>
             <key>PayloadCertificateFileName</key>
             <string>{{ item.0 }}.p12</string>
             <key>PayloadContent</key>
@@ -154,8 +156,6 @@
             <integer>1</integer>
         </dict>
         <dict>
-            <key>Password</key>
-            <string>{{ p12_export_password }}</string>
             <key>PayloadCertificateFileName</key>
             <string>ca.crt</string>
             <key>PayloadContent</key>

--- a/roles/vpn/templates/mobileconfig.j2
+++ b/roles/vpn/templates/mobileconfig.j2
@@ -154,6 +154,8 @@
             <integer>1</integer>
         </dict>
         <dict>
+            <key>Password</key>
+            <string>{{ easyrsa_p12_export_password }}</string>
             <key>PayloadCertificateFileName</key>
             <string>ca.crt</string>
             <key>PayloadContent</key>

--- a/roles/vpn/templates/mobileconfig.j2
+++ b/roles/vpn/templates/mobileconfig.j2
@@ -189,4 +189,4 @@
     <key>PayloadVersion</key>
     <integer>1</integer>
 </dict>
-</plist>
+</plist> 

--- a/roles/vpn/templates/mobileconfig.j2
+++ b/roles/vpn/templates/mobileconfig.j2
@@ -155,7 +155,7 @@
         </dict>
         <dict>
             <key>Password</key>
-            <string>{{ easyrsa_p12_export_password }}</string>
+            <string>{{ p12_export_password }}</string>
             <key>PayloadCertificateFileName</key>
             <string>ca.crt</string>
             <key>PayloadContent</key>


### PR DESCRIPTION
Include Algo generated password in the Mobileconfig file so that users do not need to manually enter a password when installing on Apple devices.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added two lines to the mobileconfig file to insert the certificate password.

## Motivation and Context

Makes it easier for users to install configuration profile without needing to look up the password.

## How Has This Been Tested?

I tested this in production by spinning up an Algo VPN and installing the generated mobileconfig file onto my iPhone.

## Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
