### PR TITLE
Add flags=(attach_disconnected) to dnscrypt-proxy apparmor profile

### DIFF
--- a/roles/dns_encryption/files/apparmor.profile.dnscrypt-proxy
+++ b/roles/dns_encryption/files/apparmor.profile.dnscrypt-proxy
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-/usr/bin/dnscrypt-proxy {
+/usr/bin/dnscrypt-proxy flags=(attach_disconnected) {
   #include <abstractions/base>
   #include <abstractions/nameservice>
   #include <abstractions/openssl>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `flags=(attach_disconnected)` to the dnscrupt-proxy apparmor profile as described in 1223
Fixes #1223

## How Has This Been Tested?
Deployed to digitalocean

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
