### PR TITLE
Support for Ubuntu 19.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,56 +51,73 @@ custom_scripts:
     - sudo env "PATH=$PATH" ./tests/ipsec-client.sh
     - sudo ./tests/ssh-tunnel.sh
 
+stages:
+  - &tests-and-linters
+    stage: Tests
+    name: code checks and linters
+    addons:
+      apt:
+        packages:
+          - shellcheck
+    script:
+      - pip install ansible-lint
+      - shellcheck algo install.sh
+      - ansible-playbook main.yml --syntax-check
+      - ansible-lint -v *.yml
+
+  - &deploy-local
+    stage: Deploy
+    name: local deployment from docker
+    addons:
+      apt:
+        sources: *default_sources
+        packages: *default_packages
+    before_install: *provisioning
+    before_script:
+      - docker build -t travis/algo .
+      - ./tests/local-deploy.sh
+      - ./tests/update-users.sh
+    script: *tests
+
+  - &deploy-cloudinit
+    stage: Deploy
+    name: cloud-init deployment
+    addons:
+      apt:
+        sources: *default_sources
+        packages: *default_packages
+    env: DEPLOY=cloud-init
+    before_install: *provisioning
+    before_script:
+      - until sudo lxc exec algo -- test -f /var/log/cloud-init-output.log; do echo 'Log file not found, Sleep for 3 seconds'; sleep 3; done
+      - ( sudo lxc exec algo -- tail -f /var/log/cloud-init-output.log & )
+      - |
+        until sudo lxc exec algo -- test -f /var/lib/cloud/data/result.json; do
+          echo 'Cloud init is not finished. Sleep for 30 seconds';
+          sleep 30;
+        done
+      - sudo lxc exec algo -- test -f /opt/algo/configs/localhost/.config.yml
+      - sudo lxc exec algo -- tar zcf /root/algo-configs.tar -C /opt/algo/configs/ .
+      - sudo lxc file pull algo/root/algo-configs.tar ./
+      - sudo tar -C ./configs -zxf algo-configs.tar
+    script: *tests
+
 matrix:
   fast_finish: true
   include:
-    - stage: Tests
-      name: code checks and linters
-      addons:
-        apt:
-          packages:
-            - shellcheck
-      script:
-        - pip install ansible-lint
-        - shellcheck algo install.sh
-        - ansible-playbook main.yml --syntax-check
-        - ansible-lint -v roles/*/*/*.yml playbooks/*.yml *.yml
-
-    - stage: Deploy
-      name: local deployment from docker
-      addons:
-        apt:
-          sources: *default_sources
-          packages: *default_packages
-      env: DEPLOY=docker
-      before_install: *provisioning
-      before_script:
-        - docker build -t travis/algo .
-        - ./tests/local-deploy.sh
-        - ./tests/update-users.sh
-      script: *tests
-
-    - stage: Deploy
-      name: cloud-init deployment
-      addons:
-        apt:
-          sources: *default_sources
-          packages: *default_packages
-      env: DEPLOY=cloud-init
-      before_install: *provisioning
-      before_script:
-        - until sudo lxc exec algo -- test -f /var/log/cloud-init-output.log; do echo 'Log file not found, Sleep for 3 seconds'; sleep 3; done
-        - ( sudo lxc exec algo -- tail -f /var/log/cloud-init-output.log & )
-        - |
-          until sudo lxc exec algo -- test -f /var/lib/cloud/data/result.json; do
-            echo 'Cloud init is not finished. Sleep for 30 seconds';
-            sleep 30;
-          done
-        - sudo lxc exec algo -- test -f /opt/algo/configs/localhost/.config.yml
-        - sudo lxc exec algo -- tar zcf /root/algo-configs.tar -C /opt/algo/configs/ .
-        - sudo lxc file pull algo/root/algo-configs.tar ./
-        - sudo tar -C ./configs -zxf algo-configs.tar
-      script: *tests
+    - <<: *tests-and-linters
+    - <<: *deploy-local
+      name: 'Ubuntu 18.04: local deployment from docker'
+      env: DEPLOY=docker UBUNTU_VERSION=18.04
+    - <<: *deploy-local
+      name: 'Ubuntu 19.04: local deployment from docker'
+      env: DEPLOY=docker UBUNTU_VERSION=19.04
+    - <<: *deploy-cloudinit
+      name: 'Ubuntu 18.04: cloud-init deployment'
+      env: DEPLOY=cloud-init UBUNTU_VERSION=18.04
+    - <<: *deploy-cloudinit
+      name: 'Ubuntu 19.04: cloud-init deployment'
+      env: DEPLOY=cloud-init UBUNTU_VERSION=19.04
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Algo VPN is a set of Ansible scripts that simplify the setup of a personal IPSEC
 * Blocks ads with a local DNS resolver (optional)
 * Sets up limited SSH users for tunneling traffic (optional)
 * Based on current versions of Ubuntu and strongSwan
-* Installs to DigitalOcean, Amazon Lightsail, Amazon EC2, Vultr, Microsoft Azure, Google Compute Engine, Scaleway, OpenStack, or your own Ubuntu 18.04 LTS server
+* Installs to DigitalOcean, Amazon Lightsail, Amazon EC2, Vultr, Microsoft Azure, Google Compute Engine, Scaleway, OpenStack, or your own Ubuntu server
 
 ## Anti-features
 
@@ -93,9 +93,9 @@ WireGuard is used to provide VPN services on Apple devices. Algo generates a Wir
 
 On iOS, install the [WireGuard](https://itunes.apple.com/us/app/wireguard/id1441195209?mt=8) app from the iOS App Store. Then, use the WireGuard app to scan the QR code or AirDrop the configuration file to the device.
 
-On macOS Mojave or later, install the [WireGuard](https://itunes.apple.com/us/app/wireguard/id1451685025?mt=12) app from the Mac App Store. WireGuard will appear in the menu bar once you run the app. Click on the WireGuard icon, choose **Import tunnel(s) from file...**, then select the appropriate WireGuard configuration file. 
+On macOS Mojave or later, install the [WireGuard](https://itunes.apple.com/us/app/wireguard/id1451685025?mt=12) app from the Mac App Store. WireGuard will appear in the menu bar once you run the app. Click on the WireGuard icon, choose **Import tunnel(s) from file...**, then select the appropriate WireGuard configuration file.
 
-On either iOS or macOS, you can enable "Connect on Demand" and/or exclude certain trusted Wi-Fi networks (such as your home or work) by editing the tunnel configuration in the WireGuard app. (Algo can't do this automatically for you.) 
+On either iOS or macOS, you can enable "Connect on Demand" and/or exclude certain trusted Wi-Fi networks (such as your home or work) by editing the tunnel configuration in the WireGuard app. (Algo can't do this automatically for you.)
 
 Installing WireGuard is a little more complicated on older version of macOS. See [Using macOS as a Client with WireGuard](docs/client-macos-wireguard.md).
 
@@ -122,7 +122,7 @@ Network Manager does not support AES-GCM. In order to support Linux Desktop clie
 
 Install strongSwan, then copy the included ipsec_user.conf, ipsec_user.secrets, user.crt (user certificate), and user.key (private key) files to your client device. These will require customization based on your exact use case. These files were originally generated with a point-to-point OpenWRT-based VPN in mind.
 
-#### Ubuntu Server 18.04 example
+#### Ubuntu Server example
 
 1. `sudo apt-get install strongswan libstrongswan-standard-plugins`: install strongSwan
 2. `/etc/ipsec.d/certs`: copy `<name>.crt` from `algo-master/configs/<server_ip>/ipsec/manual/<name>.crt`

--- a/config.cfg
+++ b/config.cfg
@@ -129,18 +129,18 @@ cloud_providers:
     image: 18.04-LTS
   digitalocean:
     size: s-1vcpu-1gb
-    image: "ubuntu-18-04-x64"
+    image: "ubuntu-19-04-x64"
   ec2:
   # Change the encrypted flag to "true" to enable AWS volume encryption, for encryption of data at rest.
   # Warning: the Algo script will take approximately 6 minutes longer to complete.
     encrypted: false
     size: t2.micro
     image:
-      name: "ubuntu-bionic-18.04"
+      name: "ubuntu-disco-19.04"
       owner: "099720109477"
   gce:
     size: f1-micro
-    image: ubuntu-1804
+    image: ubuntu-1904
     external_static_ip: false
   lightsail:
     size: nano_1_0
@@ -153,7 +153,7 @@ cloud_providers:
     flavor_ram: ">=512"
     image:  Ubuntu-18.04
   vultr:
-    os: Ubuntu 18.04 x64
+    os: Ubuntu 19.04 x64
     size: 1024 MB RAM,25 GB SSD,1.00 TB BW
   local:
 

--- a/config.cfg
+++ b/config.cfg
@@ -126,7 +126,7 @@ SSH_keys:
 cloud_providers:
   azure:
     size: Basic_A0
-    image: 18.04-LTS
+    image: 19.04
   digitalocean:
     size: s-1vcpu-1gb
     image: "ubuntu-19-04-x64"

--- a/docs/cloud-do.md
+++ b/docs/cloud-do.md
@@ -34,8 +34,8 @@ What provider would you like to use?
     6. Google Compute Engine
     7. Scaleway
     8. OpenStack (DreamCompute optimised)
-    9. Install to existing Ubuntu 18.04 server (Advanced)
-  
+    9. Install to existing Ubuntu server (Advanced)
+
 Enter the number of your desired provider
 :
 1
@@ -68,7 +68,7 @@ What region should the server be located in?
     7. sfo2     San Francisco 2
     8. sgp1     Singapore 1
     9. tor1     Toronto 1
-  
+
 Enter the number of your desired region
 [6]
 :

--- a/docs/deploy-to-ubuntu.md
+++ b/docs/deploy-to-ubuntu.md
@@ -4,7 +4,7 @@ You can use Algo to configure a local server as an AlgoVPN rather than create an
 
 Install the Algo scripts on your server and follow the normal installation instructions, then choose:
 ```
-Install to existing Ubuntu 18.04 server (Advanced)
+Install to existing Ubuntu 18.04 or 19.04 server (Advanced)
 ```
 Make sure your server is running the operating system specified.
 

--- a/docs/deploy-to-unsupported-cloud.md
+++ b/docs/deploy-to-unsupported-cloud.md
@@ -2,7 +2,7 @@
 
 Algo officially supports DigitalOcean, Amazon Web Services, Microsoft Azure, and Google Cloud Engine. If you want to deploy Algo on another virtual hosting provider, that provider must support:
 
-1. the base operating system image that Algo uses (Ubuntu 18.04), and
+1. the base operating system image that Algo uses (Ubuntu 18.04, 19.04), and
 2. a minimum of certain kernel modules required for the strongSwan IPsec server.
 
 Please see the [Required Kernel Modules](https://wiki.strongswan.org/projects/strongswan/wiki/KernelModules) documentation from strongSwan for a list of the specific required modules and a script to check for them. As a first step, we recommend running their shell script to determine initial compatibility with your new hosting provider.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@
   - Configure [Vultr](cloud-vultr.md)
 * Advanced Deployment
   - Deploy to your own [FreeBSD](deploy-to-freebsd.md) server
-  - Deploy to your own [Ubuntu 18.04](deploy-to-ubuntu.md) server
+  - Deploy to your own [Ubuntu](deploy-to-ubuntu.md) server
   - Deploy to an [unsupported cloud provider](deploy-to-unsupported-cloud.md)
 * [FAQ](faq.md)
 * [Firewalls](firewalls.md)

--- a/input.yml
+++ b/input.yml
@@ -20,7 +20,7 @@
       - { name: Google Compute Engine, alias: gce }
       - { name: Scaleway, alias: scaleway}
       - { name: OpenStack (DreamCompute optimised), alias: openstack }
-      - { name: Install to existing Ubuntu 18.04 server (Advanced), alias: local }
+      - { name: Install to existing Ubuntu 18.04 or 19.04 server (Advanced), alias: local }
   vars_files:
     - config.cfg
 

--- a/roles/dns_encryption/files/apparmor.profile.dnscrypt-proxy
+++ b/roles/dns_encryption/files/apparmor.profile.dnscrypt-proxy
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-/usr/bin/dnscrypt-proxy flags=(attach_disconnected) {
+/usr/{s,}bin/dnscrypt-proxy flags=(attach_disconnected) {
   #include <abstractions/base>
   #include <abstractions/nameservice>
   #include <abstractions/openssl>

--- a/roles/dns_encryption/tasks/ubuntu.yml
+++ b/roles/dns_encryption/tasks/ubuntu.yml
@@ -2,8 +2,9 @@
 - name: Add the repository
   apt_repository:
     state: present
-    codename: bionic
+    codename: "{{ ansible_distribution_release }}"
     repo: ppa:shevchuk/dnscrypt-proxy
+  when: ansible_distribution_version is version_compare('19.04', '<')
   register: result
   until: result is succeeded
   retries: 10

--- a/roles/strongswan/tasks/ubuntu.yml
+++ b/roles/strongswan/tasks/ubuntu.yml
@@ -10,17 +10,26 @@
     update_cache: yes
     install_recommends: yes
 
-- name: Ubuntu | Enforcing ipsec with apparmor
-  command: aa-enforce "{{ item }}"
+- block:
+  # https://bugs.launchpad.net/ubuntu/+source/strongswan/+bug/1826238
+  - name: Ubuntu | Charon profile for apparmor configured
+    copy:
+      dest: /etc/apparmor.d/local/usr.lib.ipsec.charon
+      content: ' capability setpcap,'
+      owner: root
+      group: root
+      mode: 0644
+    notify: restart strongswan
+
+  - name: Ubuntu | Enforcing ipsec with apparmor
+    command: aa-enforce "{{ item }}"
+    changed_when: false
+    with_items:
+      - /usr/lib/ipsec/charon
+      - /usr/lib/ipsec/lookip
+      - /usr/lib/ipsec/stroke
+  tags: apparmor
   when: apparmor_enabled|default(false)|bool
-  changed_when: false
-  with_items:
-    - /usr/lib/ipsec/charon
-    - /usr/lib/ipsec/lookip
-    - /usr/lib/ipsec/stroke
-  notify:
-    - restart apparmor
-  tags: ['apparmor']
 
 - name: Ubuntu | Enable services
   service: name={{ item }} enabled=yes

--- a/tests/pre-deploy.sh
+++ b/tests/pre-deploy.sh
@@ -19,7 +19,7 @@ systemctl restart lxd-bridge.service lxd-containers.service lxd.service
 lxc profile set default raw.lxc lxc.aa_profile=unconfined
 lxc profile set default security.privileged true
 lxc profile show default
-lxc launch ubuntu:18.04 algo
+lxc launch ubuntu:${UBUNTU_VERSION} algo
 
 ip addr
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move some providers to Ubuntu 19.04 by default:
- DigitalOcean
- EC2
- GCE
- Azure
- Vultr

## Motivation and Context
A new Ubuntu release 19.04 (Disco Dingo) recently came out with updated StrongSwan version (5.7.1) where many of [bugs](https://wiki.strongswan.org/versions/69), [vulnerabilities](https://wiki.strongswan.org/versions/70) and security [issues](https://wiki.strongswan.org/versions/71) fixed. Although not all providers currently support 19.04, the effort required on our end to support both versions is minimal. Dnscrypt-proxy is now included in the standard ubuntu repositories. Also, we provide a modified apparmor profile for charon because of a [bug](https://bugs.launchpad.net/ubuntu/+source/strongswan/+bug/1826238)


## How Has This Been Tested?
Deployed to the providers above on both 18.04 and 19.04 + TravisCI tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
