### PR TITLE
skip generation of SSH keypair when deploying locally

### DIFF
--- a/playbooks/cloud-pre.yml
+++ b/playbooks/cloud-pre.yml
@@ -31,9 +31,11 @@
     size: 2048
     mode: "0600"
     type: RSA
+  when: algo_provider != "local"
 
 - name: Generate the SSH public key
   openssl_publickey:
     path: "{{ SSH_keys.public }}"
     privatekey_path: "{{ SSH_keys.private }}"
     format: OpenSSH
+  when: algo_provider != "local"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Right now, it generates an SSH keypair in all cases. This changes that to skip if we're building locally on the system, since a keypair isn't required.
<!--- Describe your changes in detail -->

## How Has This Been Tested?

Did a local build w/ this patch, confirmed it still works w/o the keypair

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
