### PR TITLE
Update users: add server pick-list

### DIFF
--- a/users.yml
+++ b/users.yml
@@ -16,16 +16,24 @@
             patterns: ".config.yml"
           register: _configs_list
 
+        - name: Verify servers
+          assert:
+            that: _configs_list.matched > 0
+            msg: No servers found, nothing to update.
+
         - name: Build string of installed servers
           set_fact:
-            server_list: "{% if server_list is defined %}{{ server_list }},{% endif %}{{ item.path|replace('configs/','')|replace('/.config.yml','') }}"
-          with_items: "{{ _configs_list.files }}"
+            server_list: >-
+              [{% for i in _configs_list.files %}
+                '{{ i.path.split('/')[1] }}'
+                {{ ',' if not loop.last else '' }}
+              {% endfor %}]
 
         - name: Server address prompt
           pause:
             prompt: |
               Select the server to update user list below:
-                {% for r in server_list.split(',') %}
+                {% for r in server_list %}
                 {{ loop.index }}. {{ r }}
                 {% endfor %}
           register: _server
@@ -36,7 +44,7 @@
           set_fact:
             algo_server: >-
               {% if server is defined %}{{ server }}
-              {%- elif _server.user_input %}{{ server_list.split(',')[_server.user_input | int -1 ] }}
+              {%- elif _server.user_input %}{{ server_list[_server.user_input | int -1 ] }}
               {%- else %}omit{% endif %}
 
         - name: Import host specific variables

--- a/users.yml
+++ b/users.yml
@@ -21,7 +21,7 @@
             that: _configs_list.matched > 0
             msg: No servers found, nothing to update.
 
-        - name: Build string of installed servers
+        - name: Build list of installed servers
           set_fact:
             server_list: >-
               [{% for i in _configs_list.files %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When updating users, you no longer have to type out the entire IP address or domain name (or 'localhost') of the Algo server that you deployed and want to update. This might also be helpful if you've deployed multiple Algo servers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1438. Typing a whole IP address is hard. Cutting-and-pasting is also hard. Typing a number is easy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Numerous runs of `ansible-playbook users.yml`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.