### PR TITLE
WireGuard update-users fix

### DIFF
--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+wireguard_client_ip: "{{ wireguard_network_ipv4['clients_range'] }}.{{ wireguard_network_ipv4['clients_start'] + item.0 + 1 }}/32{% if ipv6_support %},{{ wireguard_network_ipv6['clients_range'] }}{{ wireguard_network_ipv6['clients_start'] + item.0 + 1 }}/{{ wireguard_network_ipv6['prefix'] }}{% endif %}"
+wireguard_server_ip: "{{ wireguard_network_ipv4['gateway'] }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['gateway'] }}/{{ wireguard_network_ipv6['prefix'] }}{% endif %}"

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -7,6 +7,7 @@
   with_items:
     - private
     - public
+    - ip
   delegate_to: localhost
   become: false
 
@@ -24,6 +25,16 @@
   import_tasks: keys.yml
   tags: update-users
 
+- name: Dump IP addresses
+  copy:
+    dest: "{{ wireguard_config_path }}/ip/{{ item.1 }}"
+    content: "{{ wireguard_client_ip }}"
+    force: false
+  with_indexed_items: "{{ users }}"
+  tags: update-users
+  become: false
+  delegate_to: localhost
+
 - name: WireGuard configured
   template:
     src: server.conf.j2
@@ -38,9 +49,9 @@
     dest: "{{ wireguard_config_path }}/{{ item.1 }}.conf"
     mode: "0600"
   with_indexed_items: "{{ users }}"
+  become: false
   tags: update-users
   delegate_to: localhost
-  become: false
 
 - name: Generate QR codes
   shell: >

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -1,8 +1,6 @@
 [Interface]
 PrivateKey = {{ lookup('file', wireguard_config_path + '/private/' + item.1) }}
-Address = {{ wireguard_network_ipv4['clients_range'] }}.{{ wireguard_network_ipv4['clients_start'] + item.0 + 1 }}/32{% if ipv6_support %},{{ wireguard_network_ipv6['clients_range'] }}{{ wireguard_network_ipv6['clients_start'] + item.0 + 1 }}/{{ wireguard_network_ipv6['prefix'] }}
-{% endif %}
-
+Address = {{ lookup('file', wireguard_config_path + '/ip/' + item.1) }}
 DNS = {{ wireguard_dns_servers }}
 
 [Peer]

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -1,16 +1,13 @@
 [Interface]
-Address = {{ wireguard_network_ipv4['gateway'] }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['gateway'] }}/{{ wireguard_network_ipv6['prefix'] }}
-{% endif %}
-
+Address = {{ wireguard_server_ip }}
 ListenPort = {{ wireguard_port }}
 PrivateKey = {{ lookup('file', wireguard_config_path + '/private/' + IP_subject_alt_name) }}
 SaveConfig = false
 
-{% for u in users %}
+{% for u in users|sort %}
 
 [Peer]
 # {{ u }}
 PublicKey = {{ lookup('file', wireguard_config_path + '/public/' + u) }}
-AllowedIPs = {{ wireguard_network_ipv4['clients_range'] }}.{{ wireguard_network_ipv4['clients_start'] + loop.index }}/32{% if ipv6_support %},{{ wireguard_network_ipv6['clients_range'] }}{{ wireguard_network_ipv6['clients_start'] + loop.index }}/128
-{% endif %}
+AllowedIPs = {{ lookup('file', wireguard_config_path + '/ip/' + u) }}
 {% endfor %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Due to the WireGuard implementation we have to define IP addresses for each user explicitly. Previously, it was done in sequential order, with IPs stored in memory, and it was the root cause of [this](1131) bug. This PR brings ability to save the IPs in to the file

## Motivation and Context
Fixes #1131

## How Has This Been Tested?
Deployed an algo server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
