### PR TITLE
Dnscrypt-Proxy Wildcard Blocking

### DIFF
--- a/roles/dns/tasks/dns_adblocking.yml
+++ b/roles/dns/tasks/dns_adblocking.yml
@@ -15,6 +15,11 @@
     job: /usr/local/sbin/adblock.sh
     user: root
 
+- name: Adblock wildcard-blacklist configured
+  template:
+    src: wildcard.list.j2
+    dest: "{{ config_prefix|default('/') }}etc/dnscrypt-proxy/wildcard.list"
+
 - name: Update adblock hosts
   command: /usr/local/sbin/adblock.sh
   changed_when: false

--- a/roles/dns/templates/adblock.sh.j2
+++ b/roles/dns/templates/adblock.sh.j2
@@ -5,6 +5,7 @@ TEMP="$(mktemp)"
 TEMP_SORTED="$(mktemp)"
 WHITELIST="/etc/dnscrypt-proxy/white.list"
 BLACKLIST="/etc/dnscrypt-proxy/black.list"
+WILDCARDS="{{ config_prefix|default('/') }}etc/dnscrypt-proxy/wildcard.list"
 BLOCKHOSTS="{{ config_prefix|default('/') }}etc/dnscrypt-proxy/blacklist.txt"
 BLOCKLIST_URLS="{% for url in adblock_lists %}{{ url }} {% endfor %}"
 
@@ -16,6 +17,13 @@ echo 'Downloading hosts lists...'
 for url in $BLOCKLIST_URLS; do
   wget --timeout=2 --tries=3 -qO- "$url" | grep -Ev "(localhost)" | grep -Ew "(0.0.0.0|127.0.0.1)" | awk '{sub(/\r$/,"");print $2}'  >> "$TEMP"
 done
+
+#Add wildcards, if non empty
+if [ -s "$WILDCARDS" ]
+then
+    echo 'Adding wildcards...'
+    cat $WILDCARDS >> "$TEMP"
+fi
 
 #Add black list, if non-empty
 if [ -s "$BLACKLIST" ]

--- a/roles/dns/templates/wildcard.list.j2
+++ b/roles/dns/templates/wildcard.list.j2
@@ -1,0 +1,13 @@
+ad.*
+ads.*
+ad[0-9]*
+ads[0-9]*
+adserver.*
+adserver[0-9].*
+banner.*
+banners.*
+beacon.*
+stats.*
+tag.*
+telemetry.*
+tracker.*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
By moving adblocking to dnscrypt-proxy, we can add wildcard blocking to the adblocking. This pull request adds a list of wildcards and appends them to the beginning of the blocklist in the adblock.sh script.

I really wanted to then do a sweep of the domain blocklist to remove anything covered in a wildcard (akin to https://github.com/mmotti/pihole-gravity-optimise), but my shell scripting isn't nearly good enough for that. I'm not sure how it would affect speed and memory, but it would make the domain list significantly shorter.

## Motivation and Context
The blockhosts becomes list agnostic -- you no longer need to wait for the script to update with any new domains that might show up.

## How Has This Been Tested?
GCE and EC2 installations

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
