### PR TITLE
Don't set CA facts if IPsec is disabled

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -114,7 +114,7 @@ congrats:
   p12_pass: |
     "#        The p12 and SSH keys password for new users is {{ p12_export_password }}       #"
   ca_key_pass: |
-    "#        The CA key password is {{ CA_password }}       #"
+    "#        The CA key password is {{ CA_password|default(omit) }}       #"
   ssh_access: |
     "#      Shell access: ssh -i {{ ansible_ssh_private_key_file|default(omit) }} {{ ansible_ssh_user|default(omit) }}@{{ ansible_ssh_host|default(omit) }}        #"
 

--- a/users.yml
+++ b/users.yml
@@ -25,7 +25,8 @@
           set_fact:
             server_list: >-
               [{% for i in _configs_list.files %}
-                '{{ i.path.split('/')[1] }}'
+                {% set config  = lookup('file', i.path)|from_yaml %}
+                '{{ config.server }}'
                 {{ ',' if not loop.last else '' }}
               {% endfor %}]
 
@@ -111,7 +112,9 @@
       - debug:
           msg:
             - "{{ congrats.common.split('\n') }}"
-            - "    {% if p12.changed %}{{ congrats.p12_pass }}{% endif %}"
+            - "    {{ congrats.p12_pass if algo_ssh_tunneling or ipsec_enabled else '' }}"
+            - "    {{ congrats.ca_key_pass if algo_store_cakey and ipsec_enabled else '' }}"
+            - "    {{ congrats.ssh_access if algo_provider != 'local' else ''}}"
         tags: always
       rescue:
         - include_tasks: playbooks/rescue.yml

--- a/users.yml
+++ b/users.yml
@@ -51,21 +51,21 @@
           include_vars:
             file: "configs/{{ algo_server }}/.config.yml"
 
-        - name: CA password prompt
-          pause:
-            prompt: Enter the password for the private CA key
-            echo: false
-          register: _ca_password
-          when:
-            - ca_password is undefined
-            - ipsec_enabled
+        - when: ipsec_enabled
+          block:
+          - name: CA password prompt
+            pause:
+              prompt: Enter the password for the private CA key
+              echo: false
+            register: _ca_password
+            when: ca_password is undefined
 
-        - name: Set facts based on the input
-          set_fact:
-            CA_password: >-
-              {% if ca_password is defined %}{{ ca_password }}
-              {%- elif _ca_password.user_input %}{{ _ca_password.user_input }}
-              {%- else %}omit{% endif %}
+          - name: Set facts based on the input
+            set_fact:
+              CA_password: >-
+                {% if ca_password is defined %}{{ ca_password }}
+                {%- elif _ca_password.user_input %}{{ _ca_password.user_input }}
+                {%- else %}omit{% endif %}
 
         - name: Local pre-tasks
           import_tasks: playbooks/cloud-pre.yml
@@ -78,7 +78,7 @@
             ansible_ssh_user: "{{ server_user|default('root') }}"
             ansible_connection: "{% if algo_server == 'localhost' %}local{% else %}ssh{% endif %}"
             ansible_python_interpreter: "/usr/bin/python3"
-            CA_password: "{{ CA_password }}"
+            CA_password: "{{ CA_password|default(omit) }}"
       rescue:
         - include_tasks: playbooks/rescue.yml
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We don't need to set the CA_password fact is ipsec is disabled

## Motivation and Context
Fixes #1444

## How Has This Been Tested?
Deployed without ipsec and updates users successfully 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All new and existing tests passed.
