### PR TITLE
Start dnscrypt-proxy after systemd-resolved

### DIFF
--- a/roles/dns_encryption/tasks/ubuntu.yml
+++ b/roles/dns_encryption/tasks/ubuntu.yml
@@ -47,10 +47,14 @@
     owner: root
     group: root
 
-- name: Ubuntu | Add capabilities to bind ports
+- name: Ubuntu | Add custom requirements to successfully start the unit
   copy:
-    dest: /etc/systemd/system/dnscrypt-proxy.service.d/99-capabilities.conf
+    dest: /etc/systemd/system/dnscrypt-proxy.service.d/99-algo.conf
     content: |
+      [Unit]
+      After=systemd-resolved.service
+      Requires=systemd-resolved.service
+
       [Service]
       AmbientCapabilities=CAP_NET_BIND_SERVICE
   notify:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
dnscrypt-proxy uses systemd-resolved as a fallback resolver for one-shot queries when retrieving the initial resolvers list, thus systemd-resolved should already be started when dnscrypt-proxy comes up

## Motivation and Context
Fixes #1356

## How Has This Been Tested?
Deployed to EC2 and rebooted the server, dnscrypt-proxy successfully started

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
