### PR TITLE
Fix for interactive Docker deployments

### DIFF
--- a/algo-docker.sh
+++ b/algo-docker.sh
@@ -37,7 +37,7 @@ fi
 tr -d '\r' < "${DATA_DIR}"/config.cfg > "${ALGO_DIR}"/config.cfg
 test -d "${DATA_DIR}"/configs && rsync -qLktr --delete "${DATA_DIR}"/configs "${ALGO_DIR}"/
 
-"${ALGO_DIR}"/algo "${ALGO_ARGS}"
+"${ALGO_DIR}"/algo "${ALGO_ARGS[@]}"
 retcode=${?}
 
 rsync -qLktr --delete "${ALGO_DIR}"/configs "${DATA_DIR}"/


### PR DESCRIPTION
Fixes https://github.com/trailofbits/algo/issues/1587.

## Description
Bash turns `"$MISSING_VAR"` into an empty command-line argument. If quotes are absent, however, nothing is passed. Test case:
```bash
test() {
    PLAYBOOK=main.yml
    ARGS=( "${@}" )
    echo "'" ${PLAYBOOK} "'" "${ARGS[@]}" "'"
}

test $MISSING_VAR      # Prints ' main.yml ' '
test "$MISSING_VAR"    # Prints ' main.yml '  ' (double space between '')
test "$MISSING_VAR[@]" # Prints ' main.yml ' '
```

## How Has This Been Tested?
Built Docker image and ran both interactively and in scripted mode.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.