### PR TITLE
Google Cloud: remove sshguard

### DIFF
--- a/roles/cloud-gce/tasks/main.yml
+++ b/roles/cloud-gce/tasks/main.yml
@@ -47,7 +47,7 @@
       metadata:
         ssh-keys: "ubuntu:{{ ssh_public_key_lookup }}"
         user-data: |
-          #! /bin/bash
+          #!/bin/bash
           sudo apt-get remove -y --purge sshguard
       network: "{{ algo_server_name }}"
       tags:

--- a/roles/cloud-gce/tasks/main.yml
+++ b/roles/cloud-gce/tasks/main.yml
@@ -44,7 +44,11 @@
       service_account_email: "{{ service_account_email }}"
       credentials_file: "{{ credentials_file_path }}"
       project_id: "{{ project_id }}"
-      metadata: '{"ssh-keys":"ubuntu:{{ ssh_public_key_lookup }}"}'
+      metadata:
+        ssh-keys: "ubuntu:{{ ssh_public_key_lookup }}"
+        user-data: |
+          #! /bin/bash
+          sudo apt-get remove -y --purge sshguard
       network: "{{ algo_server_name }}"
       tags:
         - "environment-algo"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For some reason google's ubuntu images include sshguard by default. It takes too long for GCP to populate the `authorized_keys` file from the metadata, meanwhile Ansible attempts to connect with no success, and therefore sshguard blocks the IP. 

This PR adds a cloud-init script which deletes sshguard completely from the system. 

## Motivation and Context
Fixes #1543 

## How Has This Been Tested?
Deployed to GCP successfully

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
