### PR TITLE
A pause for Vultr

### DIFF
--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- pause:
+    minutes: 1
+    prompt: "Pausing for one minute to ensure CPU is ready."
+    when: algo_provider == "vultr"
+
 - name: Ensure the required directories exist
   file:
     dest: "{{ wireguard_pki_path }}/{{ item }}"

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- pause:
-    minutes: 1
-    prompt: "Pausing for one minute to ensure CPU is ready."
-    when: algo_provider == "vultr"
-
 - name: Ensure the required directories exist
   file:
     dest: "{{ wireguard_pki_path }}/{{ item }}"

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- pause:
+    minutes: 1
+    prompt: "Pausing for one minute to ensure CPU is ready."
+  when: algo_provider == "vultr"
+
 - name: Ensure the required directories exist
   file:
     dest: "{{ wireguard_pki_path }}/{{ item }}"


### PR DESCRIPTION
## Description
I've been having issues in Algo occasionally where the script will get stuck when trying to install Wireguard on Vultr. Through some experimentation, the problem was solved by forcing a pause before the Wireguard step.

## Motivation and Context
This change fixes Algo hanging on Wireguard installation when using Vultr. Maybe there's too much CPU bursting and it can't handle it? Not sure the cause, but this fixes the issue.

## How Has This Been Tested?
Ran the code on own server and ran the change through Travis CI

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
