### PR TITLE
Support for START1-XS in Scaleway

### DIFF
--- a/roles/cloud-scaleway/tasks/image_facts.yml
+++ b/roles/cloud-scaleway/tasks/image_facts.yml
@@ -6,4 +6,5 @@
   when:
     - cloud_providers.scaleway.image == item.name
     - cloud_providers.scaleway.arch == item.arch
+    - server_disk_size == item.root_volume.size
   with_items: "{{ outer_item['json']['images'] }}"

--- a/roles/cloud-scaleway/tasks/main.yml
+++ b/roles/cloud-scaleway/tasks/main.yml
@@ -2,6 +2,15 @@
   - name: Include prompts
     import_tasks: prompts.yml
 
+  - name: Set disk size
+    set_fact:
+      server_disk_size: 50000000000
+
+  - name: Check server size
+    set_fact:
+      server_disk_size: 25000000000
+    when: cloud_providers.scaleway.size == "START1-XS"
+
   - name: Check if server exists
     uri:
       url: "https://cp-{{ algo_region }}.scaleway.com/servers"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Variable `server_disk_size` has a default value of `50000000000` for 50 GB images. If `cloud_providers.scaleway.size == "START1-XS"`, server_disk_size becomes equal to `25000000000`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If cloud_providers.scaleway.size in config.cfg is equal to "START1-XS", Algo will not be able to power on the server. With this changes AlgoVPN can be deployed on 2€ instance.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested it in Docker container for:
`cloud_providers.scaleway.size: START1-S`
and
`cloud_providers.scaleway.size: START1-XS`
In all cases task `[cloud-scaleway : Power on the server]` returns `ok: [localhost]`
**Before:**
![master-result](https://user-images.githubusercontent.com/44378542/47316459-dccd4280-d64f-11e8-8411-73c5c3d576ce.png)
**After:**
![scaleway_start1-xs-result](https://user-images.githubusercontent.com/44378542/47316460-dccd4280-d64f-11e8-8c4e-24fdc72e2edb.png)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.