### PR TITLE
Add a note to urlencode AZURE_SECRET

### DIFF
--- a/docs/cloud-azure.md
+++ b/docs/cloud-azure.md
@@ -8,7 +8,7 @@
 | 4. Fill out the forms and click **Create** | [![step4-thumb]][step4-screen]  |
 | 5. Click on the app name | [![step5-thumb]][step5-screen]  |
 | 6. Copy and save somewhere the **Application ID** and click on **Keys**. | [![step6-thumb]][step6-screen]  |
-| 7. Fill out the forms and click **Save**. Copy and save somewhere the **Secret ID** (the value) | [![step7-thumb]][step7-screen]  |
+| 7. Fill out the forms and click **Save**. Copy and save somewhere the **Secret ID** (the value). NOTE: This needs to be urlencoded, so replace '+' with '%2B', '=' with '%3D'. | [![step7-thumb]][step7-screen]  |
 | 8. Go to the **Main menu**, **Azure Active Directory** and click on **Properties**. Copy and save somewhere the **Directory ID**  | [![step8-thumb]][step8-screen]  |
 | 9. Go to the **Main menu**, **Subscriptions** and click on the subscription you want you use in Algo. Copy and save the subscription id from the **Overview** tab | [![step9-thumb]][step9-screen]  |
 | 10. Go to the **Access control (IAM)** tab and click to **Add** | [![step10-thumb]][step10-screen]  |


### PR DESCRIPTION
## Description
I was getting this error when I was doing Azure deploy:

TASK [cloud-azure : Create AlgoVPN Server] ***********************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: Timestamp: 2019-02-05 06:10:23Z
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/5y/zj428_z939x2dmqvrvl1k2480000gn/T/ansible_fno0Lp/ansible_module_azure_rm_deployment.py\", line 664, in <module>\n    main()\n  File \"/var/folders/5y/zj428_z939x2dmqvrvl1k2480000gn/T/ansible_fno0Lp/ansible_module_azure_rm_deployment.py\", line 660, in main\n    AzureRMDeploymentManager()\n  File \"/var/folders/5y/zj428_z939x2dmqvrvl1k2480000gn/T/ansible_fno0Lp/ansible_module_azure_rm_deployment.py\", line 434, in __init__\n    supports_check_mode=False)\n  File \"/var/folders/5y/zj428_z939x2dmqvrvl1k2480000gn/T/ansible_fno0Lp/ansible_modlib.zip/ansible/module_utils/azure_rm_common.py\", line 323, in __init__\n  File \"/Users/samyun/Downloads/algo-master/configs/.venvs/azure/lib/python2.7/site-packages/msrestazure/azure_active_directory.py\", line 453, in __init__\n    self.set_token()\n  File \"/Users/samyun/Downloads/algo-master/configs/.venvs/azure/lib/python2.7/site-packages/msrestazure/azure_active_directory.py\", line 480, in set_token\n    raise_with_traceback(AuthenticationError, \"\", err)\n  File \"/Users/samyun/Downloads/algo-master/configs/.venvs/azure/lib/python2.7/site-packages/msrest/exceptions.py\", line 48, in raise_with_traceback\n    raise error\nmsrest.exceptions.AuthenticationError: , InvalidClientError: (invalid_client) AADSTS50012: Invalid client secret is provided.\r\nTrace ID: 8414d96b-fca2-465e-ab45-573e25ee6f00\r\nCorrelation ID: 4459828a-2978-414c-80e8-7ed549fdf439\r\nTimestamp: 2019-02-05 06:10:23Z\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}

Turns out, the Azure web portal generates keys in the format 'blahblah+blahblah='. After searching on StackOverflow, seems it needs to be url encoded - 'blahblah%2Bblahblah%3D'. Making this change let the script continue without issue. Just adding a note in the documentation to help anyone else who runs into this

## Motivation and Context
See above

## How Has This Been Tested?
Documentation change only

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.