### PR TITLE
fix(update-users): changed generate p12 password task

### DIFF
--- a/roles/common/tasks/facts.yml
+++ b/roles/common/tasks/facts.yml
@@ -9,7 +9,7 @@
   - name: Generate p12 export password
     local_action:
       module: shell
-        openssl rand 8 | python -c 'import sys,string; chars=string.ascii_letters + string.digits + "_@"; print "".join([chars[ord(c) % 64] for c in list(sys.stdin.read())])'
+        openssl rand 8 | python -c 'import sys,string; chars=string.ascii_letters + string.digits + "_@"; print("".join([chars[ord(c) % 64] for c in list(sys.stdin.read())]))'
     register: p12_password_generated
     when: p12_password is not defined
     tags: update-users


### PR DESCRIPTION
Changed task's module to generic python format for python2 and python3.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`./algo update-users`

While updating the users in the VPN, I was getting the following error. Took a look at it and it was a syntax error on the print statement which can only be run via python2. So, I changed the print statement which would run on both python2 and python3.

I don't know why this error occurred in the first place, because python2 was available in the digital ocean droplet. I guess, ansible is using python3 interpreter. Also, this VPN was set up by someone else in my organization, not me, so not aware of the full picture. I made this patch because it was breaking due to a simple print statement, which should not happen.

```
< TASK [common : Generate p12 export password] >
 ----------------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

fatal: [xx.xx.xx.xx -> localhost]: FAILED! => {"changed": true, "cmd": "openssl rand 8 | python -c 'import sys,string; chars=string.ascii_letters + string.digits + \"_@\"; print \"\".join([chars[ord(c) % 64] for c in list(sys.stdin.read())])'", "delta": "0:00:00.037517", "end": "2019-01-04 15:07:28.386356", "msg": "non-zero return code", "rc": 1, "start": "2019-01-04 15:07:28.348839", "stderr": "  File \"<string>\", line 1\n    import sys,string; chars=string.ascii_letters + string.digits + \"_@\"; print \"\".join([chars[ord(c) % 64] for c in list(sys.stdin.read())])\n                                                                                 ^\nSyntaxError: invalid syntax", "stderr_lines": ["  File \"<string>\", line 1", "    import sys,string; chars=string.ascii_letters + string.digits + \"_@\"; print \"\".join([chars[ord(c) % 64] for c in list(sys.stdin.read())])", "                                                                                 ^", "SyntaxError: invalid syntax"], "stdout": "", "stdout_lines": []}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`./algo update-users` command was breaking.

I was trying to update users in my current VPN hosted on digital ocean. During that process, I was getting the above error. 

The updation of users was failing, so it was required to solve that problem.

<!--- If it fixes an open issue, please link to the issue here. -->
Could not find any open issues related to this

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I ran it on my own personal VPN, worked fine there. Also, its a print statement, so ideally should not break anything(I felt dumb writing this, I know).
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It does not affect any other code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
