### PR TITLE
Add IPv6 support to DNS

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -122,7 +122,7 @@ congrats:
     "#    Config files and certificates are in the ./configs/ directory.    #"
     "#              Go to https://whoer.net/ after connecting               #"
     "#        and ensure that all your traffic passes through the VPN.      #"
-    "#                     Local DNS resolver {{ local_service_ip }}                    #"
+    "#                     Local DNS resolver {{ local_service_ip }}{{ ', ' + {{ local_service_ipv6 }}  if ipv6_support else '' }}                   #"
   p12_pass: |
     "#        The p12 and SSH keys password for new users is {{ p12_export_password }}       #"
   ca_key_pass: |

--- a/config.cfg
+++ b/config.cfg
@@ -122,7 +122,7 @@ congrats:
     "#    Config files and certificates are in the ./configs/ directory.    #"
     "#              Go to https://whoer.net/ after connecting               #"
     "#        and ensure that all your traffic passes through the VPN.      #"
-    "#                     Local DNS resolver {{ local_service_ip }}{{ ', ' + {{ local_service_ipv6 }}  if ipv6_support else '' }}                   #"
+    "#                     Local DNS resolver {{ local_service_ip }}{{ ', ' + local_service_ipv6 if ipv6_support else '' }}                   #"
   p12_pass: |
     "#        The p12 and SSH keys password for new users is {{ p12_export_password }}       #"
   ca_key_pass: |

--- a/roles/dns_adblocking/templates/dnsmasq.conf.j2
+++ b/roles/dns_adblocking/templates/dnsmasq.conf.j2
@@ -91,7 +91,7 @@ no-resolv
 {% if dns_encryption %}
 server={{ local_service_ip }}#5353
 {% if ipv6_support -%}
-server=FCAA::1#5353
+server={{ local_service_ipv6 }}#5353
 {% endif %}
 {% else %}
 {% for host in dns_servers.ipv4 %}

--- a/roles/dns_adblocking/templates/dnsmasq.conf.j2
+++ b/roles/dns_adblocking/templates/dnsmasq.conf.j2
@@ -90,6 +90,9 @@ no-resolv
 # server=10.1.2.3@eth1
 {% if dns_encryption %}
 server={{ local_service_ip }}#5353
+{% if ipv6_support -%}
+server=FCAA::1#5353
+{% endif %}
 {% else %}
 {% for host in dns_servers.ipv4 %}
 server={{ host }}

--- a/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
+++ b/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
@@ -37,7 +37,7 @@
 ## List of local addresses and ports to listen to. Can be IPv4 and/or IPv6.
 ## Note: When using systemd socket activation, choose an empty set (i.e. [] ).
 
-listen_addresses  = ['{{ local_service_ip }}:{{ listen_port }}']
+listen_addresses  = ['{{ local_service_ip }}:{{ listen_port }}'{% if ipv6_support %}, '[FCAA::1]:{{ listen_port }}'{% endif %}]
 
 
 ## Maximum number of simultaneous client connections to accept

--- a/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
+++ b/roles/dns_encryption/templates/dnscrypt-proxy.toml.j2
@@ -37,7 +37,7 @@
 ## List of local addresses and ports to listen to. Can be IPv4 and/or IPv6.
 ## Note: When using systemd socket activation, choose an empty set (i.e. [] ).
 
-listen_addresses  = ['{{ local_service_ip }}:{{ listen_port }}'{% if ipv6_support %}, '[FCAA::1]:{{ listen_port }}'{% endif %}]
+listen_addresses  = ['{{ local_service_ip }}:{{ listen_port }}'{% if ipv6_support %}, '[{{ local_service_ipv6 }}]:{{ listen_port }}'{% endif %}]
 
 
 ## Maximum number of simultaneous client connections to accept

--- a/roles/strongswan/templates/ipsec.conf.j2
+++ b/roles/strongswan/templates/ipsec.conf.j2
@@ -31,7 +31,7 @@ conn %default
     rightauth=pubkey
     rightsourceip={{ strongswan_network }},{{ strongswan_network_ipv6 }}
 {% if algo_local_dns or dns_encryption %}
-    rightdns={{ local_service_ip }}{{ ",FCAA::1"  if ipv6_support else '' }}
+    rightdns={{ local_service_ip }}{{ ',' + {{ local_service_ipv6 }}  if ipv6_support else '' }}
 {% else %}
     rightdns={% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {% endif %}

--- a/roles/strongswan/templates/ipsec.conf.j2
+++ b/roles/strongswan/templates/ipsec.conf.j2
@@ -31,7 +31,7 @@ conn %default
     rightauth=pubkey
     rightsourceip={{ strongswan_network }},{{ strongswan_network_ipv6 }}
 {% if algo_local_dns or dns_encryption %}
-    rightdns={{ local_service_ip }}{{ ',' + {{ local_service_ipv6 }}  if ipv6_support else '' }}
+    rightdns={{ local_service_ip }}{{ ',' + local_service_ipv6 if ipv6_support else '' }}
 {% else %}
     rightdns={% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {% endif %}

--- a/roles/strongswan/templates/ipsec.conf.j2
+++ b/roles/strongswan/templates/ipsec.conf.j2
@@ -31,7 +31,7 @@ conn %default
     rightauth=pubkey
     rightsourceip={{ strongswan_network }},{{ strongswan_network_ipv6 }}
 {% if algo_local_dns or dns_encryption %}
-    rightdns={{ local_service_ip }}
+    rightdns={{ local_service_ip }}{{ ",FCAA::1"  if ipv6_support else '' }}
 {% else %}
     rightdns={% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 {% endif %}

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -6,7 +6,7 @@ wireguard_interface: wg0
 keys_clean_all: false
 wireguard_dns_servers: >-
   {% if local_dns|default(false)|bool or dns_encryption|default(false)|bool %}
-  {{ local_service_ip }}{{ ', ' + {{ local_service_ipv6 }} if ipv6_support else '' }}
+  {{ local_service_ip }}{{ ', ' + local_service_ipv6 if ipv6_support else '' }}
   {% else %}
   {% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
   {% endif %}

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -6,7 +6,7 @@ wireguard_interface: wg0
 keys_clean_all: false
 wireguard_dns_servers: >-
   {% if local_dns|default(false)|bool or dns_encryption|default(false)|bool %}
-  {{ local_service_ip }}
+  {{ local_service_ip }}{{ ", FCAA::1"  if ipv6_support else '' }}
   {% else %}
   {% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
   {% endif %}

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -6,7 +6,7 @@ wireguard_interface: wg0
 keys_clean_all: false
 wireguard_dns_servers: >-
   {% if local_dns|default(false)|bool or dns_encryption|default(false)|bool %}
-  {{ local_service_ip }}{{ ", FCAA::1"  if ipv6_support else '' }}
+  {{ local_service_ip }}{{ ', ' + {{ local_service_ipv6 }} if ipv6_support else '' }}
   {% else %}
   {% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
   {% endif %}


### PR DESCRIPTION
## Description
While the entire system tests for and uses ipv6, it doesn't take advantage of it for dns encryption or dnsmasq. This adds a test a few areas of configuration to see if it should include FCAA::1 as an option.

## Motivation and Context
In my testing, IPv6 has been a touch faster as a listen address in dnscrypt-proxy for systems with the support.

## How Has This Been Tested?
Built and ran on GCE vs EC2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
