### PR TITLE
Add documentation on how to setup GCE accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ After this process completes, the Algo VPN server will contains only the users l
   - Configure [Amazon EC2](docs/cloud-amazon-ec2.md)
   - Configure [Azure](docs/cloud-azure.md)
   - Configure [DigitalOcean](docs/cloud-do.md)
+  - Configure [Google Cloud Platform](docs/cloud-gce.md)
 * Advanced Deployment
   - Deploy to your own [FreeBSD](docs/deploy-to-freebsd.md) server
   - Deploy to your own [Ubuntu 18.04](docs/deploy-to-ubuntu.md) server

--- a/docs/cloud-gce.md
+++ b/docs/cloud-gce.md
@@ -36,3 +36,6 @@ gcloud services enable compute.googleapis.com
 ```
 
 **Attention:** take care of the `configs/gce.json` file, which contains the credentials to manage your Google Cloud account, including create and delete servers on this project.
+
+
+There are more advanced arguments available for deploynment [using ansible](../deploy-from-ansible.md)

--- a/docs/cloud-gce.md
+++ b/docs/cloud-gce.md
@@ -1,0 +1,38 @@
+# Google Cloud Platform setup
+
+Follow the [installation instructions](https://cloud.google.com/sdk/) to have the CLI commands to interact with Google.
+
+After creating an account and installing, login in on your account using `gcloud init`
+
+### Creating a project
+
+The recommendation on GCP is to group resources on **Projets**, so we will create one project to put our VPN server and service account restricted to it.
+
+```bash
+## Create the project to group the resources
+### You might need to change it to have a global unique project id
+PROJECT_ID=${USER}-algo-vpn
+BILLING_ID="$(gcloud beta billing accounts list --format="value(ACCOUNT_ID)")"
+
+gcloud projects create ${PROJECT_ID} --name algo-vpn --set-as-default
+gcloud beta billing projects link ${PROJECT_ID} --billing-account ${BILLING_ID}
+
+## Create an account that have access to the VPN
+gcloud iam service-accounts create algo-vpn --display-name "Algo VPN"
+gcloud iam service-accounts keys create configs/gce.json \
+  --iam-account algo-vpn@${PROJECT_ID}.iam.gserviceaccount.com
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+  --member serviceAccount:algo-vpn@${PROJECT_ID}.iam.gserviceaccount.com \
+  --role roles/compute.admin
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+  --member serviceAccount:algo-vpn@${PROJECT_ID}.iam.gserviceaccount.com \
+  --role roles/iam.serviceAccountUser
+
+## Enable the services
+gcloud services enable compute.googleapis.com
+
+./algo -e "provider=gce" -e "gce_credentials_file=$(pwd)/configs/gce.json"
+
+```
+
+**Attention:** take care of the `configs/gce.json` file, which contains the credentials to manage your Google Cloud account, including create and delete servers on this project.

--- a/docs/cloud-gce.md
+++ b/docs/cloud-gce.md
@@ -38,4 +38,4 @@ gcloud services enable compute.googleapis.com
 **Attention:** take care of the `configs/gce.json` file, which contains the credentials to manage your Google Cloud account, including create and delete servers on this project.
 
 
-There are more advanced arguments available for deploynment [using ansible](../deploy-from-ansible.md)
+There are more advanced arguments available for deploynment [using ansible](deploy-from-ansible.md)


### PR DESCRIPTION
## Description
This commit adds the steps needed to create a credential with the needed access on Google Cloud Platform to be able to successfully create a new algo VPN.

Related to:
- https://github.com/trailofbits/algo/issues/682
- https://github.com/trailofbits/algo/issues/658

## Motivation and Context
There was no clear examples of what are the necessary permissions and how to create the GCE credential file, while other providers did have more documented examples

## How Has This Been Tested?
This was the set of steps I've used to go from a brand new GCP account to be able to create the server properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
