### PR TITLE
Do not copy existing env to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,6 @@ README.md
 config.cfg
 configs
 docs
+env
 logo.png
 tests


### PR DESCRIPTION
## Description
Adds `env` to `.dockerignore`.

## Motivation and Context
If `env` already exists, it overrides the one created during `docker build`, which results in “`ansible-playbook` not found” error. Inspecting `$PATH` inside the container shows a local path to virtual env, not `/algo/env`.

## How Has This Been Tested?
Deploy to DigitalOcean both with and without Docker.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.