### PR TITLE
Windows SSH key permissions workaround

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -132,6 +132,7 @@ congrats:
 SSH_keys:
   comment: algo@ssh
   private: configs/algo.pem
+  private_tmp: /tmp/algo-ssh.pem
   public: configs/algo.pem.pub
 
 cloud_providers:

--- a/main.yml
+++ b/main.yml
@@ -2,6 +2,16 @@
 - hosts: localhost
   become: false
   tasks:
+    - name: Playbook dir stat
+      stat:
+        path: "{{ playbook_dir }}"
+      register: _playbook_dir
+
+    - name: Ensure Ansible is not being run in a world writable directory
+      assert:
+        that: _playbook_dir.stat.mode|int <= 0775
+        msg: Ansible is being run in a world writable directory ({{ playbook_dir }}), ignoring it as an ansible.cfg source. For more information see https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir
+
     - name: Ensure the requirements installed
       debug:
         msg: "{{ '' | ipaddr }}"

--- a/main.yml
+++ b/main.yml
@@ -10,7 +10,9 @@
     - name: Ensure Ansible is not being run in a world writable directory
       assert:
         that: _playbook_dir.stat.mode|int <= 0775
-        msg: Ansible is being run in a world writable directory ({{ playbook_dir }}), ignoring it as an ansible.cfg source. For more information see https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir
+        msg: >
+          Ansible is being run in a world writable directory ({{ playbook_dir }}), ignoring it as an ansible.cfg source.
+          For more information see https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir
 
     - name: Ensure the requirements installed
       debug:

--- a/playbooks/cloud-post.yml
+++ b/playbooks/cloud-post.yml
@@ -23,7 +23,7 @@
 - name: Additional variables for the server
   add_host:
     name: "{% if cloud_instance_ip == 'localhost' %}localhost{% else %}{{ cloud_instance_ip }}{% endif %}"
-    ansible_ssh_private_key_file: "{{ SSH_keys.private }}"
+    ansible_ssh_private_key_file: "{{ SSH_keys.private_tmp }}"
   when: algo_provider != 'local'
 
 - name: Wait until SSH becomes ready...

--- a/playbooks/cloud-pre.yml
+++ b/playbooks/cloud-pre.yml
@@ -29,17 +29,26 @@
   delegate_to: localhost
   become: false
 
-- name: Generate the SSH private key
-  openssl_privatekey:
-    path: "{{ SSH_keys.private }}"
-    size: 2048
-    mode: "0600"
-    type: RSA
-  when: algo_provider != "local"
+- block:
+  - name: Generate the SSH private key
+    openssl_privatekey:
+      path: "{{ SSH_keys.private }}"
+      size: 2048
+      mode: "0600"
+      type: RSA
 
-- name: Generate the SSH public key
-  openssl_publickey:
-    path: "{{ SSH_keys.public }}"
-    privatekey_path: "{{ SSH_keys.private }}"
-    format: OpenSSH
+  - name: Generate the SSH public key
+    openssl_publickey:
+      path: "{{ SSH_keys.public }}"
+      privatekey_path: "{{ SSH_keys.private }}"
+      format: OpenSSH
+
+  - name: Copy the private SSH key to /tmp
+    copy:
+      src: "{{ SSH_keys.private }}"
+      dest: "{{ SSH_keys.private_tmp }}"
+      force: true
+      mode: '0600'
+    delegate_to: localhost
+    become: false
   when: algo_provider != "local"

--- a/server.yml
+++ b/server.yml
@@ -41,7 +41,7 @@
               server: {{ 'localhost' if inventory_hostname == 'localhost' else inventory_hostname }}
               server_user: {{ ansible_ssh_user }}
               {% if algo_provider != "local" %}
-              ansible_ssh_private_key_file: {{ ansible_ssh_private_key_file|default(SSH_keys.private) }}
+              ansible_ssh_private_key_file: {{ SSH_keys.private }}
               {% endif %}
               algo_provider: {{ algo_provider }}
               algo_server_name: {{ algo_server_name }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On Windows WSL everything that goes to `/mnt` gets too open permissions, which leads the ssh client to rise an error "Failed to connect to the host via ssh" because of this. The PR adds a task that copies the SSH private file to `/tmp` with '0600' permissions, should be enough to bypass.

## Motivation and Context
There's been dozens of issues like #1583. We definitely need to do something with this, and I've decided to publish this workaround. Closes #1583

## How Has This Been Tested?
- [x] MacOS / Linux
- [x] Windows WSL

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] All new and existing tests passed.
