### PR TITLE
use `openssl rand -base64` to generate password

### DIFF
--- a/roles/common/tasks/facts.yml
+++ b/roles/common/tasks/facts.yml
@@ -6,8 +6,7 @@
 
   - name: Generate p12 export password
     shell: >
-      openssl rand 8 |
-      python3 -c 'import sys,string; chars=string.ascii_letters + string.digits + "_@"; print("".join([chars[ord(c) % 64] for c in list(sys.stdin.read())]))'
+      openssl rand -base64 9
     register: p12_password_generated
     when: p12_password is not defined
     tags: update-users


### PR DESCRIPTION
## Description
Generate password directly by openssl instead of converting by python script.

## Motivation and Context
For python2/python3 compatibility.

## Types of changes
- [v] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [v] I have read the **CONTRIBUTING** document.
- [v] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [] All new and existing tests passed.
