### PR TITLE
Allow public DNS hostname or IP to be specified on config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ansible==2.5.2
+netaddr

--- a/roles/local/tasks/prompts.yml
+++ b/roles/local/tasks/prompts.yml
@@ -31,7 +31,7 @@
 
 - pause:
     prompt: |
-      Enter the public IP address of your server: (IMPORTANT! This IP is used to verify the certificate)
+      Enter the public IP or DNS address of your server: (IMPORTANT! This is used to verify the certificate)
       [{{ cloud_instance_ip }}]
   register: _endpoint
   when: endpoint is undefined

--- a/roles/vpn/defaults/main.yml
+++ b/roles/vpn/defaults/main.yml
@@ -35,7 +35,7 @@ algo_local_dns: false
 ipv6_support: false
 dns_encryption: true
 domain: false
-subjectAltName_IP: "IP:{{ IP_subject_alt_name }}"
+subjectAltName_IP: "{% if IP_subject_alt_name|ipaddr %}IP{% else %}DNS{% endif %}:{{ IP_subject_alt_name }}"
 subjectAltName_USER: "{% if '@' in item %}email:{{ item }}{% else %}DNS:{{ item }}{% endif %}"
 openssl_bin: openssl
 strongswan_enabled_plugins:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Quick mod to allow admin to specify server public hostname or ip address in ./algo config

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Removes reliance on IP address of server allowing server to be moved/clustered

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Works here :-)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.