### PR TITLE
Allow OnDemand to be toggled later

### DIFF
--- a/roles/strongswan/templates/mobileconfig.j2
+++ b/roles/strongswan/templates/mobileconfig.j2
@@ -8,11 +8,11 @@
         <dict>
             <key>IKEv2</key>
             <dict>
-{% if algo_ondemand_wifi or algo_ondemand_cellular %}
               <key>OnDemandEnabled</key>
-                <integer>1</integer>
+              <integer>{{ 1 if algo_ondemand_wifi or algo_ondemand_cellular else 0 }}</integer>
               <key>OnDemandRules</key>
               <array>
+{% if algo_ondemand_wifi or algo_ondemand_cellular %}
   {% if algo_ondemand_wifi_exclude|b64decode != '_null' %}
     {% set WIFI_EXCLUDE_LIST = (algo_ondemand_wifi_exclude|b64decode|string).split(',') %}
                   <dict>
@@ -52,12 +52,12 @@
                     <key>URLStringProbe</key>
                       <string>http://captive.apple.com/hotspot-detect.html</string>
                   </dict>
+{% endif %}
                   <dict>
                     <key>Action</key>
-                      <string>Disconnect</string>
+                      <string>{{ 'Disconnect' if algo_ondemand_wifi or algo_ondemand_cellular else 'Connect' }}</string>
                   </dict>
                 </array>
-{% endif %}
                 <key>AuthenticationMethod</key>
                 <string>Certificate</string>
                 <key>ChildSecurityAssociationParameters</key>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fix allows apple devices to toggle on the OnDemand mode, even if neither WiFi nor Cellular options were chosen during the initial deployment. 

The only rule appears to be needed:
```
<key>OnDemandEnabled</key>
<integer>0</integer>
<key>OnDemandRules</key>
<array>
  <dict>
    <key>Action</key>
    <string>Connect</string>
  </dict>
</array>
```

## Motivation and Context
Fixes #778 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
