### PR TITLE
Doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/fold_left.svg?style=social&label=Follow%20%40AlgoVPN)](https://twitter.com/AlgoVPN)
 [![TravisCI Status](https://api.travis-ci.org/trailofbits/algo.svg?branch=master)](https://travis-ci.org/trailofbits/algo)
 
-Algo VPN is a set of Ansible scripts that simplify the setup of a personal IPSEC and Wireguard VPN. It uses the most secure defaults available, works with common cloud providers, and does not require client software on most devices. See our [release announcement](https://blog.trailofbits.com/2016/12/12/meet-algo-the-vpn-that-works/) for more information.
+Algo VPN is a set of Ansible scripts that simplify the setup of a personal Wireguard and IPSEC VPN. It uses the most secure defaults available, works with common cloud providers, and does not require client software on most devices. See our [release announcement](https://blog.trailofbits.com/2016/12/12/meet-algo-the-vpn-that-works/) for more information.
 
 ## Features
 
@@ -14,7 +14,7 @@ Algo VPN is a set of Ansible scripts that simplify the setup of a personal IPSEC
 * Blocks ads with a local DNS resolver (optional)
 * Sets up limited SSH users for tunneling traffic (optional)
 * Based on current versions of Ubuntu and strongSwan
-* Installs to DigitalOcean, Amazon Lightsail, Amazon EC2, Vultr, Microsoft Azure, Google Compute Engine, Scaleway, OpenStack, or [your own Ubuntu server](docs/deploy-to-ubuntu.md)
+* Installs to DigitalOcean, Amazon Lightsail, Amazon EC2, Vultr, Microsoft Azure, Google Compute Engine, Scaleway, OpenStack, CloudStack, Hetzner Cloud, or [your own Ubuntu server](docs/deploy-to-ubuntu.md)
 
 ## Anti-features
 
@@ -27,9 +27,9 @@ Algo VPN is a set of Ansible scripts that simplify the setup of a personal IPSEC
 
 ## Deploy the Algo Server
 
-The easiest way to get an Algo server running is to let it set up a _new_ virtual machine in the cloud for you.
+The easiest way to get an Algo server running is to run it on your local machine and let it set up a _new_ virtual machine in the cloud for you.
 
-1. **Setup an account on a cloud hosting provider.** Algo supports [DigitalOcean](https://m.do.co/c/4d7f4ff9cfe4) (most user friendly), [Amazon Lightsail](https://aws.amazon.com/lightsail/), [Amazon EC2](https://aws.amazon.com/), [Vultr](https://www.vultr.com/), [Microsoft Azure](https://azure.microsoft.com/), [Google Compute Engine](https://cloud.google.com/compute/), [Scaleway](https://www.scaleway.com/), and [DreamCompute](https://www.dreamhost.com/cloud/computing/) or other OpenStack-based cloud hosting.
+1. **Setup an account on a cloud hosting provider.** Algo supports [DigitalOcean](https://m.do.co/c/4d7f4ff9cfe4) (most user friendly), [Amazon Lightsail](https://aws.amazon.com/lightsail/), [Amazon EC2](https://aws.amazon.com/), [Vultr](https://www.vultr.com/), [Microsoft Azure](https://azure.microsoft.com/), [Google Compute Engine](https://cloud.google.com/compute/), [Scaleway](https://www.scaleway.com/), [DreamCompute](https://www.dreamhost.com/cloud/computing/) or other OpenStack-based cloud hosting, [Exoscale](https://www.exoscale.com) or other CloudStack-based cloud hosting,  or [Hetzner Cloud](https://www.hetzner.com/).
 
 2. **[Download Algo](https://github.com/trailofbits/algo/archive/master.zip).** Unzip it in a convenient location on your local machine.
 

--- a/docs/client-windows.md
+++ b/docs/client-windows.md
@@ -1,6 +1,0 @@
-# Windows client setup
-
-## Installation via profiles
-
-1. Install the [WireGuard VPN Client](https://www.wireguard.com/install/#windows-7-8-81-10-2012-2016-2019) and start it.
-2. Import the corresponding `wireguard/<name>.conf` file to your device, then setup a new connection with it.

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -41,16 +41,16 @@ Cloud roles can be activated by specifying an extra variable `provider`.
 
 Cloud roles:
 
-- [role: cloud-digitalocean, provider: digitalocean](#digital-ocean)
-- [role: cloud-ec2,          provider: ec2](#amazon-ec2)
-- [role: cloud-gce,          provider: gce](#google-compute-engine)
-- [role: cloud-vultr,        provider: vultr](#vultr)
-- [role: cloud-azure,        provider: azure](#azure)
-- [role: cloud-lightsail,    provider: lightsail](#lightsail)
-- [role: cloud-scaleway,     provider: scaleway](#scaleway)
-- [role: cloud-openstack,    provider: openstack](#openstack)
-- [role: cloud-cloudstack,   provider: cloudstack](#cloudstack)
-- [role: cloud-hetzner,      proivder: hetzner](#hetzner)
+- role: cloud-digitalocean, [provider: digitalocean](#digital-ocean)
+- role: cloud-ec2,          [provider: ec2](#amazon-ec2)
+- role: cloud-gce,          [provider: gce](#google-compute-engine)
+- role: cloud-vultr,        [provider: vultr](#vultr)
+- role: cloud-azure,        [provider: azure](#azure)
+- role: cloud-lightsail,    [provider: lightsail](#lightsail)
+- role: cloud-scaleway,     [provider: scaleway](#scaleway)
+- role: cloud-openstack,    [provider: openstack](#openstack)
+- role: cloud-cloudstack,   [provider: cloudstack](#cloudstack)
+- role: cloud-hetzner,      [provider: hetzner](#hetzner)
 
 Server roles:
 

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -48,6 +48,8 @@ Cloud roles:
 - role: cloud-azure,        provider: azure
 - role: cloud-scaleway,     provider: scaleway
 - role: cloud-openstack,    provider: openstack
+- role: cloud-cloudstack,   provider: cloudstack
+- role: cloud-hetzner,      proivder: hetzner
 
 Server roles:
 
@@ -238,11 +240,30 @@ Possible options can be gathered via cli `aws lightsail get-regions`
 Required variables:
 
 - [scaleway_token](https://www.scaleway.com/docs/generate-an-api-token/)
-- region: e.g. ams1, par1
+- region: e.g. `ams1`, `par1`
 
 ### OpenStack
 
 You need to source the rc file prior to run Algo. Download it from the OpenStack dashboard->Compute->API Access and source it in the shell (eg: source /tmp/dhc-openrc.sh)
+
+### CloudStack
+
+Required variables:
+
+- [cs_config](https://trailofbits.github.io/algo/cloud-cloudstack.html): /path/to/.cloudstack.ini
+- cs_region: e.g. `exoscale`
+- cs_zones: e.g. `ch-gva2`
+
+The first two can also be defined in your environment, using the variables `CLOUDSTACK_CONFIG` and `CLOUDSTACK_REGION`.
+
+### Hetzner
+
+Required variables:
+
+- hcloud_token: Your [API token](https://trailofbits.github.io/algo/cloud-hetzner.html#api-token) - can also be defined in the environment as HCLOUD_TOKEN
+- region: e.g. `nbg1`
+
+
 
 ### Update users
 

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -183,8 +183,8 @@ Additional variables:
 
 Required variables:
 
-- gce_credentials_file
-- [region](https://cloud.google.com/compute/docs/regions-zones/)
+- gce_credentials_file: e.g. /configs/gce.json if you use the [GCE docs](https://trailofbits.github.io/algo/cloud-gce.html) - can also be defined in environment as GCE_CREDENTIALS_FILE_PATH
+- [region](https://cloud.google.com/compute/docs/regions-zones/): e.g. `useast-1`
 
 ### Vultr
 

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -41,15 +41,16 @@ Cloud roles can be activated by specifying an extra variable `provider`.
 
 Cloud roles:
 
-- role: cloud-digitalocean, provider: digitalocean
-- role: cloud-ec2,          provider: ec2
-- role: cloud-vultr,        provider: vultr
-- role: cloud-gce,          provider: gce
-- role: cloud-azure,        provider: azure
-- role: cloud-scaleway,     provider: scaleway
-- role: cloud-openstack,    provider: openstack
-- role: cloud-cloudstack,   provider: cloudstack
-- role: cloud-hetzner,      proivder: hetzner
+- [role: cloud-digitalocean, provider: digitalocean](#digital-ocean)
+- [role: cloud-ec2,          provider: ec2](#amazon-ec2)
+- [role: cloud-gce,          provider: gce](#google-compute-engine)
+- [role: cloud-vultr,        provider: vultr](#vultr)
+- [role: cloud-azure,        provider: azure](#azure)
+- [role: cloud-lightsail,    provider: lightsail](#lightsail)
+- [role: cloud-scaleway,     provider: scaleway](#scaleway)
+- [role: cloud-openstack,    provider: openstack](#openstack)
+- [role: cloud-cloudstack,   provider: cloudstack](#cloudstack)
+- [role: cloud-hetzner,      proivder: hetzner](#hetzner)
 
 Server roles:
 
@@ -262,8 +263,6 @@ Required variables:
 
 - hcloud_token: Your [API token](https://trailofbits.github.io/algo/cloud-hetzner.html#api-token) - can also be defined in the environment as HCLOUD_TOKEN
 - region: e.g. `nbg1`
-
-
 
 ### Update users
 

--- a/docs/deploy-from-script-or-cloud-init-to-localhost.md
+++ b/docs/deploy-from-script-or-cloud-init-to-localhost.md
@@ -4,7 +4,7 @@ You can use `install.sh` to prepare the environment and deploy AlgoVPN on the lo
 
 ## Cloud init deployment
 
-You can copy-paste the snippet below to the user data (cloud-init or startup script) field when creating a new server. For now it is only possible for [DigitalOcean](https://www.digitalocean.com/docs/droplets/resources/metadata/), Amazon [EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) and [Lightsail](https://lightsail.aws.amazon.com/ls/docs/en/articles/lightsail-how-to-configure-server-additional-data-shell-script), [Google Cloud](https://cloud.google.com/compute/docs/startupscript), [Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init) and [Vultr](https://my.vultr.com/startup/), although Vultr doesn't [officially support cloud-init](https://www.vultr.com/docs/getting-started-with-cloud-init).
+You can copy-paste the snippet below to the user data (cloud-init or startup script) field when creating a new server. For now this has only been successfully tested on [DigitalOcean](https://www.digitalocean.com/docs/droplets/resources/metadata/), Amazon [EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) and [Lightsail](https://lightsail.aws.amazon.com/ls/docs/en/articles/lightsail-how-to-configure-server-additional-data-shell-script), [Google Cloud](https://cloud.google.com/compute/docs/startupscript), [Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init) and [Vultr](https://my.vultr.com/startup/), although Vultr doesn't [officially support cloud-init](https://www.vultr.com/docs/getting-started-with-cloud-init).
 
 ```
 #!/bin/bash
@@ -15,17 +15,29 @@ The command will prepare the environment and install AlgoVPN with the default pa
 ## Variables
 
 `METHOD` -  which method of the deployment to use. Possible values are local and cloud. Default: cloud. The cloud method is intended to use in cloud-init deployments only. If you are not using cloud-init to deploy the server you have to use the local method.
+
 `ONDEMAND_CELLULAR` - "Connect On Demand" when connected to cellular networks. Boolean. Default: false.
+
 `ONDEMAND_WIFI` - "Connect On Demand" when connected to Wi-Fi. Default: false.
+
 `ONDEMAND_WIFI_EXCLUDE` - List the names of any trusted Wi-Fi networks where macOS/iOS IPsec clients should not use "Connect On Demand". Comma-separated list.
+
 `STORE_PKI` - To retain the PKI. (required to add users in the future, but less secure). Default: false.
+
 `DNS_ADBLOCKING` - To install an ad blocking DNS resolver. Default: false.
+
 `SSH_TUNNELING` -  Enable SSH tunneling for each user. Default: false.
-`ENDPOINT` - The public IP address or domain name of your server: (IMPORTANT! This is used to verify the certificate). It will be gathered automatically for DigitalOcean, AWS, GCE, Azure or Vultr if the `METHOD` is cloud. Otherwise you need to define this variable according to your public IP address.  
+
+`ENDPOINT` - The public IP address or domain name of your server: (IMPORTANT! This is used to verify the certificate). It will be gathered automatically for DigitalOcean, AWS, GCE, Azure or Vultr if the `METHOD` is cloud. Otherwise you need to define this variable according to your public IP address.
+
 `USERS` - list of VPN users. Comma-separated list. Default: user1.
-`REPO_SLUG` - Owner and repository that used to get the installation scripts from. Default: trailofbits/algo.   
+
+`REPO_SLUG` - Owner and repository that used to get the installation scripts from. Default: trailofbits/algo.
+
 `REPO_BRANCH` - Branch for `REPO_SLUG`. Default: master.
+
 `EXTRA_VARS` - Additional extra variables.
+
 `ANSIBLE_EXTRA_ARGS` - Any available ansible parameters. ie: `--skip-tags apparmor`.
 
 ## Examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@
   - Configure [Google Cloud Platform](cloud-gce.md)
   - Configure [Vultr](cloud-vultr.md)
   - Configure [CloudStack](cloud-cloudstack.md)
+  - Configure [Hetzner Cloud](cloud-hetzner.md)
 * Advanced Deployment
   - Deploy to your own [FreeBSD](deploy-to-freebsd.md) server
   - Deploy to your own [Ubuntu](deploy-to-ubuntu.md) server

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,6 @@
   - Setup Ubuntu clients to use [WireGuard](client-linux-wireguard.md)
   - Setup Apple devices to use [IPSEC](client-apple-ipsec.md)
   - Setup Macs running macOS 10.13 or older to use [Wireguard](client-macos-wireguard.md)
-  - Manual Windows 10 client setup for [IPSEC](client-windows.md)
 * Cloud provider setup
   - Configure [Amazon EC2](cloud-amazon-ec2.md)
   - Configure [Azure](cloud-azure.md)


### PR DESCRIPTION
- Adds links for Exoscale and Hetzner Cloud to the README. 
- Updates the docs index to include the Hetzner Cloud docs file. 
- Deletes the Win10 IPsec instructions, which give the WG instructions, anyway, and removes link from docs index. 
- Updates the deploy from Ansible instructions to add sections for CloudStack and Hetzner, and update the GCE section, among cosmetic changes.
- Minor edits to cloud-init script instructions.