### PR TITLE
allow optionally assigning a floating ip to the droplet

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -108,9 +108,12 @@ cloud_providers:
   azure:
     size: Basic_A0
     image: 18.04-LTS
+  # To use floating_ip, first allocate a floating IP via Digital Ocean, and
+  # then set floating_ip to the IP address that was allocated.
   digitalocean:
     size: s-1vcpu-1gb
     image: "ubuntu-18-04-x64"
+    floating_ip: false
   # Change the encrypted flag to "true" to enable AWS volume encryption, for encryption of data at rest.
   # Warning: the Algo script will take approximately 6 minutes longer to complete.
   # Also note that the documented AWS minimum permissions aren't sufficient.

--- a/roles/cloud-digitalocean/tasks/main.yml
+++ b/roles/cloud-digitalocean/tasks/main.yml
@@ -60,8 +60,16 @@
         ipv6: yes
       register: do
 
+    - name: "Assigning floating IP..."
+      digital_ocean_floating_ip:
+        oauth_token: "{{ algo_do_token }}"
+        ip: "{{ cloud_providers.digitalocean.floating_ip }}"
+        droplet_id: "{{ do.droplet.id }}"
+      when:
+        - cloud_providers.digitalocean.floating_ip
+
     - set_fact:
-        cloud_instance_ip: "{{ do.droplet.ip_address }}"
+        cloud_instance_ip: "{% if cloud_providers.digitalocean.floating_ip %}{{ cloud_providers.digitalocean.floating_ip }}{% else %}{{ do.droplet.ip_address }}{% endif %}"
         ansible_ssh_user: root
 
     - name: Tag the droplet


### PR DESCRIPTION
## Description
if the user has any unassigned floating ips, prompt the user to see if they would like to use one of them when creating the droplet. if the user has no existing floating ips, or if they are all already assigned to droplets, proceed as before without prompting.

## Motivation and Context
simplifies rebuilds, since using a floating ip means i can just distribute the new keys without having to also modify my configuration files.

## How Has This Been Tested?
ran `algo` with a free floating ip, both when selecting it and not, and ran it with no free floating ips. in all cases, it did the right thing.

## Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.

it doesn't look like the digitalocean code has any automated tests currently - let me know if there's something you'd like me to do there.