### PR TITLE
fix typo in powershell execution in windows client set up doc

### DIFF
--- a/docs/client-windows.md
+++ b/docs/client-windows.md
@@ -8,7 +8,7 @@ To install automatically, use the generated user Powershell script.
 2. Open Powershell as Administrator.
 3. Run the following command:
 ```powershell
-powershell -ExecutionPolicy ByPass -File C:\path\to\windows_USER.ps1 Add
+powershell -ExecutionPolicy ByPass -File C:\path\to\windows_USER.ps1 -Add
 ```
 4. The command has help information available. To view its full help, run this from Powershell:
 ```powershell


### PR DESCRIPTION
Fix a typo in docs for windows client set up

## Description
arg needs a `-Add` instead `Add`

## Motivation and Context
Fixes typo that could cause users to fail to set up windows client

## How Has This Been Tested?
Copied and ran the line in windows to set up client

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
