### PR TITLE
Increase memory limit for dnsmasq

### DIFF
--- a/roles/dns_adblocking/templates/100-CustomLimitations.conf.j2
+++ b/roles/dns_adblocking/templates/100-CustomLimitations.conf.j2
@@ -1,4 +1,4 @@
 [Service]
-MemoryLimit=16777216
+MemoryLimit=33554432
 CPUAccounting=true
 CPUQuota=5%

--- a/roles/dns_adblocking/templates/100-CustomLimitations.conf.j2
+++ b/roles/dns_adblocking/templates/100-CustomLimitations.conf.j2
@@ -1,4 +1,5 @@
 [Service]
-MemoryLimit=33554432
+MemoryHigh=128M
+MemoryMax=192M
 CPUAccounting=true
-CPUQuota=5%
+CPUQuota=20%


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Double the memory limitation on `dnsmasq`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As reported in #1221 it appears that users who are using block lists larger than the defaults are running into memory resource errors and `dnsmasq` is getting killed. This PR doubles the memory limit to 32MB.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deployed to DigitalOcean and verified the contents of the limitations file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
