### PR TITLE
Adding ipv6 localhost to dnsmasq listen addresses

### DIFF
--- a/roles/dns_adblocking/templates/dnsmasq.conf.j2
+++ b/roles/dns_adblocking/templates/dnsmasq.conf.j2
@@ -119,7 +119,7 @@ group=nogroup
 #except-interface=
 # Or which to listen on by address (remember to include 127.0.0.1 if
 # you use this.)
-listen-address=127.0.0.1,{{ local_service_ipv6 }},{{ local_service_ip }}
+listen-address=127.0.0.1,::1,{{ local_service_ipv6 }},{{ local_service_ip }}
 # If you want dnsmasq to provide only DNS service on an interface,
 # configure it as shown above, and then use the following line to
 # disable DHCP and TFTP on it.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the ipv6 localhost address to the dnsmasq listen addresses

## Motivation and Context
In a conversation with @TC1977, there are occasional issues with ipv6 and adblocking. Currently, dnsmasq listens on both ipv4 and ipv6 custom listen addresses, but only the ipv4 localhost address. Adding the ipv6 localhost address may solve this issue.

## How Has This Been Tested?
Installed on EC2 with no ill effects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
