### PR TITLE
Automatically create cloud firewall rules for installs onto Vultr

### DIFF
--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -27,8 +27,8 @@
     - { protocol: udp, port: 500, ip: v6, cidr: "::/0" }
     - { protocol: udp, port: 4500, ip: v4, cidr: "0.0.0.0/0" }
     - { protocol: udp, port: 4500, ip: v6, cidr: "::/0" }
-    - { protocol: udp, port: 51820, ip: v4, cidr: "0.0.0.0/0" }
-    - { protocol: udp, port: 51820, ip: v6, cidr: "::/0" }
+    - { protocol: udp, port: "{{ wireguard_port }}", ip: v4, cidr: "0.0.0.0/0" }
+    - { protocol: udp, port: "{{ wireguard_port }}", ip: v6, cidr: "::/0" }
      
   - name: Creating a server
     vr_server:

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -12,7 +12,7 @@
   - name: Creating a firewall group
     vultr_firewall_group:
       name: "{{ algo_server_name }}"
-      
+
   - name: Creating firewall rules
     vultr_firewall_rule:
       group: "{{ algo_server_name }}"
@@ -29,7 +29,7 @@
     - { protocol: udp, port: 4500, ip: v6, cidr: "::/0" }
     - { protocol: udp, port: "{{ wireguard_port }}", ip: v4, cidr: "0.0.0.0/0" }
     - { protocol: udp, port: "{{ wireguard_port }}", ip: v6, cidr: "::/0" }
-    
+
   - name: Creating a server
     vultr_server:
       name: "{{ algo_server_name }}"
@@ -45,7 +45,7 @@
       auto_backup_enabled: false
       notify_activate: false
     register: vultr_server
-    
+
   - set_fact:
       cloud_instance_ip: "{{ vultr_server.vultr_server.v4_main_ip }}"
       ansible_ssh_user: root

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -10,23 +10,23 @@
     register: ssh_key
 
   - name: Creating a firewall group
-    vr_firewall_group:
+    vultr_firewall_group:
       name: "{{ algo_server_name }}"
  
   - name: Creating firewall rules
-    vr_firewall_rule:
+    vultr_firewall_rule:
       group: "{{ algo_server_name }}"
       protocol: udp
-      port: 500
-    vr_firewall_rule:
-      group: "{{ algo_server_name }}"
-      protocol: udp
-      port: 4500
-    vr_firewall_rule:
-      group: "{{ algo_server_name }}"
-      protocol: udp
-      port: 51820
- 
+      port: "{{ item.port }}"
+      cidr: "{{ item.cidr }}"
+    with_items:
+    - { port: 500, cidr: "0.0.0.0/0" }
+    - { port: 500, cidr: "::/0" }
+    - { port: 4500, cidr: "0.0.0.0/0" }
+    - { port: 4500, cidr: "::/0" }
+    - { port: 51820, cidr: "0.0.0.0/0" }
+    - { port: 51820, cidr: "::/0" }
+     
   - name: Creating a server
     vultr_server:
       name: "{{ algo_server_name }}"

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -4,17 +4,17 @@
 
 - block:
   - name: Upload the SSH key
-    vultr_ssh_key:
+    vr_ssh_key:
       name: "{{ SSH_keys.comment }}"
       ssh_key: "{{ lookup('file', '{{ SSH_keys.public }}') }}"
     register: ssh_key
 
   - name: Creating a firewall group
-    vultr_firewall_group:
+    vr_firewall_group:
       name: "{{ algo_server_name }}"
  
   - name: Creating firewall rules
-    vultr_firewall_rule:
+    vr_firewall_rule:
       group: "{{ algo_server_name }}"
       protocol: udp
       port: "{{ item.port }}"
@@ -28,7 +28,7 @@
     - { port: 51820, cidr: "::/0" }
      
   - name: Creating a server
-    vultr_server:
+    vr_server:
       name: "{{ algo_server_name }}"
       hostname: "{{ algo_server_name }}"
       os: "{{ cloud_providers.vultr.os }}"

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -9,6 +9,24 @@
       ssh_key: "{{ lookup('file', '{{ SSH_keys.public }}') }}"
     register: ssh_key
 
+  - name: Creating a firewall group
+    vr_firewall_group:
+      name: "{{ algo_server_name }}"
+ 
+  - name: Creating firewall rules
+    vr_firewall_rule:
+      group: "{{ algo_server_name }}"
+      protocol: udp
+      port: 500
+    vr_firewall_rule:
+      group: "{{ algo_server_name }}"
+      protocol: udp
+      port: 4500
+    vr_firewall_rule:
+      group: "{{ algo_server_name }}"
+      protocol: udp
+      port: 51820
+ 
   - name: Creating a server
     vultr_server:
       name: "{{ algo_server_name }}"
@@ -16,6 +34,7 @@
       os: "{{ cloud_providers.vultr.os }}"
       plan: "{{ cloud_providers.vultr.size }}"
       region: "{{ algo_vultr_region }}"
+      firewall_group: "{{ algo_server_name }}"
       state: started
       tag: Environment:Algo
       ssh_key: "{{ ssh_key.vultr_ssh_key.name }}"
@@ -23,7 +42,7 @@
       auto_backup_enabled: false
       notify_activate: false
     register: vultr_server
-
+    
   - set_fact:
       cloud_instance_ip: "{{ vultr_server.vultr_server.v4_main_ip }}"
       ansible_ssh_user: root

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -12,7 +12,7 @@
   - name: Creating a firewall group
     vultr_firewall_group:
       name: "{{ algo_server_name }}"
- 
+      
   - name: Creating firewall rules
     vultr_firewall_rule:
       group: "{{ algo_server_name }}"
@@ -29,7 +29,7 @@
     - { protocol: udp, port: 4500, ip: v6, cidr: "::/0" }
     - { protocol: udp, port: "{{ wireguard_port }}", ip: v4, cidr: "0.0.0.0/0" }
     - { protocol: udp, port: "{{ wireguard_port }}", ip: v6, cidr: "::/0" }
-     
+    
   - name: Creating a server
     vultr_server:
       name: "{{ algo_server_name }}"

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -18,14 +18,15 @@
       group: "{{ algo_server_name }}"
       protocol: udp
       port: "{{ item.port }}"
+      ip_version: "{{ item.ip }}"
       cidr: "{{ item.cidr }}"
     with_items:
-    - { port: 500, cidr: "0.0.0.0/0" }
-    - { port: 500, cidr: "::/0" }
-    - { port: 4500, cidr: "0.0.0.0/0" }
-    - { port: 4500, cidr: "::/0" }
-    - { port: 51820, cidr: "0.0.0.0/0" }
-    - { port: 51820, cidr: "::/0" }
+    - { port: 500, ip: v4, cidr: "0.0.0.0/0" }
+    - { port: 500, ip: v6, cidr: "::/0" }
+    - { port: 4500, ip: v4, cidr: "0.0.0.0/0" }
+    - { port: 4500, ip: v6, cidr: "::/0" }
+    - { port: 51820, ip: v4, cidr: "0.0.0.0/0" }
+    - { port: 51820, ip: v6, cidr: "::/0" }
      
   - name: Creating a server
     vr_server:

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -16,17 +16,19 @@
   - name: Creating firewall rules
     vr_firewall_rule:
       group: "{{ algo_server_name }}"
-      protocol: udp
+      protocol: "{{ item.protocol }}"
       port: "{{ item.port }}"
       ip_version: "{{ item.ip }}"
       cidr: "{{ item.cidr }}"
     with_items:
-    - { port: 500, ip: v4, cidr: "0.0.0.0/0" }
-    - { port: 500, ip: v6, cidr: "::/0" }
-    - { port: 4500, ip: v4, cidr: "0.0.0.0/0" }
-    - { port: 4500, ip: v6, cidr: "::/0" }
-    - { port: 51820, ip: v4, cidr: "0.0.0.0/0" }
-    - { port: 51820, ip: v6, cidr: "::/0" }
+    - { protocol: tcp, port: 22, ip: v4, cidr: "0.0.0.0/0" }
+    - { protocol: tcp, port: 22, ip: v6, cidr: "::/0" }
+    - { protocol: udp, port: 500, ip: v4, cidr: "0.0.0.0/0" }
+    - { protocol: udp, port: 500, ip: v6, cidr: "::/0" }
+    - { protocol: udp, port: 4500, ip: v4, cidr: "0.0.0.0/0" }
+    - { protocol: udp, port: 4500, ip: v6, cidr: "::/0" }
+    - { protocol: udp, port: 51820, ip: v4, cidr: "0.0.0.0/0" }
+    - { protocol: udp, port: 51820, ip: v6, cidr: "::/0" }
      
   - name: Creating a server
     vr_server:

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -4,17 +4,17 @@
 
 - block:
   - name: Upload the SSH key
-    vr_ssh_key:
+    vultr_ssh_key:
       name: "{{ SSH_keys.comment }}"
       ssh_key: "{{ lookup('file', '{{ SSH_keys.public }}') }}"
     register: ssh_key
 
   - name: Creating a firewall group
-    vr_firewall_group:
+    vultr_firewall_group:
       name: "{{ algo_server_name }}"
  
   - name: Creating firewall rules
-    vr_firewall_rule:
+    vultr_firewall_rule:
       group: "{{ algo_server_name }}"
       protocol: "{{ item.protocol }}"
       port: "{{ item.port }}"
@@ -31,7 +31,7 @@
     - { protocol: udp, port: "{{ wireguard_port }}", ip: v6, cidr: "::/0" }
      
   - name: Creating a server
-    vr_server:
+    vultr_server:
       name: "{{ algo_server_name }}"
       hostname: "{{ algo_server_name }}"
       os: "{{ cloud_providers.vultr.os }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds appropriate firewall rules in Vultr during the cloud install process using the `vr_firewall_group` and `vr_firewall_rule` modules, in concordance with existing rules for EC2 and GCE. Used [this tutorial](https://www.renemoser.net/blog/2018/03/19/vultr-firewalling-with-ansible/).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Not sure if it's really necessary, given the Algo server's own iptables rules, but it may give another layer of protection.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deployed successfully from a Mac and confirmed correct firewall rules.

![Screen Shot 2019-04-21 at 1 07 51 AM](https://user-images.githubusercontent.com/37350377/56465710-164df300-63d2-11e9-9b2d-36a5088b27ad.png)
![Screen Shot 2019-04-21 at 1 08 16 AM](https://user-images.githubusercontent.com/37350377/56465711-1948e380-63d2-11e9-8b3f-5505108f2bf8.png)

If this is something you want to go ahead with, I'd then change [the consolidated firewall docs](https://github.com/trailofbits/algo/blob/master/docs/firewalls.md#external-firewall) slightly to mention that Vultr has an external firewall set up.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] All new and existing tests passed.