### PR TITLE
fix "'OS' is undefined" error on user update

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -3,6 +3,8 @@
   - name: Check the system
     raw: uname -a
     register: OS
+    tags:
+      - update-users
 
   - include_tasks: ubuntu.yml
     when: '"Ubuntu" in OS.stdout or "Linux" in OS.stdout'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds the tag `update-users` to register the `uname -a` output when updating users.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When updating the users with `./algo update-users` the following error occurred:
```
fatal: [x.x.x.x]: FAILED! => {"msg": "The conditional check '\"Ubuntu\" in OS.stdout or \"Linux\" in OS.stdout' failed. The error was: error while evaluating conditional (\"Ubuntu\" in OS.stdout or \"Linux\" in OS.stdout): 'OS' is undefined\n\nThe error appears to have been in '/.../algo/roles/common/tasks/main.yml': line 7, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n  - include_tasks: ubuntu.yml\n    ^ here\n"}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
