### PR TITLE
Support for associating to existing AWS Elastic IP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.5.2
+ansible==2.6.11

--- a/roles/cloud-ec2/files/stack.yml
+++ b/roles/cloud-ec2/files/stack.yml
@@ -11,6 +11,12 @@ Parameters:
     Type: String
   WireGuardPort:
     Type: String
+  UseThisElasticIP:
+    Type: String
+    Default: ''
+Conditions:
+  AllocateNewEIP: !Equals [!Ref UseThisElasticIP, '']
+  AssociateExistingEIP: !Not [!Equals [!Ref UseThisElasticIP, '']]
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -187,6 +193,7 @@ Resources:
 
   ElasticIP:
     Type: AWS::EC2::EIP
+    Condition: AllocateNewEIP
     Properties:
       Domain: vpc
       InstanceId: !Ref EC2Instance
@@ -194,6 +201,14 @@ Resources:
       - EC2Instance
       - VPCGatewayAttachment
 
+  ElasticIPAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Condition: AssociateExistingEIP
+    Properties:
+      AllocationId: !Ref UseThisElasticIP
+      InstanceId: !Ref EC2Instance
+
+
 Outputs:
   ElasticIP:
-    Value: !Ref ElasticIP
+    Value: !GetAtt [EC2Instance, PublicIp]

--- a/roles/cloud-ec2/tasks/cloudformation.yml
+++ b/roles/cloud-ec2/tasks/cloudformation.yml
@@ -12,6 +12,7 @@
       PublicSSHKeyParameter: "{{ lookup('file', SSH_keys.public) }}"
       ImageIdParameter: "{{ ami_image }}"
       WireGuardPort: "{{ wireguard_port }}"
+      UseThisElasticIP: "{{ use_existing_eip }}"
     tags:
       Environment: Algo
   register: stack

--- a/roles/cloud-ec2/tasks/prompts.yml
+++ b/roles/cloud-ec2/tasks/prompts.yml
@@ -53,3 +53,28 @@
         [{{ default_region }}]
     register: _algo_region
   when: region is undefined
+
+- block:
+  - name: Get existing available Elastic IPs
+    ec2_eip_facts:
+    register: raw_eip_addresses
+
+  - set_fact:
+      available_eip_addresses: "{{ raw_eip_addresses.addresses | selectattr('association_id', 'undefined') | list }}"
+
+  - pause:
+      prompt: |
+        Do you want to use a pre-allocated Elastic IP?
+        (leave blank to allocate a new IP)
+          {% for eip in available_eip_addresses %}
+          {{ loop.index }}. {{ eip['public_ip'] }}
+          {% endfor %}
+          ['']
+    register: _use_existing_eip
+
+  - set_fact:
+      use_existing_eip: >-
+        {% if _use_existing_eip.user_input is defined and _algo_region.user_input != "" %}
+        {{ available_eip_addresses[_use_existing_eip.user_input | int -1 ]['allocation_id'] }}
+        {%- else %}{% endif %}
+  when: use_existing_eip is undefined


### PR DESCRIPTION
## Description

This adds the option of associating the Algo instance to an existing Elastic IP in AWS instead of provisioning a new Elastic IP.

## Motivation and Context
I have provisioned long-lived Elastic IPs with reverse DNS configured (https://aws.amazon.com/blogs/aws/reverse-dns-for-ec2s-elastic-ip-addresses/) and whitelists configured for those IPs at customer sites. I would like the ability to use one of my existing Elastic IPs when provisioning an Algo instance instead of provisioning a brand new EIP.

## How Has This Been Tested?
I have provisioned new algo instances with and without associating to pre-existing Elastic IP, and confirmed that the cloudformation stack deletes cleanly.

## Types of changes

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
