### PR TITLE
Fix ipv4 address missing on reboot

### DIFF
--- a/roles/common/tasks/freebsd.yml
+++ b/roles/common/tasks/freebsd.yml
@@ -42,7 +42,7 @@
     block: |
       cloned_interfaces="lo100"
       ifconfig_lo100="inet {{ local_service_ip }} netmask 255.255.255.255"
-      ifconfig_lo100="inet6 FCAA::1/64"
+      ifconfig_lo100_ipv6="inet6 FCAA::1/64"
   notify:
     - restart loopback bsd
   tags:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Fix #1244.

## How Has This Been Tested?
Changed /etc/rc.conf manually and instance rebooted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
