### PR TITLE
Changing adblock from local to server

### DIFF
--- a/roles/dns_adblocking/templates/adblock.sh.j2
+++ b/roles/dns_adblocking/templates/adblock.sh.j2
@@ -25,7 +25,7 @@ then
 fi
 
 #Sort the download/black lists
-awk '/^[^#]/ { print "local=/" $1 "/" }' "$TEMP" | sort -u > "$TEMP_SORTED"
+awk '/^[^#]/ { print "server=/" $1 "/" }' "$TEMP" | sort -u > "$TEMP_SORTED"
 
 #Filter (if applicable)
 if [ -s "$DNSMASQ_WHITELIST" ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changing the adblock script to create a list of `server=` instead of `local=`.

## Motivation and Context
Honestly not sure if this is necessary, but I was looking into whether this adblock method worked with wildcards (example.com and a.example.com both blocked) and most tutorials mention using `server=` for ad blocking.

Reference: https://bering-uclibc.zetam.org/wiki/Bering-uClibc_6.x_-_User_Guide_-_Advanced_Topics_-_Setting_Up_Ad_blocking_with_dnsmasq

## How Has This Been Tested?
Tested on Amazon EC2 and works as expected (but not sure which is the better/safer/more secure way of doing it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
