### PR TITLE
Randomly generated IP address for the local dns resolver

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -100,8 +100,17 @@ dns_servers:
     - 2606:4700:4700::1111
     - 2606:4700:4700::1001
 
-# IP address for the local dns resolver
-local_service_ip: 172.16.0.1
+# Randomly generated IP address for the local dns resolver
+local_service_ip: >-
+  10.
+  {{- 255 | random(seed=algo_server_name + ansible_fqdn + 'second') }}.
+  {{- 255 | random(seed=algo_server_name + ansible_fqdn + 'third') }}.
+  {{- 255 | random(seed=algo_server_name + ansible_fqdn + 'fourth') }}
+local_service_ipv6: >-
+  FD{{ 99 | random(seed=algo_server_name + ansible_fqdn + 'first') }}:
+  {{- 9999 | random(seed=algo_server_name + ansible_fqdn + 'second') }}:
+  {{- 9999 | random(seed=algo_server_name + ansible_fqdn + 'third') }}:
+  {{- 9999 | random(seed=algo_server_name + ansible_fqdn + 'fourth') }}::1
 
 # Your Algo server will automatically install security updates. Some updates
 # require a reboot to take effect but your Algo server will not reboot itself

--- a/config.cfg
+++ b/config.cfg
@@ -40,20 +40,8 @@ wireguard_port: 51820
 wireguard_PersistentKeepalive: 0
 
 # WireGuard network configuration
-_wireguard_network_ipv4:
-  subnet: 10.19.49.0
-  prefix: 24
-  gateway: 10.19.49.1
-  clients_range: 10.19.49
-  clients_start: 2
-_wireguard_network_ipv6:
-  subnet: 'fd9d:bc11:4021::'
-  prefix: 48
-  gateway: 'fd9d:bc11:4021::1'
-  clients_range: 'fd9d:bc11:4021::'
-  clients_start: 2
-wireguard_network_ipv4: "{{ _wireguard_network_ipv4['subnet'] }}/{{ _wireguard_network_ipv4['prefix'] }}"
-wireguard_network_ipv6: "{{ _wireguard_network_ipv6['subnet'] }}/{{ _wireguard_network_ipv6['prefix'] }}"
+wireguard_network_ipv4: 10.19.49.0/24
+wireguard_network_ipv6: fd9d:bc11:4021::/48
 
 # Reduce the MTU of the VPN tunnel
 # Some cloud and internet providers use a smaller MTU (Maximum Transmission
@@ -101,16 +89,8 @@ dns_servers:
     - 2606:4700:4700::1001
 
 # Randomly generated IP address for the local dns resolver
-local_service_ip: >-
-  10.
-  {{- 255 | random(start=20, seed=algo_server_name + ansible_fqdn + 'second') }}.
-  {{- 255 | random(seed=algo_server_name + ansible_fqdn + 'third') }}.
-  {{- 255 | random(seed=algo_server_name + ansible_fqdn + 'fourth') }}
-local_service_ipv6: >-
-  FD{{ 99 | random(seed=algo_server_name + ansible_fqdn + 'first') }}:
-  {{- 9999 | random(seed=algo_server_name + ansible_fqdn + 'second') }}:
-  {{- 9999 | random(seed=algo_server_name + ansible_fqdn + 'third') }}:
-  {{- 9999 | random(seed=algo_server_name + ansible_fqdn + 'fourth') }}::1
+local_service_ip: "{{ '172.16.0.1' | ipmath(1048573 | random(seed=algo_server_name + ansible_fqdn)) }}"
+local_service_ipv6: "{{ 'fd00::1' | ipmath(1048573 | random(seed=algo_server_name + ansible_fqdn)) }}"
 
 # Your Algo server will automatically install security updates. Some updates
 # require a reboot to take effect but your Algo server will not reboot itself

--- a/config.cfg
+++ b/config.cfg
@@ -103,7 +103,7 @@ dns_servers:
 # Randomly generated IP address for the local dns resolver
 local_service_ip: >-
   10.
-  {{- 255 | random(seed=algo_server_name + ansible_fqdn + 'second') }}.
+  {{- 255 | random(start=20, seed=algo_server_name + ansible_fqdn + 'second') }}.
   {{- 255 | random(seed=algo_server_name + ansible_fqdn + 'third') }}.
   {{- 255 | random(seed=algo_server_name + ansible_fqdn + 'fourth') }}
 local_service_ipv6: >-

--- a/docs/client-linux-wireguard.md
+++ b/docs/client-linux-wireguard.md
@@ -9,7 +9,7 @@ To connect to your AlgoVPN using [WireGuard](https://www.wireguard.com) from Ubu
 sudo add-apt-repository ppa:wireguard/wireguard
 
 # Update the list of available packages (not necessary on Bionic or later):
-sudo apt update 
+sudo apt update
 
 # Install the tools and kernel module:
 sudo apt install wireguard
@@ -27,9 +27,9 @@ The Algo-generated config files for WireGuard are named `configs/<ip_address>/wi
 
 If your client is running Bionic (or another Linux that uses `systemd-resolved` for DNS but does not have `resolvectl` or `resolvconf` installed) you should first edit the config file. Comment out the line that begins with `DNS =` and replace it with:
 ```
-PostUp = systemd-resolve -i %i --set-dns=172.16.0.1 --set-domain=~.
+PostUp = systemd-resolve -i %i --set-dns=<ip_address> --set-domain=~.
 ```
-Use the IP address shown on the `DNS =` line (for most, this will be `172.16.0.1`). If the `DNS =` line contains multiple IP addresses, use multiple  `--set-dns=` options.
+Use the IP address shown on the `DNS =` line (it's randomly generated for each deployment). If the `DNS =` line contains multiple IP addresses, use multiple  `--set-dns=` options.
 
 ### Ubuntu 18.10 (Cosmic) or 19.04 (Disco)
 

--- a/docs/client-linux-wireguard.md
+++ b/docs/client-linux-wireguard.md
@@ -1,18 +1,18 @@
-# Using Ubuntu Server as a Client with WireGuard
+# Using Ubuntu as a Client with WireGuard
 
 ## Install WireGuard
 
-To connect to your AlgoVPN using [WireGuard](https://www.wireguard.com) from Ubuntu Server, first install WireGuard:
+To connect to your AlgoVPN using [WireGuard](https://www.wireguard.com) from Ubuntu, first install WireGuard:
 
 ```shell
 # Add the WireGuard repository:
 sudo add-apt-repository ppa:wireguard/wireguard
 
-# Update the list of available packages (not necessary on Bionic or later):
+# Update the list of available packages (not necessary on 18.04 or later):
 sudo apt update
 
 # Install the tools and kernel module:
-sudo apt install wireguard
+sudo apt install wireguard openresolv
 ```
 
 For installation on other Linux distributions, see the [Installation](https://www.wireguard.com/install/) page on the WireGuard site.
@@ -20,28 +20,6 @@ For installation on other Linux distributions, see the [Installation](https://ww
 ## Locate the Config File
 
 The Algo-generated config files for WireGuard are named `configs/<ip_address>/wireguard/<username>.conf` on the system where you ran `./algo`. One file was generated for each of the users you added to `config.cfg`. Each WireGuard client you connect to your AlgoVPN must use a different config file. Choose one of these files and copy it to your Linux client.
-
-## Configure DNS
-
-### Ubuntu 18.04 (Bionic)
-
-If your client is running Bionic (or another Linux that uses `systemd-resolved` for DNS but does not have `resolvectl` or `resolvconf` installed) you should first edit the config file. Comment out the line that begins with `DNS =` and replace it with:
-```
-PostUp = systemd-resolve -i %i --set-dns=<ip_address> --set-domain=~.
-```
-Use the IP address shown on the `DNS =` line (it's randomly generated for each deployment). If the `DNS =` line contains multiple IP addresses, use multiple  `--set-dns=` options.
-
-### Ubuntu 18.10 (Cosmic) or 19.04 (Disco)
-
-If your client is running Cosmic or Disco (or another Linux that uses `systemd-resolved` for DNS and has `resolvectl` but *not* `resolvconf` installed) you can either edit the config file as shown above for Bionic or run the following command once:
-
-```
-sudo ln -s /usr/bin/resolvectl /usr/bin/resolvconf
-```
-
-### Other Linux Distributions
-
-On other Linux distributions you might need to install the `openresolv` package.
 
 ## Configure WireGuard
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,7 +50,7 @@ Algo is short for "Al Gore", the **V**ice **P**resident of **N**etworks everywhe
 
 ## Can DNS filtering be disabled?
 
-You can temporarily disable DNS filtering for all IPsec clients at once with the following workaround: SSH to your Algo server (using the 'shell access' command printed upon a successful deployment), edit `/etc/ipsec.conf`, and change `rightdns=172.16.0.1` to `rightdns=8.8.8.8`. Then run `sudo systemctl restart strongswan`. DNS filtering for Wireguard clients has to be disabled on each client device separately by modifying the settings in the app, or by directly modifying the `DNS` setting on the `clientname.conf` file. If all else fails, we recommend deploying a new Algo server without the adblocking feature enabled.
+You can temporarily disable DNS filtering for all IPsec clients at once with the following workaround: SSH to your Algo server (using the 'shell access' command printed upon a successful deployment), edit `/etc/ipsec.conf`, and change `rightdns=<random_ip>` to `rightdns=8.8.8.8`. Then run `sudo systemctl restart strongswan`. DNS filtering for Wireguard clients has to be disabled on each client device separately by modifying the settings in the app, or by directly modifying the `DNS` setting on the `clientname.conf` file. If all else fails, we recommend deploying a new Algo server without the adblocking feature enabled.
 
 ## Wasn't IPSEC backdoored by the US government?
 

--- a/main.yml
+++ b/main.yml
@@ -2,11 +2,19 @@
 - hosts: localhost
   become: false
   tasks:
-    - name: Verify Ansible meets Drupal VM's version requirements.
+    - name: Ensure the requirements installed
+      debug:
+        msg: "{{ '' | ipaddr }}"
+      ignore_errors: true
+      no_log: true
+      register: ipaddr
+
+    - name: Verify Ansible meets Algo VPN requirements.
       assert:
-        that: "ansible_version.full is version('2.7.10', '==')"
+        that:
+          - ansible_version.full is version('2.7.10', '==')
+          - not ipaddr.failed
         msg: >
-          Ansible version is {{ ansible_version.full }}.
           You must update the requirements to use this version of Algo.
           Try to run python -m pip install -U -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ansible==2.7.10
+netaddr

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -18,7 +18,7 @@
     ifconfig lo100 destroy || true &&
     ifconfig lo100 create &&
     ifconfig lo100 inet {{ local_service_ip }} netmask 255.255.255.255 &&
-    ifconfig lo100 inet6 FCAA::1/64; echo $?
+    ifconfig lo100 inet6 {{ local_service_ipv6 }}/128; echo $?
 
 - name: restart iptables
   service: name=netfilter-persistent state=restarted

--- a/roles/common/tasks/freebsd.yml
+++ b/roles/common/tasks/freebsd.yml
@@ -54,7 +54,7 @@
     block: |
       cloned_interfaces="lo100"
       ifconfig_lo100="inet {{ local_service_ip }} netmask 255.255.255.255"
-      ifconfig_lo100_ipv6="inet6 FCAA::1/64"
+      ifconfig_lo100_ipv6="inet6 {{ local_service_ipv6 }}/128"
   notify:
     - restart loopback bsd
 

--- a/roles/common/templates/10-algo-lo100.network.j2
+++ b/roles/common/templates/10-algo-lo100.network.j2
@@ -4,4 +4,4 @@ Name=lo
 [Network]
 Description=lo:100
 Address={{ local_service_ip }}/32
-Address=FCAA::1/64
+Address={{ local_service_ipv6 }}/128

--- a/roles/common/templates/rules.v6.j2
+++ b/roles/common/templates/rules.v6.j2
@@ -83,7 +83,7 @@ COMMIT
 # particular virtual (tun,tap,...) or physical (ethernet) interface.
 
 # Accept DNS traffic to the local DNS resolver
--A INPUT -d fcaa::1 -p udp --dport 53 -j ACCEPT
+-A INPUT -d {{ local_service_ipv6 }}/128 -p udp --dport 53 -j ACCEPT
 
 # Drop traffic between VPN clients
 -A FORWARD -s {{ subnets|join(',') }} -d {{ subnets|join(',') }} -j {{ "DROP" if BetweenClients_DROP else "ACCEPT" }}

--- a/roles/dns_adblocking/templates/dnsmasq.conf.j2
+++ b/roles/dns_adblocking/templates/dnsmasq.conf.j2
@@ -116,7 +116,7 @@ group=nogroup
 #except-interface=
 # Or which to listen on by address (remember to include 127.0.0.1 if
 # you use this.)
-listen-address=127.0.0.1,FCAA::1,{{ local_service_ip }}
+listen-address=127.0.0.1,{{ local_service_ipv6 }},{{ local_service_ip }}
 # If you want dnsmasq to provide only DNS service on an interface,
 # configure it as shown above, and then use the following line to
 # disable DHCP and TFTP on it.

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -10,5 +10,9 @@ wireguard_dns_servers: >-
   {% else %}
   {% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
   {% endif %}
-wireguard_client_ip: "{{ _wireguard_network_ipv4['clients_range'] }}.{{ _wireguard_network_ipv4['clients_start'] + index|int + 1 }}/{{ _wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ _wireguard_network_ipv6['clients_range'] }}{{ _wireguard_network_ipv6['clients_start'] + index|int + 1 }}/{{ _wireguard_network_ipv6['prefix'] }}{% endif %}"
-wireguard_server_ip: "{{ _wireguard_network_ipv4['gateway'] }}/{{ _wireguard_network_ipv4['prefix'] }}{% if ipv6_support %},{{ _wireguard_network_ipv6['gateway'] }}/{{ _wireguard_network_ipv6['prefix'] }}{% endif %}"
+wireguard_client_ip: >-
+  {{ wireguard_network_ipv4 | ipaddr(index|int+2) }}
+  {{ ',' + wireguard_network_ipv6 | ipaddr(index|int+2) if ipv6_support else '' }}
+wireguard_server_ip: >-
+  {{ wireguard_network_ipv4 | ipaddr('1') }}
+  {{ ',' + wireguard_network_ipv6 | ipaddr('1') if ipv6_support else '' }}

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -11,6 +11,6 @@ SaveConfig = false
 [Peer]
 # {{ u }}
 PublicKey = {{ lookup('file', wireguard_pki_path + '/public/' + u) }}
-AllowedIPs = {{ wireguard_network_ipv4 | ipaddr(index|int+1) }}{{ ',' + wireguard_network_ipv6 | ipaddr(index) if ipv6_support else '' }}
+AllowedIPs = {{ wireguard_network_ipv4 | ipaddr(index|int+1) | ipv4('address') }}/32{{ ',' + wireguard_network_ipv6 | ipaddr(index) | ipv6('address') + '/128' if ipv6_support else '' }}
 {% endif %}
 {% endfor %}

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -11,7 +11,6 @@ SaveConfig = false
 [Peer]
 # {{ u }}
 PublicKey = {{ lookup('file', wireguard_pki_path + '/public/' + u) }}
-AllowedIPs = {{ _wireguard_network_ipv4['clients_range'] }}.{{ _wireguard_network_ipv4['clients_start'] + index }}/32{% if ipv6_support %},{{ _wireguard_network_ipv6['clients_range'] }}{{ _wireguard_network_ipv6['clients_start'] + index }}/128{% endif %}
-
+AllowedIPs = {{ wireguard_network_ipv4 | ipaddr(index|int+1) }}{{ ',' + wireguard_network_ipv6 | ipaddr(index) if ipv6_support else '' }}
 {% endif %}
 {% endfor %}

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -11,6 +11,6 @@ SaveConfig = false
 [Peer]
 # {{ u }}
 PublicKey = {{ lookup('file', wireguard_pki_path + '/public/' + u) }}
-AllowedIPs = {{ wireguard_network_ipv4 | ipaddr(index|int+1) | ipv4('address') }}/32{{ ',' + wireguard_network_ipv6 | ipaddr(index) | ipv6('address') + '/128' if ipv6_support else '' }}
+AllowedIPs = {{ wireguard_network_ipv4 | ipaddr(index|int+1) | ipv4('address') }}/32{{ ',' + wireguard_network_ipv6 | ipaddr(index|int+1) | ipv6('address') + '/128' if ipv6_support else '' }}
 {% endif %}
 {% endfor %}

--- a/tests/cloud-init.sh
+++ b/tests/cloud-init.sh
@@ -10,7 +10,7 @@ export LOCAL_DNS=true
 export SSH_TUNNELING=true
 export ENDPOINT=10.0.8.100
 export USERS=desktop,user1,user2
-export EXTRA_VARS='install_headers=false tests=true apparmor_enabled=false'
+export EXTRA_VARS='install_headers=false tests=true apparmor_enabled=false local_service_ip=172.16.0.1'
 export ANSIBLE_EXTRA_ARGS='--skip-tags apparmor'
 export REPO_SLUG=${TRAVIS_PULL_REQUEST_SLUG:-${TRAVIS_REPO_SLUG:-trailofbits/algo}}
 export REPO_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH:-master}}

--- a/tests/ipsec-client.sh
+++ b/tests/ipsec-client.sh
@@ -21,3 +21,5 @@ fping -t 900 -c3 -r3 -Dse 10.0.8.100 172.16.0.1
 host google.com 172.16.0.1
 
 echo "IPsec tests passed"
+
+ipsec down algovpn-10.0.8.100

--- a/tests/local-deploy.sh
+++ b/tests/local-deploy.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-DEPLOY_ARGS="provider=local server=10.0.8.100 ssh_user=ubuntu endpoint=10.0.8.100 apparmor_enabled=false ondemand_cellular=true ondemand_wifi=true ondemand_wifi_exclude=test local_dns=true ssh_tunneling=true windows=true store_cakey=true install_headers=false tests=true"
+DEPLOY_ARGS="provider=local server=10.0.8.100 ssh_user=ubuntu endpoint=10.0.8.100 apparmor_enabled=false ondemand_cellular=true ondemand_wifi=true ondemand_wifi_exclude=test local_dns=true ssh_tunneling=true windows=true store_cakey=true install_headers=false tests=true local_service_ip=172.16.0.1"
 
 if [ "${DEPLOY}" == "docker" ]
 then

--- a/tests/update-users.sh
+++ b/tests/update-users.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-USER_ARGS="{ 'server': '10.0.8.100', 'users': ['desktop', 'user1', 'user2'] }"
+USER_ARGS="{ 'server': '10.0.8.100', 'users': ['desktop', 'user1', 'user2'], 'local_service_ip': '172.16.0.1' }"
 
 if [ "${DEPLOY}" == "docker" ]
 then

--- a/tests/wireguard-client.sh
+++ b/tests/wireguard-client.sh
@@ -19,3 +19,5 @@ wg | grep "latest handshake"
 host google.com 172.16.0.1
 
 echo "WireGuard tests passed"
+
+wg-quick down user1

--- a/tests/wireguard-client.sh
+++ b/tests/wireguard-client.sh
@@ -20,4 +20,4 @@ host google.com 172.16.0.1
 
 echo "WireGuard tests passed"
 
-wg-quick down user1
+wg-quick down configs/10.0.8.100/wireguard/user1.conf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We need to generate a random service IP for each deployment in order to avoid DNS leaking (see #1422)

## Motivation and Context
- fixes #1422
- eliminates complexity of assigning IPs for WireGuard

## How Has This Been Tested?
Deployed to EC2 and digitalocean

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] All new and existing tests passed.
