### PR TITLE
Install resolvconf on Ubuntu to fix DNS configurations

### DIFF
--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -7,6 +7,7 @@
     with_items:
       - python2.7
       - sudo
+      - resolvconf
 
   - name: Ubuntu | Configure defaults
     alternatives:


### PR DESCRIPTION
The local (non-cloud) installation process changes /etc/resolv.conf such that
127.0.0.53 is the only nameserver. Moreover, the dnscrypt-proxy
configuration relies on 127.0.0.53:53 as the fallback DNS server.
However, there is no DNS server listening on that IP unless the package
resolvconf is installed.

Thus, a local installation of algo on Ubuntu breaks the DNS
configuration. The issue is fixed by installing resolvconf.