### PR TITLE
Fixes error in 10-algo-lo100.network

### DIFF
--- a/roles/common/templates/10-algo-lo100.network.j2
+++ b/roles/common/templates/10-algo-lo100.network.j2
@@ -2,6 +2,6 @@
 Name=lo
 
 [Network]
-Label=lo:100
+Description=lo:100
 Address={{ local_service_ip }}/32
 Address=FCAA::1/64


### PR DESCRIPTION
 ## Description

Having read through the systemd-networkd man the [Network] section accepts only certain keys. Description is the permitted key to use for labelling purposes. This PR makes the necessary change.

## Motivation and Context

Resolves #1360

## How Has This Been Tested?

Amended the service on my existing localhost deployment from today and reloaded. The "Unknown lvalue 'Label' in section 'Network'" error is no longer showing when systemd-networkd starts.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.