### PR TITLE
Apache CloudStack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ After this process completes, the Algo VPN server will contain only the users li
   - Configure [Azure](docs/cloud-azure.md)
   - Configure [DigitalOcean](docs/cloud-do.md)
   - Configure [Google Cloud Platform](docs/cloud-gce.md)
+  - Configure [CloudStack](docs/cloud-cloudstack.md)
 * Advanced Deployment
   - Deploy to your own [FreeBSD](docs/deploy-to-freebsd.md) server
   - Deploy to your own [Ubuntu 18.04](docs/deploy-to-ubuntu.md) server

--- a/cloud.yml
+++ b/cloud.yml
@@ -33,6 +33,8 @@
       when: algo_provider == "scaleway"
     - role: cloud-openstack
       when: algo_provider == "openstack"
+    - role: cloud-cloudstack
+      when: algo_provider == "cloudstack"
     - role: local
       when: algo_provider == "local"
 

--- a/config.cfg
+++ b/config.cfg
@@ -150,6 +150,10 @@ cloud_providers:
   openstack:
     flavor_ram: ">=512"
     image:  Ubuntu-18.04
+  cloudstack:
+    size: Tiny
+    image: Linux Ubuntu 18.04 LTS 64-bit
+    disk: 10
   vultr:
     os: Ubuntu 18.04 x64
     size: 1024 MB RAM,25 GB SSD,1.00 TB BW

--- a/config.cfg
+++ b/config.cfg
@@ -151,7 +151,7 @@ cloud_providers:
     flavor_ram: ">=512"
     image:  Ubuntu-18.04
   cloudstack:
-    size: Tiny
+    size: Micro
     image: Linux Ubuntu 18.04 LTS 64-bit
     disk: 10
   vultr:

--- a/config.cfg
+++ b/config.cfg
@@ -22,6 +22,10 @@ vpn_network: 10.19.48.0/24
 vpn_network_ipv6: 'fd9d:bc11:4020::/48'
 wireguard_enabled: true
 wireguard_port: 51820
+# If you're behind NAT or a firewall and you want to receive incoming connections long after network traffic has gone silent.
+# This option will keep the "connection" open in the eyes of NAT.
+# See: https://www.wireguard.com/quickstart/#nat-and-firewall-traversal-persistence
+wireguard_PersistentKeepalive: 0
 
 # Reduce the MTU of the VPN tunnel
 # Some cloud and internet providers use a smaller MTU (Maximum Transmission
@@ -36,9 +40,9 @@ reduce_mtu: 0
 # https://wiki.strongswan.org/projects/strongswan/wiki/LoggerConfiguration
 strongswan_log_level: 2
 
-# Algo will use the following lists to block ads. You can add new block lists 
+# Algo will use the following lists to block ads. You can add new block lists
 # after deployment by modifying the line starting "BLOCKLIST_URLS=" at:
-# /usr/local/sbin/adblock.sh 
+# /usr/local/sbin/adblock.sh
 # If you load very large blocklists, you may also have to modify resource limits:
 # /etc/systemd/system/dnsmasq.service.d/100-CustomLimitations.conf
 adblock_lists:

--- a/docs/client-windows.md
+++ b/docs/client-windows.md
@@ -29,7 +29,7 @@ Get-Help -Name .\windows_USER.ps1 -Full | more
 3. If you haven't already, you will need to change the Execution Policy to allow unsigned scripts to run.
 
 ```powershell
-Set-ExecutionPolicy Unrestricted -Scope CurrentUser
+Set-ExecutionPolicy Unrestricted -Scope Process
 ```
 
 4. In the same window, run the necessary commands to install the certificates and create the VPN configuration. Note the lines at the top defining the VPN address, USER.p12 file location, and CA certificate location - change those lines to the IP address of your Algo server and the location you saved those two files. Also note that it will prompt for the "User p12 password", which is printed at the end of a successful Algo deployment.
@@ -67,12 +67,6 @@ $setVpnParams = @{
 }
 Set-VpnConnectionIPsecConfiguration @setVpnParams
 
-```
-
-5. After you execute the user script, set the Execution Policy back before you close the PowerShell window.
-
-```powershell
-Set-ExecutionPolicy Restricted -Scope CurrentUser
 ```
 
 Your VPN is now installed and ready to use.

--- a/docs/cloud-cloudstack.md
+++ b/docs/cloud-cloudstack.md
@@ -1,0 +1,20 @@
+### Configuration file
+
+You need to create a configuration file in INI format with your api key in `$HOME/.cloudstack.ini`
+
+```
+[cloudstack]
+endpoint = <endpoint>
+key = <your api key>
+secret = <your secret>
+timeout = 30
+```
+Example for Exoscale (European cloud provider exposing CloudStack API), visit https://portal.exoscale.com/u/<your account>/account/profile/api to gather the required information:
+
+```
+[cloudstack]
+endpoint = https://api.exoscale.com/compute
+key = <your api key>
+secret = <your secret>
+timeout = 30
+```

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -248,7 +248,7 @@ You need to source the rc file prior to run Algo. Download it from the OpenStack
 Required variables:
 
 - server - IP or hostname to access the server via SSH
-- endpoint - Public IP address of your server
+- endpoint - Public IP address or domain name of your server
 - ssh_user
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@
   - Configure [Azure](cloud-azure.md)
   - Configure [DigitalOcean](cloud-do.md)
   - Configure [Vultr](cloud-vultr.md)
+  - Configure [CloudStack](cloud-cloudstack.md)
 * Advanced Deployment
   - Deploy to your own [FreeBSD](deploy-to-freebsd.md) server
   - Deploy to your own [Ubuntu 18.04](deploy-to-ubuntu.md) server

--- a/input.yml
+++ b/input.yml
@@ -20,7 +20,7 @@
       - { name: Google Compute Engine, alias: gce }
       - { name: Scaleway, alias: scaleway}
       - { name: OpenStack (DreamCompute optimised), alias: openstack }
-      - { name: CloudStack, alias: cloudstask }
+      - { name: CloudStack, alias: cloudstack }
       - { name: Install to existing Ubuntu 18.04 server (Advanced), alias: local }
   vars_files:
     - config.cfg

--- a/input.yml
+++ b/input.yml
@@ -20,6 +20,7 @@
       - { name: Google Compute Engine, alias: gce }
       - { name: Scaleway, alias: scaleway}
       - { name: OpenStack (DreamCompute optimised), alias: openstack }
+      - { name: CloudStack, alias: cloudstask }
       - { name: Install to existing Ubuntu 18.04 server (Advanced), alias: local }
   vars_files:
     - config.cfg

--- a/input.yml
+++ b/input.yml
@@ -20,7 +20,7 @@
       - { name: Google Compute Engine, alias: gce }
       - { name: Scaleway, alias: scaleway}
       - { name: OpenStack (DreamCompute optimised), alias: openstack }
-      - { name: CloudStack, alias: cloudstack }
+      - { name: CloudStack (Exoscale optimised), alias: cloudstack }
       - { name: Install to existing Ubuntu 18.04 server (Advanced), alias: local }
   vars_files:
     - config.cfg

--- a/playbooks/cloud-post.yml
+++ b/playbooks/cloud-post.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set subjectAltName as afact
   set_fact:
-    IP_subject_alt_name: "{% if algo_provider == 'local' %}{{ IP_subject_alt_name }}{% else %}{{ cloud_instance_ip }}{% endif %}"
+    IP_subject_alt_name: "{{ (IP_subject_alt_name if algo_provider == 'local' else cloud_instance_ip) | lower }}"
 
 - name: Add the server to an inventory group
   add_host:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ansible==2.5.2
+jmespath==0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 ansible==2.5.2
-jmespath==0.9.4

--- a/roles/cloud-cloudstack/defaults/main.yml
+++ b/roles/cloud-cloudstack/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+cloudstack_venv: "{{ playbook_dir }}/configs/.venvs/cloudstack"

--- a/roles/cloud-cloudstack/defaults/main.yml
+++ b/roles/cloud-cloudstack/defaults/main.yml
@@ -1,2 +1,49 @@
 ---
 cloudstack_venv: "{{ playbook_dir }}/configs/.venvs/cloudstack"
+_cloudstack_zones: >
+    [
+        {
+        "allocationstate": "Enabled",
+        "dhcpprovider": "VirtualRouter",
+        "id": "1128bd56-b4d9-4ac6-a7b9-c715b187ce11",
+        "localstorageenabled": true,
+        "name": "ch-gva-2",
+        "networktype": "Basic",
+        "securitygroupsenabled": true,
+        "tags": [],
+        "zonetoken": "token"
+        },
+        {
+        "allocationstate": "Enabled",
+        "dhcpprovider": "VirtualRouter",
+        "id": "91e5e9e4-c9ed-4b76-bee4-427004b3baf9",
+        "localstorageenabled": true,
+        "name": "ch-dk-2",
+        "networktype": "Basic",
+        "securitygroupsenabled": true,
+        "tags": [],
+        "zonetoken": "token"
+        },
+        {
+        "allocationstate": "Enabled",
+        "dhcpprovider": "VirtualRouter",
+        "id": "4da1b188-dcd6-4ff5-b7fd-bde984055548",
+        "localstorageenabled": true,
+        "name": "at-vie-1",
+        "networktype": "Basic",
+        "securitygroupsenabled": true,
+        "tags": [],
+        "zonetoken": "token"
+        },
+        {
+        "allocationstate": "Enabled",
+        "dhcpprovider": "VirtualRouter",
+        "id": "35eb7739-d19e-45f7-a581-4687c54d6d02",
+        "localstorageenabled": true,
+        "name": "de-fra-1",
+        "networktype": "Basic",
+        "securitygroupsenabled": true,
+        "tags": [],
+        "zonetoken": "token"
+        }
+    ]

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -53,6 +53,7 @@
           ssh_key: "{{ keypair_name }}"
           security_groups: "{{ cs_security_group.name }}"
           zone: "{{ algo_region }}"
+          service_offering: "{{ size }}"
         register: cs_server
 
       - set_fact:

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -6,6 +6,12 @@
     - block:
       - name: Include prompts
         import_tasks: prompts.yml
+        
+      - set_fact:
+          algo_region: >-
+            {% if region is defined %}{{ region }}
+            {%- elif _algo_region.user_input is defined and _algo_region.user_input != "" %}{{ cs_zones[_algo_region.user_input | int -1 ] }}
+            {%- else %}{{ cs_zones[default_region | int - 1] }}{% endif %}
 
       - name: Security group created
         local_action:
@@ -50,7 +56,7 @@
           template: "{{ image_id }}"
           ssh_key: "{{ keypair_name }}"
           security_groups: "{{ cs_security_group.name }}"
-          zone: "{{ _algo_region.user_input }}"
+          zone: "{{ algo_region }}"
         register: cs_server
 
       - set_fact:

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -6,7 +6,7 @@
     - block:
       - name: Include prompts
         import_tasks: prompts.yml
-        
+
       - name: Security group created
         local_action:
           module: cs_securitygroup
@@ -16,11 +16,11 @@
 
       - name: Security rules created
         local_action:
-          module: cs_security_group_rule
+          module: cs_securitygroup_rule
           security_group: "{{ cs_security_group.name }}"
           protocol: "{{ item.proto }}"
-          start_port: "{{ item.port_min }}"
-          end_port: "{{ item.port_max }}"
+          start_port: "{{ item.start_port }}"
+          end_port: "{{ item.end_port }}"
           cidr: "{{ item.range }}"
         with_items:
           - { proto: tcp, start_port: 22, end_port: 22, range: 0.0.0.0/0 }

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -14,15 +14,13 @@
             {%- else %}{{ cs_zones[default_region | int - 1] }}{% endif %}
 
       - name: Security group created
-        local_action:
-          module: cs_securitygroup
+        cs_securitygroup:
           name: "{{ algo_server_name }}-security_group"
           description: AlgoVPN security group
         register: cs_security_group
 
       - name: Security rules created
-        local_action:
-          module: cs_securitygroup_rule
+        cs_securitygroup_rule:
           security_group: "{{ cs_security_group.name }}"
           protocol: "{{ item.proto }}"
           start_port: "{{ item.start_port }}"
@@ -35,8 +33,7 @@
           - { proto: udp, start_port: "{{ wireguard_port }}", end_port: "{{ wireguard_port }}", range: 0.0.0.0/0 }
 
       - name: Keypair created
-        local_action:
-          module: cs_sshkeypair
+        cs_sshkeypair:
           name: "{{ SSH_keys.comment|regex_replace('@', '_') }}"
           public_key: "{{ lookup('file', '{{ SSH_keys.public }}') }}"
         register: cs_keypair
@@ -49,8 +46,7 @@
           keypair_name: "{{ cs_keypair.name }}"
 
       - name: Server created
-        local_action:
-          module: cs_instance
+        cs_instance:
           name: "{{ algo_server_name }}"
           root_disk_size: "{{ disk }}"
           template: "{{ image_id }}"

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+- block:
+  - name: Build python virtual environment
+    import_tasks: venv.yml
+
+  - block:
+    - name: Security group created
+      cs_securitygroup:
+        name: "{{ algo_server_name }}-security_group"
+        description: AlgoVPN security group
+      register: cs_security_group
+
+    - name: Security rules created
+      cs_security_group_rule:
+        security_group: "{{ cs_security_group.name }}"
+        protocol: "{{ item.proto }}"
+        start_port: "{{ item.port_min }}"
+        end_port: "{{ item.port_max }}"
+        cidr: "{{ item.range }}"
+      with_items:
+        - { proto: tcp, start_port: 22, end_port: 22, range: 0.0.0.0/0 }
+        - { proto: udp, start_port: 4500, end_port: 4500, range: 0.0.0.0/0 }
+        - { proto: udp, start_port: 500, end_port: 500, range: 0.0.0.0/0 }
+        - { proto: udp, start_port: "{{ wireguard_port }}", end_port: "{{ wireguard_port }}", range: 0.0.0.0/0 }
+
+    - name: Keypair created
+      cs_sshkeypair:
+        name: "{{ SSH_keys.comment|regex_replace('@', '_') }}"
+        public_key: "{{ SSH_keys.public }}"
+      register: cs_keypair
+
+    - name: Set facts
+      set_fact:
+        image_id: "{{ cloud_providers.cloudstack.image }}"
+        size: "{{ cloud_providers.cloudstack.size }}"
+        disk: "{{ cloud_providers.cloudstack.disk }}"
+        keypair_name: "{{ cs_keypair.name }}"
+
+    - name: Server created
+      cs_instance:
+        name: "{{ algo_server_name }}"
+        root_disk_size: "{{ disk }}"
+        image: "{{ image_id }}"
+        ssh_key: "{{ keypair_name }}"
+        security_groups: "{{ cs_security_group.name }}"
+      register: cs_server
+
+    - set_fact:
+        cloud_instance_ip: "{{ cs_server.default_ip }}"
+        ansible_ssh_user: ubuntu
+    environment:
+      PYTHONPATH: "{{ cloudstack_venv }}/lib/python2.7/site-packages/"
+
+  rescue:
+  - debug: var=fail_hint
+    tags: always
+  - fail:
+    tags: always

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -61,6 +61,8 @@
           ansible_ssh_user: ubuntu
       environment:
         PYTHONPATH: "{{ cloudstack_venv }}/lib/python2.7/site-packages/"
+        CLOUDSTACK_CONFIG: "{{ _cs_config }}"
+        CLOUDSTACK_REGION: "{{ _cs_region.user_input }}"
 
       rescue:
       - debug: var=fail_hint

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -32,7 +32,7 @@
         local_action:
           module: cs_sshkeypair
           name: "{{ SSH_keys.comment|regex_replace('@', '_') }}"
-          public_key: "{{ SSH_keys.public }}"
+          public_key: "{{ lookup('file', '{{ SSH_keys.public }}') }}"
         register: cs_keypair
 
       - name: Set facts
@@ -47,10 +47,10 @@
           module: cs_instance
           name: "{{ algo_server_name }}"
           root_disk_size: "{{ disk }}"
-          image: "{{ image_id }}"
+          template: "{{ image_id }}"
           ssh_key: "{{ keypair_name }}"
           security_groups: "{{ cs_security_group.name }}"
-          zone: "{{ _algo_region }}"
+          zone: "{{ _algo_region.user_input }}"
         register: cs_server
 
       - set_fact:

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -1,58 +1,66 @@
 ---
 - block:
-  - name: Build python virtual environment
-    import_tasks: venv.yml
+    - name: Build python virtual environment
+      import_tasks: venv.yml
 
-  - block:
-    - name: Security group created
-      cs_securitygroup:
-        name: "{{ algo_server_name }}-security_group"
-        description: AlgoVPN security group
-      register: cs_security_group
+    - block:
+      - name: Include prompts
+        import_tasks: prompts.yml
+        
+      - name: Security group created
+        local_action:
+          module: cs_securitygroup
+          name: "{{ algo_server_name }}-security_group"
+          description: AlgoVPN security group
+        register: cs_security_group
 
-    - name: Security rules created
-      cs_security_group_rule:
-        security_group: "{{ cs_security_group.name }}"
-        protocol: "{{ item.proto }}"
-        start_port: "{{ item.port_min }}"
-        end_port: "{{ item.port_max }}"
-        cidr: "{{ item.range }}"
-      with_items:
-        - { proto: tcp, start_port: 22, end_port: 22, range: 0.0.0.0/0 }
-        - { proto: udp, start_port: 4500, end_port: 4500, range: 0.0.0.0/0 }
-        - { proto: udp, start_port: 500, end_port: 500, range: 0.0.0.0/0 }
-        - { proto: udp, start_port: "{{ wireguard_port }}", end_port: "{{ wireguard_port }}", range: 0.0.0.0/0 }
+      - name: Security rules created
+        local_action:
+          module: cs_security_group_rule
+          security_group: "{{ cs_security_group.name }}"
+          protocol: "{{ item.proto }}"
+          start_port: "{{ item.port_min }}"
+          end_port: "{{ item.port_max }}"
+          cidr: "{{ item.range }}"
+        with_items:
+          - { proto: tcp, start_port: 22, end_port: 22, range: 0.0.0.0/0 }
+          - { proto: udp, start_port: 4500, end_port: 4500, range: 0.0.0.0/0 }
+          - { proto: udp, start_port: 500, end_port: 500, range: 0.0.0.0/0 }
+          - { proto: udp, start_port: "{{ wireguard_port }}", end_port: "{{ wireguard_port }}", range: 0.0.0.0/0 }
 
-    - name: Keypair created
-      cs_sshkeypair:
-        name: "{{ SSH_keys.comment|regex_replace('@', '_') }}"
-        public_key: "{{ SSH_keys.public }}"
-      register: cs_keypair
+      - name: Keypair created
+        local_action:
+          module: cs_sshkeypair
+          name: "{{ SSH_keys.comment|regex_replace('@', '_') }}"
+          public_key: "{{ SSH_keys.public }}"
+        register: cs_keypair
 
-    - name: Set facts
-      set_fact:
-        image_id: "{{ cloud_providers.cloudstack.image }}"
-        size: "{{ cloud_providers.cloudstack.size }}"
-        disk: "{{ cloud_providers.cloudstack.disk }}"
-        keypair_name: "{{ cs_keypair.name }}"
+      - name: Set facts
+        set_fact:
+          image_id: "{{ cloud_providers.cloudstack.image }}"
+          size: "{{ cloud_providers.cloudstack.size }}"
+          disk: "{{ cloud_providers.cloudstack.disk }}"
+          keypair_name: "{{ cs_keypair.name }}"
 
-    - name: Server created
-      cs_instance:
-        name: "{{ algo_server_name }}"
-        root_disk_size: "{{ disk }}"
-        image: "{{ image_id }}"
-        ssh_key: "{{ keypair_name }}"
-        security_groups: "{{ cs_security_group.name }}"
-      register: cs_server
+      - name: Server created
+        local_action:
+          module: cs_instance
+          name: "{{ algo_server_name }}"
+          root_disk_size: "{{ disk }}"
+          image: "{{ image_id }}"
+          ssh_key: "{{ keypair_name }}"
+          security_groups: "{{ cs_security_group.name }}"
+          zone: "{{ _algo_region }}"
+        register: cs_server
 
-    - set_fact:
-        cloud_instance_ip: "{{ cs_server.default_ip }}"
-        ansible_ssh_user: ubuntu
-    environment:
-      PYTHONPATH: "{{ cloudstack_venv }}/lib/python2.7/site-packages/"
+      - set_fact:
+          cloud_instance_ip: "{{ cs_server.default_ip }}"
+          ansible_ssh_user: ubuntu
+      environment:
+        PYTHONPATH: "{{ cloudstack_venv }}/lib/python2.7/site-packages/"
 
-  rescue:
-  - debug: var=fail_hint
-    tags: always
-  - fail:
-    tags: always
+      rescue:
+      - debug: var=fail_hint
+        tags: always
+      - fail:
+        tags: always

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -11,7 +11,7 @@
           algo_region: >-
             {% if region is defined %}{{ region }}
             {%- elif _algo_region.user_input is defined and _algo_region.user_input != "" %}{{ cs_zones[_algo_region.user_input | int -1 ]['name'] }}
-            {%- else %}{{ cs_zones[default_region | int - 1]['name'] }}{% endif %}
+            {%- else %}{{ cs_zones[default_zone | int - 1]['name'] }}{% endif %}
 
       - name: Security group created
         cs_securitygroup:
@@ -62,7 +62,7 @@
       environment:
         PYTHONPATH: "{{ cloudstack_venv }}/lib/python2.7/site-packages/"
         CLOUDSTACK_CONFIG: "{{ _cs_config }}"
-        CLOUDSTACK_REGION: "{{ _cs_region.user_input }}"
+        CLOUDSTACK_REGION: "{% if _cs_region.user_input == '' %}{{ 'exoscale' }}{% else %}{{ _cs_region.user_input }}{% endif %}"
 
       rescue:
       - debug: var=fail_hint

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -10,8 +10,8 @@
       - set_fact:
           algo_region: >-
             {% if region is defined %}{{ region }}
-            {%- elif _algo_region.user_input is defined and _algo_region.user_input != "" %}{{ cs_zones[_algo_region.user_input | int -1 ] }}
-            {%- else %}{{ cs_zones[default_region | int - 1] }}{% endif %}
+            {%- elif _algo_region.user_input is defined and _algo_region.user_input != "" %}{{ cs_zones[_algo_region.user_input | int -1 ]['name'] }}
+            {%- else %}{{ cs_zones[default_region | int - 1]['name'] }}{% endif %}
 
       - name: Security group created
         cs_securitygroup:

--- a/roles/cloud-cloudstack/tasks/prompts.yml
+++ b/roles/cloud-cloudstack/tasks/prompts.yml
@@ -1,16 +1,12 @@
 ---
 - block:
-  - name: List zones on configured cloud provider
-    local_action: shell "{{ cloudstack_venv }}/bin/cs" listZones
-    register: cs_zones_list
-
   - name: Parse zones from output
     set_fact:
-      _cs_zones: "{{cs_zones_list.stdout | from_json }}"
+      _cs_zones: "{{ _cloudstack_zones | from_json }}"
   
   - name: Extract zones from output
     set_fact:
-      cs_zones: "{{ _cs_zones.zone | sort(attribute='name') }}"
+      cs_zones: "{{ _cs_zones | sort(attribute='name') }}"
 
   - name: Set the default zone
     set_fact:

--- a/roles/cloud-cloudstack/tasks/prompts.yml
+++ b/roles/cloud-cloudstack/tasks/prompts.yml
@@ -1,5 +1,28 @@
 ---
 - block:
+  - set_fact:
+      _cs_config: "{{ lookup('env', 'CLOUDSTACK_CONFIG') }}"
+
+  - pause:
+      prompt: |
+        Enter path for cloudstack.ini file
+        [~/.cloudstack.ini]
+    register: _cs_config_input
+    when: _cs_config == ""
+
+  - set_fact:
+      _cs_config_input: "{% if _cs_config_input.user_input == ''%}{{ '~/.cloudstack.ini' }}{% else %}{{ _cs_config_input.user_input }}{% endif %}"
+    when: _cs_config == ""
+
+  - set_fact:
+      _cs_config: "{% if _cs_config == '' %}{{ _cs_config_input }}{% else %}{{ _cs_config }}{% endif %}"
+
+  - pause:
+      prompt: |
+        Specify region to use in cloudstack.ini_file
+        [default]
+    register: _cs_region
+
   - name: Parse zones from output
     set_fact:
       _cs_zones: "{{ _cloudstack_zones | from_json }}"
@@ -19,8 +42,8 @@
       prompt: |
         What zone should the server be located in?
           {% for z in cs_zones %}
-            {{ loop.index }}. {{ z['name'] }}
-            {% endfor %}
+          {{ loop.index }}. {{ z['name'] }}
+          {% endfor %}
 
           Enter the number of your desired zone
           [{{ default_zone }}]

--- a/roles/cloud-cloudstack/tasks/prompts.yml
+++ b/roles/cloud-cloudstack/tasks/prompts.yml
@@ -6,20 +6,24 @@
 
   - name: Parse zones from output
     set_fact:
-      cs_zones: "{{cs_zones_list.stdout | from_json | json_query('zone[*].name')}}"
+      _cs_zones: "{{cs_zones_list.stdout | from_json }}"
   
+  - name: Extract zones from output
+    set_fact:
+      cs_zones: "{{ _cs_zones.zone | sort(attribute='name') }}"
+
   - name: Set the default zone
     set_fact:
       default_zone: >-
         {% for z in cs_zones %}
-        {%- if z == "ch-gva-2" %}{{ loop.index }}{% endif %}
+        {%- if z['name'] == "ch-gva-2" %}{{ loop.index }}{% endif %}
         {%- endfor %}
 
   - pause:
       prompt: |
         What zone should the server be located in?
           {% for z in cs_zones %}
-            {{ loop.index }}. {{ z }}
+            {{ loop.index }}. {{ z['name'] }}
             {% endfor %}
 
           Enter the number of your desired zone

--- a/roles/cloud-cloudstack/tasks/prompts.yml
+++ b/roles/cloud-cloudstack/tasks/prompts.yml
@@ -1,7 +1,30 @@
 ---
 - block:
+  - name: List zones on configured cloud provider
+    local_action: shell "{{ cloudstack_venv }}/bin/cs" listZones
+    register: cs_zones_list
+
+  - name: Parse zones from output
+    set_fact:
+      cs_zones: "{{cs_zones_list.stdout | from_json | json_query('zone[*].name')}}"
+  
+  - name: Set the default zone
+    set_fact:
+      default_zone: >-
+        {% for z in cs_zones %}
+        {%- if z == "ch-gva-2" %}{{ loop.index }}{% endif %}
+        {%- endfor %}
+
   - pause:
       prompt: |
-        What region should the server be located in?
+        What zone should the server be located in?
+          {% for z in cs_zones %}
+            {{ loop.index }}. {{ z }}
+            {% endfor %}
+
+          Enter the number of your desired zone
+          [{{ default_zone }}]
     register: _algo_region
   when: region is undefined
+  environment:
+        PYTHONPATH: "{{ cloudstack_venv }}/lib/python2.7/site-packages/"

--- a/roles/cloud-cloudstack/tasks/prompts.yml
+++ b/roles/cloud-cloudstack/tasks/prompts.yml
@@ -1,0 +1,7 @@
+---
+- block:
+  - pause:
+      prompt: |
+        What region should the server be located in?
+    register: _algo_region
+  when: region is undefined

--- a/roles/cloud-cloudstack/tasks/prompts.yml
+++ b/roles/cloud-cloudstack/tasks/prompts.yml
@@ -20,7 +20,7 @@
   - pause:
       prompt: |
         Specify region to use in cloudstack.ini_file
-        [default]
+        [exoscale]
     register: _cs_region
 
   - name: Parse zones from output
@@ -48,6 +48,6 @@
           Enter the number of your desired zone
           [{{ default_zone }}]
     register: _algo_region
-  when: region is undefined
+    when: region is undefined
   environment:
         PYTHONPATH: "{{ cloudstack_venv }}/lib/python2.7/site-packages/"

--- a/roles/cloud-cloudstack/tasks/venv.yml
+++ b/roles/cloud-cloudstack/tasks/venv.yml
@@ -7,7 +7,7 @@
 
 - name: Install requirements
   pip:
-    name: sc
+    name: cs
     version: 2.5.8
     virtualenv: "{{ cloudstack_venv }}"
     virtualenv_python: python2.7

--- a/roles/cloud-cloudstack/tasks/venv.yml
+++ b/roles/cloud-cloudstack/tasks/venv.yml
@@ -7,7 +7,9 @@
 
 - name: Install requirements
   pip:
-    name: cs
-    version: 2.5.8
+    name:
+      - cs
+      - sshpubkeys
+    state: latest
     virtualenv: "{{ cloudstack_venv }}"
     virtualenv_python: python2.7

--- a/roles/cloud-cloudstack/tasks/venv.yml
+++ b/roles/cloud-cloudstack/tasks/venv.yml
@@ -1,0 +1,13 @@
+---
+- name: Clean up the environment
+  file:
+    dest: "{{ cloudstack_venv }}"
+    state: absent
+  when: clean_environment
+
+- name: Install requirements
+  pip:
+    name: sc
+    version: 2.5.8
+    virtualenv: "{{ cloudstack_venv }}"
+    virtualenv_python: python2.7

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -3,6 +3,8 @@
   - name: Check the system
     raw: uname -a
     register: OS
+    tags:
+      - update-users
 
   - include_tasks: ubuntu.yml
     when: '"Ubuntu" in OS.stdout or "Linux" in OS.stdout'

--- a/roles/local/tasks/prompts.yml
+++ b/roles/local/tasks/prompts.yml
@@ -31,7 +31,7 @@
 
 - pause:
     prompt: |
-      Enter the public IP address of your server: (IMPORTANT! This IP is used to verify the certificate)
+      Enter the public IP address or domain name of your server: (IMPORTANT! This is used to verify the certificate)
       [{{ cloud_instance_ip }}]
   register: _endpoint
   when: endpoint is undefined

--- a/roles/vpn/defaults/main.yml
+++ b/roles/vpn/defaults/main.yml
@@ -35,7 +35,7 @@ algo_local_dns: false
 ipv6_support: false
 dns_encryption: true
 domain: false
-subjectAltName_IP: "IP:{{ IP_subject_alt_name }}"
+subjectAltName_IP: "{{ 'DNS:' if IP_subject_alt_name|regex_search('[a-z]') else 'IP:' }}{{ IP_subject_alt_name }}"
 subjectAltName_USER: "{% if '@' in item %}email:{{ item }}{% else %}DNS:{{ item }}{% endif %}"
 openssl_bin: openssl
 strongswan_enabled_plugins:

--- a/roles/vpn/templates/mobileconfig.j2
+++ b/roles/vpn/templates/mobileconfig.j2
@@ -52,6 +52,10 @@
                     <key>URLStringProbe</key>
                       <string>http://captive.apple.com/hotspot-detect.html</string>
                   </dict>
+                  <dict>
+                    <key>Action</key>
+                      <string>Disconnect</string>
+                  </dict>
                 </array>
 {% else %}
 {% endif %}

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+wireguard_PersistentKeepalive: 0
 wireguard_client_ip: "{{ wireguard_network_ipv4['clients_range'] }}.{{ wireguard_network_ipv4['clients_start'] + index|int + 1 }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['clients_range'] }}{{ wireguard_network_ipv6['clients_start'] + index|int + 1 }}/{{ wireguard_network_ipv6['prefix'] }}{% endif %}"
 wireguard_server_ip: "{{ wireguard_network_ipv4['gateway'] }}/{{ wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ wireguard_network_ipv6['gateway'] }}/{{ wireguard_network_ipv6['prefix'] }}{% endif %}"

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -9,4 +9,4 @@ DNS = {{ wireguard_dns_servers }}
 PublicKey = {{ lookup('file', wireguard_config_path + '/public/' + IP_subject_alt_name) }}
 AllowedIPs = 0.0.0.0/0, ::/0
 Endpoint = {{ IP_subject_alt_name }}:{{ wireguard_port }}
-PersistentKeepalive = 25
+{{ 'PersistentKeepalive = ' + wireguard_PersistentKeepalive|string if wireguard_PersistentKeepalive > 0 else '' }}


### PR DESCRIPTION
This new role allows to provision instances on Apache CloudStack providers like Exoscale.

I initially wanted to add a role specific for Exoscale but since they are using Apache CloudStack, better make it generic :)

## Description
I added a new role `cloud-cloudstack` and modified the required files for inputs and configurations defaults.

## Motivation and Context
I got an Exoscale gift-card to try their service at the latest Lausanne DevSecOps meetup. Since they advertised the non-US feature of their business, we discussed VPN and the like. What better use than add support for their cloud for this gift card?

## How Has This Been Tested?
I only tested this CloudStack role on Exoscale. However, the only things to change would be in the user's `$HOME/.cloudstack.ini` file to specify the endpoint to use.

## Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
