### PR TITLE
fix typos in docker documentation and shell-script text

### DIFF
--- a/algo-docker.sh
+++ b/algo-docker.sh
@@ -11,7 +11,7 @@ usage() {
     retcode="${1:-0}"
     echo "To run algo from Docker:"
     echo ""
-    echo "docker run --cap-drop ALL -it -v <path to configurations>:"${DATA_DIR}" trailofbits/algo:latest"
+    echo "docker run --cap-drop=all -it -v <path to configurations>:"${DATA_DIR}" trailofbits/algo:latest"
     echo ""
     exit ${retcode}
 }

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -22,7 +22,7 @@ While it is not possible to run your Algo server from within a Docker container,
    ```
   - From Linux:
   ```bash
-  $ docker run --cap-drop-all -it \
+  $ docker run --cap-drop=all -it \
     -v /home/trailofbits/Documents/VPNs:/data \
     trailofbits/algo:latest
   ```


### PR DESCRIPTION
Fix typo in documentation for running install from docker on linux, causing command to fail.  Also align the echo in the docker shell script with the other docker documentation.

## Description
Documentation and shell echo text changes only.

## Motivation and Context
Fixes failure to execute docker install based on reading the linux docker documentation ver-batim.

## How Has This Been Tested?
After failing to install using the documentation in-place on from a linux machine, I changed the command to what is in the commit, and it worked.  (ubuntu 18.04 LTS w docker-ce edge)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
