### PR TITLE
WireGuard update-users fix

### DIFF
--- a/roles/vpn/defaults/main.yml
+++ b/roles/vpn/defaults/main.yml
@@ -7,13 +7,13 @@ wireguard_network_ipv4:
   prefix: 24
   gateway: 10.19.49.1
   clients_range: 10.19.49
-  clients_start: 100
+  clients_start: 2
 wireguard_network_ipv6:
   subnet: 'fd9d:bc11:4021::'
   prefix: 48
   gateway: 'fd9d:bc11:4021::1'
   clients_range: 'fd9d:bc11:4021::'
-  clients_start: 100
+  clients_start: 2
 wireguard_vpn_network: "{{ wireguard_network_ipv4['subnet'] }}/{{ wireguard_network_ipv4['prefix'] }}"
 wireguard_vpn_network_ipv6: "{{ wireguard_network_ipv6['subnet'] }}/{{ wireguard_network_ipv6['prefix'] }}"
 keys_clean_all: false

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-wireguard_client_ip: "{{ wireguard_network_ipv4['clients_range'] }}.{{ wireguard_network_ipv4['clients_start'] + item.0 + 1 }}/32{% if ipv6_support %},{{ wireguard_network_ipv6['clients_range'] }}{{ wireguard_network_ipv6['clients_start'] + item.0 + 1 }}/{{ wireguard_network_ipv6['prefix'] }}{% endif %}"
+wireguard_client_ip: "{{ wireguard_network_ipv4['clients_range'] }}.{{ wireguard_network_ipv4['clients_start'] + index|int + 1 }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['clients_range'] }}{{ wireguard_network_ipv6['clients_start'] + index|int + 1 }}/{{ wireguard_network_ipv6['prefix'] }}{% endif %}"
 wireguard_server_ip: "{{ wireguard_network_ipv4['gateway'] }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['gateway'] }}/{{ wireguard_network_ipv6['prefix'] }}{% endif %}"

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -7,7 +7,6 @@
   with_items:
     - private
     - public
-    - ip
   delegate_to: localhost
   become: false
 
@@ -25,50 +24,57 @@
   import_tasks: keys.yml
   tags: update-users
 
-- name: Dump IP addresses
-  copy:
-    dest: "{{ wireguard_config_path }}/ip/{{ item.1 }}"
-    content: "{{ wireguard_client_ip }}"
-    force: false
-  with_indexed_items: "{{ users }}"
-  tags: update-users
-  become: false
-  delegate_to: localhost
+- block:
+  - block:
+    - name: WireGuard user list updated
+      lineinfile:
+        dest: "{{ wireguard_config_path }}/index.txt"
+        create: true
+        mode: "0600"
+        insertafter: EOF
+        line: "{{ item }}"
+      register: lineinfile
+      with_items: "{{ users }}"
 
-- name: WireGuard configured
-  template:
-    src: server.conf.j2
-    dest: "{{ config_prefix|default('/') }}etc/wireguard/{{ wireguard_interface }}.conf"
-    mode: "0600"
-  notify: restart wireguard
+    - set_fact:
+        wireguard_users: "{{ (lookup('file', wireguard_config_path + 'index.txt')).split('\n') }}"
+
+    - name: WireGuard users config generated
+      template:
+        src: client.conf.j2
+        dest: "{{ wireguard_config_path }}/{{ item.1 }}.conf"
+        mode: "0600"
+      with_indexed_items:  "{{ wireguard_users }}"
+      when: item.1 in users
+      vars:
+        index: "{{ item.0 }}"
+
+    - name: Generate QR codes
+      shell: >
+        umask 077;
+        which segno &&
+        segno --scale=5 --output={{ item.1 }}.png \
+          "{{ lookup('template', 'client.conf.j2') }}" || true
+      changed_when: false
+      with_indexed_items:  "{{ wireguard_users }}"
+      when: item.1 in users
+      vars:
+        index: "{{ item.0 }}"
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+      args:
+        chdir: "{{ wireguard_config_path }}"
+        executable: bash
+    become: false
+    delegate_to: localhost
+
+  - name: WireGuard configured
+    template:
+      src: server.conf.j2
+      dest: "{{ config_prefix|default('/') }}etc/wireguard/{{ wireguard_interface }}.conf"
+      mode: "0600"
+    notify: restart wireguard
   tags: update-users
 
-- name: WireGuard users config generated
-  template:
-    src: client.conf.j2
-    dest: "{{ wireguard_config_path }}/{{ item.1 }}.conf"
-    mode: "0600"
-  with_indexed_items: "{{ users }}"
-  become: false
-  tags: update-users
-  delegate_to: localhost
-
-- name: Generate QR codes
-  shell: >
-    umask 077;
-    which segno &&
-    segno --scale=5 --output={{ item.1 }}.png \
-      "{{ lookup('template', 'client.conf.j2') }}" || true
-  changed_when: false
-  with_indexed_items: "{{ users }}"
-  delegate_to: localhost
-  become: false
-  tags: update-users
-  vars:
-    ansible_python_interpreter: "{{ ansible_playbook_python }}"
-  args:
-    chdir: "{{ wireguard_config_path }}"
-    executable: bash
 
 - name: WireGuard enabled and started
   service:

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -1,6 +1,6 @@
 [Interface]
 PrivateKey = {{ lookup('file', wireguard_config_path + '/private/' + item.1) }}
-Address = {{ lookup('file', wireguard_config_path + '/ip/' + item.1) }}
+Address = {{ wireguard_client_ip }}
 DNS = {{ wireguard_dns_servers }}
 
 [Peer]

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -4,10 +4,14 @@ ListenPort = {{ wireguard_port }}
 PrivateKey = {{ lookup('file', wireguard_config_path + '/private/' + IP_subject_alt_name) }}
 SaveConfig = false
 
-{% for u in users|sort %}
+{% for u in wireguard_users %}
+{% if u in users %}
+{% set index = loop.index %}
 
 [Peer]
 # {{ u }}
 PublicKey = {{ lookup('file', wireguard_config_path + '/public/' + u) }}
-AllowedIPs = {{ lookup('file', wireguard_config_path + '/ip/' + u) }}
+AllowedIPs = {{ wireguard_network_ipv4['clients_range'] }}.{{ wireguard_network_ipv4['clients_start'] + index }}/32{% if ipv6_support %},{{ wireguard_network_ipv6['clients_range'] }}{{ wireguard_network_ipv6['clients_start'] + index }}/128{% endif %}
+
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Due to the WireGuard implementation we have to define IP addresses for each user explicitly. Previously, it was done in sequential order, with IPs stored in memory, and it was the root cause of [this](1131) bug. This PR brings ability not to restrict users by IP addresses, I don't think it makes any sense n this implementation.

## Motivation and Context
Fixes #1131

## How Has This Been Tested?
Deployed an algo server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
