### PR TITLE
Unattended upgrade fixes 

### DIFF
--- a/roles/common/tasks/unattended-upgrades.yml
+++ b/roles/common/tasks/unattended-upgrades.yml
@@ -19,11 +19,3 @@
     owner: root
     group: root
     mode: 0644
-
-- name: Unattended reboots configured
-  template:
-    src: 60unattended-reboot.j2
-    dest: /etc/apt/apt.conf.d/60unattended-reboot
-    owner: root
-    group: root
-    mode: 0644

--- a/roles/common/templates/50unattended-upgrades.j2
+++ b/roles/common/templates/50unattended-upgrades.j2
@@ -1,32 +1,45 @@
 // Automatically upgrade packages from these (origin:archive) pairs
+//
+// Note that in Ubuntu security updates may pull in new dependencies
+// from non-security sources (e.g. chromium). By allowing the release
+// pocket these get automatically pulled in.
 Unattended-Upgrade::Allowed-Origins {
     "${distro_id}:${distro_codename}-security";
+    // Extended Security Maintenance; doesn't necessarily exist for
+    // every release and this system may not have it installed, but if
+    // available, the policy for updates is such that unattended-upgrades
+    // should also install from here by default.
+    "${distro_id}ESM:${distro_codename}";
     "${distro_id}:${distro_codename}-updates";
-//  "${distro_id}:${distro_codename}-proposed";
-//  "${distro_id}:${distro_codename}-backports";
+    //	"${distro_id}:${distro_codename}-proposed";
+    //	"${distro_id}:${distro_codename}-backports";
 };
 
 // List of packages to not update (regexp are supported)
 Unattended-Upgrade::Package-Blacklist {
-//  "vim";
-//  "libc6";
-//  "libc6-dev";
-//  "libc6-i686";
+//	"vim";
+//	"libc6";
+//	"libc6-dev";
+//	"libc6-i686";
 };
+
+// This option will controls whether the development release of Ubuntu will be
+// upgraded automatically.
+Unattended-Upgrade::DevRelease "false";
 
 // This option allows you to control if on a unclean dpkg exit
 // unattended-upgrades will automatically run
 //   dpkg --force-confold --configure -a
 // The default is true, to ensure updates keep getting installed
-//Unattended-Upgrade::AutoFixInterruptedDpkg "false";
+Unattended-Upgrade::AutoFixInterruptedDpkg "true";
 
 // Split the upgrade into the smallest possible chunks so that
-// they can be interrupted with SIGUSR1. This makes the upgrade
+// they can be interrupted with SIGTERM. This makes the upgrade
 // a bit slower but it has the benefit that shutdown while a upgrade
 // is running is possible (with a small delay)
-//Unattended-Upgrade::MinimalSteps "true";
+Unattended-Upgrade::MinimalSteps "true";
 
-// Install all unattended-upgrades when the machine is shuting down
+// Install all unattended-upgrades when the machine is shutting down
 // instead of doing it in the background while the machine is running
 // This will (obviously) make shutdown slower
 //Unattended-Upgrade::InstallOnShutdown "true";
@@ -41,19 +54,43 @@ Unattended-Upgrade::Package-Blacklist {
 // is to always send a mail if Unattended-Upgrade::Mail is set
 //Unattended-Upgrade::MailOnlyOnError "true";
 
+// Remove unused automatically installed kernel-related packages
+// (kernel images, kernel headers and kernel version locked tools).
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
-//Unattended-Upgrade::Remove-Unused-Dependencies "false";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
 
 // Automatically reboot *WITHOUT CONFIRMATION*
 //  if the file /var/run/reboot-required is found after the upgrade
-//Unattended-Upgrade::Automatic-Reboot "false";
+Unattended-Upgrade::Automatic-Reboot "{{ unattended_reboot.enabled|lower }}";
 
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
 //  Default: "now"
-//Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_reboot.time }}";
 
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";
+
+// Enable logging to syslog. Default is False
+Unattended-Upgrade::SyslogEnable "true";
+
+// Specify syslog facility. Default is daemon
+// Unattended-Upgrade::SyslogFacility "daemon";
+
+// Download and install upgrades only on AC power
+// (i.e. skip or gracefully stop updates on battery)
+// Unattended-Upgrade::OnlyOnACPower "true";
+
+// Download and install upgrades only on non-metered connection
+// (i.e. skip or gracefully stop updates on a metered connection)
+// Unattended-Upgrade::Skip-Updates-On-Metered-Connections "true";
+
+// Keep the custom conffile when upgrading
+Dpkg::Options {
+   "--force-confdef";
+   "--force-confold";
+};

--- a/roles/common/templates/60unattended-reboot.j2
+++ b/roles/common/templates/60unattended-reboot.j2
@@ -1,2 +1,0 @@
-Unattended-Upgrade::Automatic-Reboot "{{ unattended_reboot.enabled|lower }}";
-Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_reboot.time }}";

--- a/roles/dns/files/50-dnscrypt-proxy-unattended-upgrades
+++ b/roles/dns/files/50-dnscrypt-proxy-unattended-upgrades
@@ -2,3 +2,8 @@
 Unattended-Upgrade::Allowed-Origins {
     "LP-PPA-shevchuk-dnscrypt-proxy:${distro_codename}";
 };
+// Keep the custom conffile when upgrading
+Dpkg::Options {
+   "--force-confdef";
+   "--force-confold";
+};

--- a/roles/dns/files/50-dnscrypt-proxy-unattended-upgrades
+++ b/roles/dns/files/50-dnscrypt-proxy-unattended-upgrades
@@ -2,8 +2,3 @@
 Unattended-Upgrade::Allowed-Origins {
     "LP-PPA-shevchuk-dnscrypt-proxy:${distro_codename}";
 };
-// Keep the custom conffile when upgrading
-Dpkg::Options {
-   "--force-confdef";
-   "--force-confold";
-};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Since the Algo server is configured to automatically download and apply all updates (not just security updates), there's a danger of some packages not being updated as expected, if they have manual conffile prompts. Specifically, dnscrypt-proxy has a modified conffile installed by Algo. This won't be caught unless the server admin is monitoring `unattended-upgrades` through sendmail, or logging in at least daily and running `sudo apt update` and `sudo apt upgrade`.

```Unattended upgrade returned: False

Packages that attempted to upgrade:

Packages with upgradable origin but kept back:
 dnscrypt-proxy 



Unattended-upgrades log:
Initial blacklisted packages: 
Initial whitelisted packages: 
Starting unattended upgrades script
Allowed origins are: o=LP-PPA-shevchuk-dnscrypt-proxy,a=bionic, o=LP-PPA-wireguard-wireguard,a=bionic, o=Ubuntu,a=bionic-security, o=Ubuntu,a=bionic-updates
Package dnscrypt-proxy has conffile prompt and needs to be upgraded manually
package dnscrypt-proxy not upgraded
Packages that will be upgraded:
```

## Description
<!--- Describe your changes in detail -->
Forces the option to keep the custom conffile as described in [this link](https://askubuntu.com/questions/921162/how-can-i-automate-a-conffile-prompt-in-unattended-upgrades).

I'm not certain that putting these lines in `50-dnscrypt-proxy-unattended-upgrades` will cause the option to apply _only_ to dnscrypt-proxy. It's possible that having other upgrades keep the custom conffile could cause errors, so I wouldn't necessarily _want_ it to apply to other packages. (Although in the three months that I've been running this Ubuntu 18.04 server on Lightsail, dnscrypt-proxy is the only upgrade that's failed in this way.) One alternative would be to change `50unattended-upgrades` itself to escape out the `"${distro_id}:${distro_codename}-updates";` line, but this would stop regular updates other than security updates. Or conversely, these lines could be added to `50unattended-upgrades` to ensure that this option applies to _all_ packages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helps keep the server up-to-date as expected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Not sure whether this is a bug fix or a new feature.
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.