### PR TITLE
Adding preshared key support

### DIFF
--- a/roles/wireguard/tasks/keys.yml
+++ b/roles/wireguard/tasks/keys.yml
@@ -1,16 +1,7 @@
 ---
-- name: Delete the private lock files
+- name: Delete the lock files
   file:
     dest: "{{ config_prefix|default('/') }}etc/wireguard/private_{{ item }}.lock"
-    state: absent
-  when: keys_clean_all|bool
-  with_items:
-    - "{{ users }}"
-    - "{{ IP_subject_alt_name }}"
-    
-- name: Delete the preshared lock files
-  file:
-    dest: "{{ config_prefix|default('/') }}etc/wireguard/preshared_{{ item }}.lock"
     state: absent
   when: keys_clean_all|bool
   with_items:
@@ -25,27 +16,16 @@
   with_items:
     - "{{ users }}"
     - "{{ IP_subject_alt_name }}"
-    
-- name: Generate preshared keys
-  command: wg genpsk
-  register: wg_genpsk
-  args:
-    creates: "{{ config_prefix|default('/') }}etc/wireguard/preshared_{{ item }}.lock"
-  with_items:
-    - "{{ users }}"
-    - "{{ IP_subject_alt_name }}"
 
 - block:
-  - name: Save keys
+  - name: Save private keys
     copy:
       dest: "{{ wireguard_pki_path }}/private/{{ item['item'] }}"
       content: "{{ item['stdout'] }}"
       mode: "0600"
     no_log: true
     when: item.changed
-    with_items:
-      - "{{ wg_genkey['results'] }}"
-      - "{{ wg_genpsk['results'] }}"
+    with_items: "{{ wg_genkey['results'] }}"
     delegate_to: localhost
     become: false
 
@@ -57,15 +37,45 @@
       - "{{ users }}"
       - "{{ IP_subject_alt_name }}"
   when: wg_genkey.changed
-  
-  - name: Touch the lock file
+
+- name: Delete the preshared lock files
+  file:
+    dest: "{{ config_prefix|default('/') }}etc/wireguard/preshared_{{ item }}.lock"
+    state: absent
+  when: keys_clean_all|bool
+  with_items:
+    - "{{ users }}"
+    - "{{ IP_subject_alt_name }}"
+
+- name: Generate preshared keys
+  command: wg genpsk
+  register: wg_genpsk
+  args:
+    creates: "{{ config_prefix|default('/') }}etc/wireguard/preshared_{{ item }}.lock"
+  with_items:
+    - "{{ users }}"
+    - "{{ IP_subject_alt_name }}"
+
+- block:
+  - name: Save private keys
+    copy:
+      dest: "{{ wireguard_pki_path }}/preshared/{{ item['item'] }}"
+      content: "{{ item['stdout'] }}"
+      mode: "0600"
+    no_log: true
+    when: item.changed
+    with_items: "{{ wg_genpsk['results'] }}"
+    delegate_to: localhost
+    become: false
+
+  - name: Touch the preshared lock file
     file:
       dest: "{{ config_prefix|default('/') }}etc/wireguard/preshared_{{ item }}.lock"
       state: touch
     with_items:
       - "{{ users }}"
       - "{{ IP_subject_alt_name }}"
-  when: wg_preshared.changed
+  when: wg_genpsk.changed
 
 - name: Generate public keys
   shell: |

--- a/roles/wireguard/tasks/keys.yml
+++ b/roles/wireguard/tasks/keys.yml
@@ -57,7 +57,7 @@
     - "{{ IP_subject_alt_name }}"
 
 - block:
-  - name: Save private keys
+  - name: Save preshared keys
     copy:
       dest: "{{ wireguard_pki_path }}/preshared/{{ item['item'] }}"
       content: "{{ item['stdout'] }}"

--- a/roles/wireguard/tasks/keys.yml
+++ b/roles/wireguard/tasks/keys.yml
@@ -1,7 +1,16 @@
 ---
-- name: Delete the lock files
+- name: Delete the private lock files
   file:
     dest: "{{ config_prefix|default('/') }}etc/wireguard/private_{{ item }}.lock"
+    state: absent
+  when: keys_clean_all|bool
+  with_items:
+    - "{{ users }}"
+    - "{{ IP_subject_alt_name }}"
+    
+- name: Delete the preshared lock files
+  file:
+    dest: "{{ config_prefix|default('/') }}etc/wireguard/preshared_{{ item }}.lock"
     state: absent
   when: keys_clean_all|bool
   with_items:
@@ -16,16 +25,27 @@
   with_items:
     - "{{ users }}"
     - "{{ IP_subject_alt_name }}"
+    
+- name: Generate preshared keys
+  command: wg genpsk
+  register: wg_genpsk
+  args:
+    creates: "{{ config_prefix|default('/') }}etc/wireguard/preshared_{{ item }}.lock"
+  with_items:
+    - "{{ users }}"
+    - "{{ IP_subject_alt_name }}"
 
 - block:
-  - name: Save private keys
+  - name: Save keys
     copy:
       dest: "{{ wireguard_pki_path }}/private/{{ item['item'] }}"
       content: "{{ item['stdout'] }}"
       mode: "0600"
     no_log: true
     when: item.changed
-    with_items: "{{ wg_genkey['results'] }}"
+    with_items:
+      - "{{ wg_genkey['results'] }}"
+      - "{{ wg_genpsk['results'] }}"
     delegate_to: localhost
     become: false
 
@@ -37,6 +57,15 @@
       - "{{ users }}"
       - "{{ IP_subject_alt_name }}"
   when: wg_genkey.changed
+  
+  - name: Touch the lock file
+    file:
+      dest: "{{ config_prefix|default('/') }}etc/wireguard/preshared_{{ item }}.lock"
+      state: touch
+    with_items:
+      - "{{ users }}"
+      - "{{ IP_subject_alt_name }}"
+  when: wg_preshared.changed
 
 - name: Generate public keys
   shell: |

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -7,6 +7,7 @@
   with_items:
     - private
     - public
+    - preshared
   delegate_to: localhost
   become: false
 

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -7,6 +7,7 @@ DNS = {{ wireguard_dns_servers }}
 
 [Peer]
 PublicKey = {{ lookup('file', wireguard_pki_path + '/public/' + IP_subject_alt_name) }}
+PresharedKey = {{ lookup('file', wireguard_pki_path + '/public/' + item.1) }}
 AllowedIPs = 0.0.0.0/0{{ ', ::/0'  if ipv6_support else '' }}
 Endpoint = {{ IP_subject_alt_name }}:{{ wireguard_port }}
 {{ 'PersistentKeepalive = ' + wireguard_PersistentKeepalive|string if wireguard_PersistentKeepalive > 0 else '' }}

--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -7,7 +7,7 @@ DNS = {{ wireguard_dns_servers }}
 
 [Peer]
 PublicKey = {{ lookup('file', wireguard_pki_path + '/public/' + IP_subject_alt_name) }}
-PresharedKey = {{ lookup('file', wireguard_pki_path + '/public/' + item.1) }}
+PresharedKey = {{ lookup('file', wireguard_pki_path + '/preshared/' + item.1) }}
 AllowedIPs = 0.0.0.0/0{{ ', ::/0'  if ipv6_support else '' }}
 Endpoint = {{ IP_subject_alt_name }}:{{ wireguard_port }}
 {{ 'PersistentKeepalive = ' + wireguard_PersistentKeepalive|string if wireguard_PersistentKeepalive > 0 else '' }}

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -11,6 +11,7 @@ SaveConfig = false
 [Peer]
 # {{ u }}
 PublicKey = {{ lookup('file', wireguard_pki_path + '/public/' + u) }}
+PresharedKey = {{ lookup('file', wireguard_pki_path + '/preshared/' + u) }}
 AllowedIPs = {{ wireguard_network_ipv4 | ipaddr(index|int+1) | ipv4('address') }}/32{{ ',' + wireguard_network_ipv6 | ipaddr(index|int+1) | ipv6('address') + '/128' if ipv6_support else '' }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Description
So I in this pull request I simply took the existing ansible code and extended it to include preshared key support for wireguard. This is what it says about preshared keys in the man page:
```
PresharedKey — a base64 preshared key generated by wg genpsk. Optional, and may be omitted. This option adds an additional layer of symmetric-key cryptography to be mixed into the already existing public-key cryptography, for post-quantum resistance.
```
so since it is as simple as adding a `wg genpsk` instead of `wg genkey` and adding it to the configs, and you are supposed to get an extra layer of encryption for pretty much nothing.

## Motivation and Context
the project touts that it
> It uses the most secure defaults available

and I never see any other tutorials mention about this feature at all. So I figured maybe you didn't know about it and though why not include a little more security for a minimal amount of effort. I just wanted to help out since I saw it didn't include it yet :smile: 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I ran it multiple times from a vagrant box image to a digital ocean vps: https://gist.github.com/elreydetoda/bac472aef59fc8d47145c4f25330187b#file-vagrantfile-elrey
<!--- Include details of your testing environment, tests ran to see how -->
simply ran `vagrant up` and then `./algo`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project. 
it is literally copied and pasted of what was already there.

I don't believe it needs documentation because it does this transparently to the user.