### PR TITLE
IPv6 range to AllowedIPs only when ipv6_support is true

### DIFF
--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -7,6 +7,6 @@ DNS = {{ wireguard_dns_servers }}
 
 [Peer]
 PublicKey = {{ lookup('file', wireguard_pki_path + '/public/' + IP_subject_alt_name) }}
-AllowedIPs = 0.0.0.0/0, ::/0
+AllowedIPs = 0.0.0.0/0{{ ', ::/0'  if ipv6_support else '' }}
 Endpoint = {{ IP_subject_alt_name }}:{{ wireguard_port }}
 {{ 'PersistentKeepalive = ' + wireguard_PersistentKeepalive|string if wireguard_PersistentKeepalive > 0 else '' }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
WireGuard: We don't need to add `::/0` to `AllowedIPs` if IPv6 is not supported

## Motivation and Context
Mentioned in #1385

## How Has This Been Tested?
Deployed to Lightsail (without ipv6) and to DO (with ipv6)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
