### PR TITLE
Replace 'max_mss' with 'reduce_mtu'

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -21,15 +21,14 @@ vpn_network_ipv6: 'fd9d:bc11:4020::/48'
 wireguard_enabled: true
 wireguard_port: 51820
 
-# MSS is the TCP Max Segment Size
-# Setting the 'max_mss' Ansible variable can solve some issues related to packet fragmentation
-# This appears to be necessary on (at least) Google Cloud,
-# however, some routers also require a change to this parameter
-# See also:
-# - https://github.com/trailofbits/algo/issues/216
-# - https://github.com/trailofbits/algo/issues?utf8=%E2%9C%93&q=is%3Aissue%20mtu
-# - https://serverfault.com/questions/601143/ssh-not-working-over-ipsec-tunnel-strongswan
-#max_mss: 1316
+# Reduce the MTU of the VPN tunnel
+# Some cloud and internet providers use a smaller MTU (Maximum Transmission
+# Unit) than the normal value of 1500 and if you don't reduce the MTU of your
+# VPN tunnel some network connections will hang. Algo will attempt to set this
+# automatically based on your server, but if connections hang you might need to
+# adjust this yourself.
+# See: https://github.com/trailofbits/algo/blob/master/docs/troubleshooting.md#various-websites-appear-to-be-offline-through-the-vpn
+reduce_mtu: 0
 
 # StrongSwan log level
 # https://wiki.strongswan.org/projects/strongswan/wiki/LoggerConfiguration

--- a/roles/common/tasks/facts.yml
+++ b/roles/common/tasks/facts.yml
@@ -28,3 +28,8 @@
   set_fact:
     ipv6_support: "{% if ansible_default_ipv6['gateway'] is defined %}true{% else %}false{% endif %}"
   tags: always
+
+- name: Check size of MTU
+  set_fact:
+    reduce_mtu: "{% if reduce_mtu|int == 0 and ansible_default_ipv4['mtu']|int < 1500 %}{{ 1500 - ansible_default_ipv4['mtu']|int }}{% else %}{{ reduce_mtu|int }}{% endif %}"
+  tags: always

--- a/roles/vpn/templates/rules.v4.j2
+++ b/roles/vpn/templates/rules.v4.j2
@@ -10,8 +10,8 @@
 :OUTPUT ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]
 
-{% if max_mss is defined %}
--A FORWARD -s {{ vpn_network }}{% if wireguard_enabled %},{{ wireguard_vpn_network }}{% endif %} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss {{ max_mss }}
+{% if reduce_mtu|int > 0 %}
+-A FORWARD -s {{ vpn_network }} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss {{ 1360 - reduce_mtu|int }}
 {% endif %}
 
 COMMIT

--- a/roles/vpn/templates/rules.v6.j2
+++ b/roles/vpn/templates/rules.v6.j2
@@ -10,10 +10,8 @@
 :OUTPUT ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]
 
-{% if max_mss is defined %}
-# MSS is the TCP Max Segment Size
-# See rules.v4 for a more complete explanation
--A FORWARD -s {{ vpn_network_ipv6 }}{% if wireguard_enabled %},{{ wireguard_vpn_network_ipv6 }}{% endif %} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss {{ max_mss }}
+{% if reduce_mtu|int > 0 %}
+-A FORWARD -s {{ vpn_network_ipv6 }} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss {{ 1340 - reduce_mtu|int }}
 {% endif %}
 
 COMMIT

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -2,6 +2,8 @@
 PrivateKey = {{ lookup('file', wireguard_config_path + '/private/' + item.1) }}
 Address = {{ wireguard_client_ip }}
 DNS = {{ wireguard_dns_servers }}
+{% if reduce_mtu|int > 0 %}MTU = {{ 1420 - reduce_mtu|int }}
+{% endif %}
 
 [Peer]
 PublicKey = {{ lookup('file', wireguard_config_path + '/public/' + IP_subject_alt_name) }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Replaces the `max_mss` configuration variable with a new variable `reduce_mtu`  used to calculate both the MSS clamping values for IPsec and the MTU value for WireGuard. Also sets it automatically based on the server MTU.

## Description
<!--- Describe your changes in detail -->
Previously, MSS clamping on the server was used for both IPsec and WireGuard connections, even though WireGuard can set the MTU directly in its config files and has less tunnel overhead than IPsec. This change makes use of WireGuard's ability to set the MTU on the client side. The optimal MTU settings for IPsec and WireGuard are different and this allows them to be adjusted together by changing a single variable.

This change also automatically reduces the MTU if the MTU on the server is found to be less than 1500, but only if the user leaves `reduce_mtu` at the default of `0`. Otherwise the user value is used.

Apple devices use an MTU of 1400 for IPsec, and the Linux and iOS WireGuard implementations use an MTU of 1420. Therefore the MTU and MSS values used when `reduce_mtu > 0` are:

WireGuard MTU = 1420 - `reduce_mtu`
IPsec IPv4 MSS = 1400 - 40 - `reduce_mtu`
IPsec IPv6 MSS = 1400 - 60 - `reduce_mtu`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The user should not have to understand the concept of MSS.

The user should not have to change any settings in order to deploy to providers with smaller MTUs like GCE.

Closes #1217.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deployed to DigitalOcean to verify the config file changes. Deployed to GCE to verify no hang when accessing Google properties over IPsec and WireGuard. 

More testing should be done and the rewritten troubleshooting instructions should be reviewed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
