### PR TITLE
Generates a password by native module

### DIFF
--- a/roles/common/tasks/facts.yml
+++ b/roles/common/tasks/facts.yml
@@ -6,7 +6,7 @@
 
   - name: Generate p12 export password
     set_fact:
-      p12_password_generated: "{{ lookup('password', '/dev/null length=9 chars=ascii_letters,digits,!,@,#,$,%,^,&,*,<,>,/,?') }}"
+      p12_password_generated: "{{ lookup('password', '/dev/null length=9 chars=ascii_letters,digits,_,@') }}"
     when: p12_password is not defined
     tags: update-users
   become: false

--- a/roles/common/tasks/facts.yml
+++ b/roles/common/tasks/facts.yml
@@ -5,10 +5,8 @@
     register: CA_password
 
   - name: Generate p12 export password
-    shell: >
-      openssl rand 8 |
-      python -c 'import sys,string; chars=string.ascii_letters + string.digits + "_@"; print("".join([chars[ord(c) % 64] for c in list(sys.stdin.read())]))'
-    register: p12_password_generated
+    set_fact:
+      p12_password_generated: "{{ lookup('password', '/dev/null length=9 chars=ascii_letters,digits,!,@,#,$,%,^,&,*,<,>,/,?') }}"
     when: p12_password is not defined
     tags: update-users
   become: false

--- a/roles/common/tasks/facts.yml
+++ b/roles/common/tasks/facts.yml
@@ -1,25 +1,12 @@
 ---
-- block:
-  - name: Generate password for the CA key
-    command: openssl rand -hex 16
-    register: CA_password
-
-  - name: Generate p12 export password
-    set_fact:
-      p12_password_generated: "{{ lookup('password', '/dev/null length=9 chars=ascii_letters,digits,_,@') }}"
-    when: p12_password is not defined
-    tags: update-users
-  become: false
-  delegate_to: localhost
-
 - name: Define facts
   set_fact:
-    p12_export_password: "{{ p12_password|default(p12_password_generated) }}"
+    p12_export_password: "{{ p12_password|default(lookup('password', '/dev/null length=9 chars=ascii_letters,digits,_,@')) }}"
   tags: update-users
 
 - name: Set facts
   set_fact:
-    CA_password: "{{ CA_password.stdout }}"
+    CA_password: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits,_,@') }}"
     IP_subject_alt_name: "{{ IP_subject_alt_name }}"
 
 - name: Set IPv6 support as a fact

--- a/roles/common/tasks/facts.yml
+++ b/roles/common/tasks/facts.yml
@@ -14,7 +14,7 @@
 
 - name: Define facts
   set_fact:
-    p12_export_password: "{{ p12_password|default(p12_password_generated.stdout) }}"
+    p12_export_password: "{{ p12_password|default(p12_password_generated) }}"
   tags: update-users
 
 - name: Set facts


### PR DESCRIPTION
Use native password module to generate password instead of using complicated scripts.

## Description
Generates a p12 password from password module. The password contains a random mix of `[a-zA-Z0-9!@#$%^&*/?<>]` ( exclude square brackets ).

## Motivation and Context
#1574 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [v] Bug fix (non-breaking change which fixes an issue)
- [v] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [v] I have read the **CONTRIBUTING** document.
- [v] My code follows the code style of this project.
- [v] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.