### PR TITLE
Wireguard runs twice on ubuntu

### DIFF
--- a/server.yml
+++ b/server.yml
@@ -17,7 +17,7 @@
       when: algo_local_dns
       tags: dns_adblocking
     - role: wireguard
-      when: wireguard_enabled
+      when: wireguard_enabled and ansible_distribution != 'Ubuntu'
       tags: wireguard
     - role: vpn
       tags: vpn


### PR DESCRIPTION
Wireguard role is included twice on ubuntu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
