### PR TITLE
Update-users fix

### DIFF
--- a/roles/vpn/tasks/openssl.yml
+++ b/roles/vpn/tasks/openssl.yml
@@ -196,6 +196,8 @@
       executable: bash
   delegate_to: localhost
   become: no
+  vars:
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Copy the CRL to the vpn server
   copy:

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -52,6 +52,9 @@
   with_indexed_items: "{{ users }}"
   delegate_to: localhost
   become: false
+  tags: update-users
+  vars:
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   args:
     chdir: "{{ wireguard_config_path }}"
     executable: bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
WireGuard QR codes not being generated with update-users 
Ansible uses the default python path for the tasks delegated to localhost, therefore some tasks fail due to missing libraries if deploying to localhost

## Motivation and Context
Fixes #1145

## How Has This Been Tested?
Deployed to localhost

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
