### PR TITLE
Add note about new WireGuard for iOS default MTU

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -391,6 +391,10 @@ sudo ifconfig eth0 mtu 1440
 ```
 To make the change take affect after a reboot, on Ubuntu 18.04 and later edit the relevant file in the `/etc/netplan` directory (see `man netplan`).
 
+#### Note for WireGuard iOS users
+
+As of WireGuard for iOS 0.0.20190107 the default MTU is 1280, a conservative value intended to allow mobile devices to continue to work as they switch between different networks which might have smaller than normal MTUs. In order to use this default MTU review the configuration in the WireGuard app and remove any value for MTU that might have been added automatically by Algo.
+
 ### Clients appear stuck in a reconnection loop
 
 If you're using 'Connect on Demand' on iOS and your client device appears stuck in a reconnection loop after switching from WiFi to LTE or vice versa, you may want to try disabling DoS protection in strongSwan.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update the troubleshooting section on MTU issues to point out that the default MTU for WireGuard for iOS is now 1280 (was 1420) but that Algo might have changed it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If Algo detects the server has a smaller than normal MTU, the generated WireGuard client config files will contain an MTU directive intended to match the client MTU with that of WireGuard on the server. This should normally be the right thing to do, but now in the case of WireGuard for iOS this will generally cause the MTU to be larger than the new default of 1280. The user might want to delete the MTU directive added by Algo in order to use the new default.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
No testing, documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.