### PR TITLE
Add default IPv6 routes to the windows powershell script

### DIFF
--- a/roles/strongswan/templates/client_windows.ps1.j2
+++ b/roles/strongswan/templates/client_windows.ps1.j2
@@ -174,6 +174,12 @@ function Add-AlgoVPN {
     }
     Add-VpnConnection @addVpnParams
 
+    $addVpnRouteParams = @{
+        ConnectionName = $VpnName
+    }
+    Add-VpnConnectionRoute @addVpnRouteParams -DestinationPrefix ::/1
+    Add-VpnConnectionRoute @addVpnRouteParams -DestinationPrefix 8000::/1
+
     $setVpnParams = @{
         ConnectionName = $VpnName
         AuthenticationTransformConstants = "GCMAES256"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Windows doesn't add IPv6 routes for IKEv2 connections automatically, so we should add them via the powershell script. For some reason ::/0 doesn't work and we have to use ::/1 + 8000::/1

## Motivation and Context
Fixes #1453

## How Has This Been Tested?
Deployed an instance with windows support and configured my windows vm successfully 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
