### PR TITLE
Disable wireguard PersistentKeepalive by default

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -22,6 +22,10 @@ vpn_network: 10.19.48.0/24
 vpn_network_ipv6: 'fd9d:bc11:4020::/48'
 wireguard_enabled: true
 wireguard_port: 51820
+# If you're behind NAT or a firewall and you want to receive incoming connections long after network traffic has gone silent.
+# This option will keep the "connection" open in the eyes of NAT.
+# See: https://www.wireguard.com/quickstart/#nat-and-firewall-traversal-persistence
+wireguard_PersistentKeepalive: 0
 
 # Reduce the MTU of the VPN tunnel
 # Some cloud and internet providers use a smaller MTU (Maximum Transmission
@@ -36,9 +40,9 @@ reduce_mtu: 0
 # https://wiki.strongswan.org/projects/strongswan/wiki/LoggerConfiguration
 strongswan_log_level: 2
 
-# Algo will use the following lists to block ads. You can add new block lists 
+# Algo will use the following lists to block ads. You can add new block lists
 # after deployment by modifying the line starting "BLOCKLIST_URLS=" at:
-# /usr/local/sbin/adblock.sh 
+# /usr/local/sbin/adblock.sh
 # If you load very large blocklists, you may also have to modify resource limits:
 # /etc/systemd/system/dnsmasq.service.d/100-CustomLimitations.conf
 adblock_lists:

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+wireguard_PersistentKeepalive: 0
 wireguard_client_ip: "{{ wireguard_network_ipv4['clients_range'] }}.{{ wireguard_network_ipv4['clients_start'] + index|int + 1 }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['clients_range'] }}{{ wireguard_network_ipv6['clients_start'] + index|int + 1 }}/{{ wireguard_network_ipv6['prefix'] }}{% endif %}"
 wireguard_server_ip: "{{ wireguard_network_ipv4['gateway'] }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['gateway'] }}/{{ wireguard_network_ipv6['prefix'] }}{% endif %}"

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -9,4 +9,4 @@ DNS = {{ wireguard_dns_servers }}
 PublicKey = {{ lookup('file', wireguard_config_path + '/public/' + IP_subject_alt_name) }}
 AllowedIPs = 0.0.0.0/0, ::/0
 Endpoint = {{ IP_subject_alt_name }}:{{ wireguard_port }}
-PersistentKeepalive = 25
+{{ 'PersistentKeepalive = ' + wireguard_PersistentKeepalive|string if wireguard_PersistentKeepalive > 0 else '' }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes WireGuard PersistentKeepalive and include as an option in config

## Motivation and Context
Closes #1251

## How Has This Been Tested?
Deployed with and without PersistentKeepalive values and connected to the instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] All new and existing tests passed.
