### PR TITLE
Get public IP from default interface in `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ getAlgo() {
 publicIpFromInterface() {
   echo "Couldn't find a valid ipv4 address, using the first IP found on the interfaces as the endpoint."
   DEFAULT_INTERFACE="$(ip -4 route list match default | grep -Eo "dev .*" | awk '{print $2}')"
-  ENDPOINT=$(ip -4 addr sh dev eth0 | grep -w inet | head -n1 | awk '{print $2}' | grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b')
+  ENDPOINT=$(ip -4 addr sh dev $DEFAULT_INTERFACE | grep -w inet | head -n1 | awk '{print $2}' | grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b')
   export ENDPOINT=$ENDPOINT
   echo "Using ${ENDPOINT} as the endpoint"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently, `publicIpFromInterface` in `install.sh` will only get the IP from the `eth0` interface, which may not exist.  Since there's a `DEFAULT_INTERFACE` defined directly above it and that isn't used anywhere else, I guess that's supposed to be used.

## Description
<!--- Describe your changes in detail -->
Get the IP from the default interface instead of always `eth0`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`eth0` may not be the default interface.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I ran the altered script in an environment without an `eth0` and that got set up.  I didn't see a way to run tests in `CONTRIBUTING.md`, so I guess it's supposed to go through CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
