### PR TITLE
Use VULTR_API_CONFIG variable if set

### DIFF
--- a/roles/cloud-vultr/tasks/prompts.yml
+++ b/roles/cloud-vultr/tasks/prompts.yml
@@ -4,7 +4,9 @@
       Enter the local path to your configuration INI file
       (https://trailofbits.github.io/algo/cloud-vultr.html):
   register: _vultr_config
-  when: vultr_config is undefined
+  when:
+    - vultr_config is undefined
+    - lookup('env','VULTR_API_CONFIG')|length <= 0
 
 - name: Set the token as a fact
   set_fact:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If the environment variable VULTR_API_CONFIG is set, use it as the name of the file which contains the Vultr API key.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With other cloud providers there are environment variables that can be set to avoid the interactive prompts for credentials, but this wasn't working for Vultr.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Initiated deployments with and without the variable set and confirmed working API access.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.