### PR TITLE
dnscrypt-proxy apparmor fix

### DIFF
--- a/roles/dns_encryption/files/apparmor.profile.dnscrypt-proxy
+++ b/roles/dns_encryption/files/apparmor.profile.dnscrypt-proxy
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-/usr/sbin/dnscrypt-proxy {
+/usr/bin/dnscrypt-proxy {
   #include <abstractions/base>
   #include <abstractions/nameservice>
   #include <abstractions/openssl>
@@ -12,12 +12,18 @@
   capability setuid,
   capability sys_resource,
 
-  /etc/dnscrypt-proxy.toml r,
+  /etc/dnscrypt-proxy/** r,
+  /usr/bin/dnscrypt-proxy mr,
+  /tmp/public-resolvers.md* rw,
+
+  /tmp/*.tmp w,
+  owner /tmp/*.tmp r,
+
+  /run/systemd/notify rw,
+  /lib/x86_64-linux-gnu/ld-*.so mr,
+  @{PROC}/sys/kernel/hostname r,
+  @{PROC}/sys/net/core/somaxconn r,
   /etc/ld.so.cache r,
-  /usr/sbin/dnscrypt-proxy mr,
-  /usr/share/dnscrypt-proxy/dnscrypt-resolvers.csv r,
   /usr/local/lib/{@{multiarch}/,}libldns.so* mr,
   /usr/local/lib/{@{multiarch}/,}libsodium.so* mr,
-  /run/dnscrypt-proxy.pid rw,
-  /run/systemd/notify rw,
 }

--- a/roles/dns_encryption/tasks/ubuntu.yml
+++ b/roles/dns_encryption/tasks/ubuntu.yml
@@ -27,14 +27,14 @@
   - name: Ubuntu | Unbound profile for apparmor configured
     copy:
       src: apparmor.profile.dnscrypt-proxy
-      dest: /etc/apparmor.d/usr.sbin.dnscrypt-proxy
+      dest: /etc/apparmor.d/usr.bin.dnscrypt-proxy
       owner: root
       group: root
       mode: 0600
     notify: restart dnscrypt-proxy
 
   - name: Ubuntu | Enforce the dnscrypt-proxy AppArmor policy
-    command: aa-enforce usr.sbin.dnscrypt-proxy
+    command: aa-enforce usr.bin.dnscrypt-proxy
     changed_when: false
   tags: apparmor
   when: apparmor_enabled|default(false)|bool == true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Apparmor profile for dnscrypt-proxy didn't work at all

## Motivation and Context
Fixes #1155

## How Has This Been Tested?
Deployed to DigitalOcean, checked that the dnscrypt-proxy binary is in enforce mode

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
