### PR TITLE
Allow WireGuard to listen on port 53

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -32,6 +32,9 @@ strongswan_network: 10.19.48.0/24
 strongswan_network_ipv6: 'fd9d:bc11:4020::/48'
 
 # Deploy WireGuard
+# WireGuard will listen on 51820/UDP. You might need to change to another port
+# if your network blocks this one. Be aware that 53/UDP (DNS) is blocked on some
+# mobile data networks.
 wireguard_enabled: true
 wireguard_port: 51820
 # If you're behind NAT or a firewall and you want to receive incoming connections long after network traffic has gone silent.

--- a/roles/common/templates/rules.v4.j2
+++ b/roles/common/templates/rules.v4.j2
@@ -1,5 +1,5 @@
 {% set subnets = ([strongswan_network] if ipsec_enabled else []) + ([wireguard_network_ipv4] if wireguard_enabled else []) %}
-{% set ports = (['500', '4500'] if ipsec_enabled else []) + ([wireguard_port] if wireguard_enabled else []) + ([wireguard_port_alt] if wireguard_enabled and wireguard_port|int == 53 else []) %}
+{% set ports = (['500', '4500'] if ipsec_enabled else []) + ([wireguard_port] if wireguard_enabled else []) + ([wireguard_port_actual] if wireguard_enabled and wireguard_port|int == wireguard_port_avoid|int else []) %}
 
 #### The mangle table
 # This table allows us to modify packet headers
@@ -29,9 +29,10 @@ COMMIT
 :PREROUTING ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]
 
-{% if wireguard_enabled and wireguard_port|int == 53 %}
-# Handle the special case of allowing access to WireGuard over port 53
--A PREROUTING --in-interface {{ ansible_default_ipv4['interface'] }} -p udp --dport 53 -j REDIRECT --to-port {{ wireguard_port_alt }}
+{% if wireguard_enabled and wireguard_port|int == wireguard_port_avoid|int %}
+# Handle the special case of allowing access to WireGuard over an already used
+# port like 53
+-A PREROUTING --in-interface {{ ansible_default_ipv4['interface'] }} -p udp --dport {{ wireguard_port_avoid }} -j REDIRECT --to-port {{ wireguard_port_actual }}
 {% endif %}
 # Allow traffic from the VPN network to the outside world, and replies
 -A POSTROUTING -s {{ subnets|join(',') }} -m policy --pol none --dir out -j MASQUERADE

--- a/roles/common/templates/rules.v4.j2
+++ b/roles/common/templates/rules.v4.j2
@@ -1,5 +1,5 @@
 {% set subnets = ([strongswan_network] if ipsec_enabled else []) + ([wireguard_network_ipv4] if wireguard_enabled else []) %}
-{% set ports = (['500', '4500'] if ipsec_enabled else []) + ([wireguard_port] if wireguard_enabled else []) %}
+{% set ports = (['500', '4500'] if ipsec_enabled else []) + ([wireguard_port] if wireguard_enabled else []) + ([wireguard_port_alt] if wireguard_enabled and wireguard_port|int == 53 else []) %}
 
 #### The mangle table
 # This table allows us to modify packet headers
@@ -29,6 +29,10 @@ COMMIT
 :PREROUTING ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]
 
+{% if wireguard_enabled and wireguard_port|int == 53 %}
+# Handle the special case of allowing access to WireGuard over port 53
+-A PREROUTING --in-interface {{ ansible_default_ipv4['interface'] }} -p udp --dport 53 -j REDIRECT --to-port {{ wireguard_port_alt }}
+{% endif %}
 # Allow traffic from the VPN network to the outside world, and replies
 -A POSTROUTING -s {{ subnets|join(',') }} -m policy --pol none --dir out -j MASQUERADE
 

--- a/roles/common/templates/rules.v6.j2
+++ b/roles/common/templates/rules.v6.j2
@@ -1,5 +1,5 @@
 {% set subnets = ([strongswan_network_ipv6] if ipsec_enabled else []) + ([wireguard_network_ipv6] if wireguard_enabled else []) %}
-{% set ports = (['500', '4500'] if ipsec_enabled else []) + ([wireguard_port] if wireguard_enabled else []) + ([wireguard_port_alt] if wireguard_enabled and wireguard_port|int == 53 else []) %}
+{% set ports = (['500', '4500'] if ipsec_enabled else []) + ([wireguard_port] if wireguard_enabled else []) + ([wireguard_port_actual] if wireguard_enabled and wireguard_port|int == wireguard_port_avoid|int else []) %}
 
 #### The mangle table
 # This table allows us to modify packet headers
@@ -28,9 +28,10 @@ COMMIT
 :PREROUTING ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]
 
-{% if wireguard_enabled and wireguard_port|int == 53 %}
-# Handle the special case of allowing access to WireGuard over port 53
--A PREROUTING --in-interface {{ ansible_default_ipv6['interface'] }} -p udp --dport 53 -j REDIRECT --to-port {{ wireguard_port_alt }}
+{% if wireguard_enabled and wireguard_port|int == wireguard_port_avoid|int %}
+# Handle the special case of allowing access to WireGuard over an already used
+# port like 53
+-A PREROUTING --in-interface {{ ansible_default_ipv6['interface'] }} -p udp --dport {{ wireguard_port_avoid }} -j REDIRECT --to-port {{ wireguard_port_actual }}
 {% endif %}
 # Allow traffic from the VPN network to the outside world, and replies
 -A POSTROUTING -s {{ subnets|join(',') }} -m policy --pol none --dir out -j MASQUERADE

--- a/roles/common/templates/rules.v6.j2
+++ b/roles/common/templates/rules.v6.j2
@@ -1,5 +1,5 @@
 {% set subnets = ([strongswan_network_ipv6] if ipsec_enabled else []) + ([wireguard_network_ipv6] if wireguard_enabled else []) %}
-{% set ports = (['500', '4500'] if ipsec_enabled else []) + ([wireguard_port] if wireguard_enabled else []) %}
+{% set ports = (['500', '4500'] if ipsec_enabled else []) + ([wireguard_port] if wireguard_enabled else []) + ([wireguard_port_alt] if wireguard_enabled and wireguard_port|int == 53 else []) %}
 
 #### The mangle table
 # This table allows us to modify packet headers
@@ -28,6 +28,10 @@ COMMIT
 :PREROUTING ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]
 
+{% if wireguard_enabled and wireguard_port|int == 53 %}
+# Handle the special case of allowing access to WireGuard over port 53
+-A PREROUTING --in-interface {{ ansible_default_ipv6['interface'] }} -p udp --dport 53 -j REDIRECT --to-port {{ wireguard_port_alt }}
+{% endif %}
 # Allow traffic from the VPN network to the outside world, and replies
 -A POSTROUTING -s {{ subnets|join(',') }} -m policy --pol none --dir out -j MASQUERADE
 

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -3,7 +3,8 @@ wireguard_PersistentKeepalive: 0
 wireguard_config_path: "configs/{{ IP_subject_alt_name }}/wireguard/"
 wireguard_pki_path: "{{ wireguard_config_path }}/.pki/"
 wireguard_interface: wg0
-wireguard_port_alt: 51820
+wireguard_port_avoid: 53
+wireguard_port_actual: 51820
 keys_clean_all: false
 wireguard_dns_servers: >-
   {% if algo_dns_adblocking|default(false)|bool or dns_encryption|default(false)|bool %}

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -3,6 +3,7 @@ wireguard_PersistentKeepalive: 0
 wireguard_config_path: "configs/{{ IP_subject_alt_name }}/wireguard/"
 wireguard_pki_path: "{{ wireguard_config_path }}/.pki/"
 wireguard_interface: wg0
+wireguard_port_alt: 51820
 keys_clean_all: false
 wireguard_dns_servers: >-
   {% if algo_dns_adblocking|default(false)|bool or dns_encryption|default(false)|bool %}

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -1,6 +1,6 @@
 [Interface]
 Address = {{ wireguard_server_ip }}
-ListenPort = {{ wireguard_port }}
+ListenPort = {{ wireguard_port_alt if wireguard_port|int == 53 else wireguard_port }}
 PrivateKey = {{ lookup('file', wireguard_pki_path + '/private/' + IP_subject_alt_name) }}
 SaveConfig = false
 

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -1,6 +1,6 @@
 [Interface]
 Address = {{ wireguard_server_ip }}
-ListenPort = {{ wireguard_port_alt if wireguard_port|int == 53 else wireguard_port }}
+ListenPort = {{ wireguard_port_actual if wireguard_port|int == wireguard_port_avoid|int else wireguard_port }}
 PrivateKey = {{ lookup('file', wireguard_pki_path + '/private/' + IP_subject_alt_name) }}
 SaveConfig = false
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change allows the special case of setting `wireguard_port: 53` in `config.cfg` and is based on an approach suggested on the [WireGuard mailing list](https://lists.zx2c4.com/pipermail/wireguard/2018-June/003013.html). 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some networks block most outgoing UDP traffic, but port 53 might still be allowed for DNS.

Closes #1593.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deployed to DigitalOcean both with and without `wireguard_port: 53`. Also tested connecting using a DigitalOcean Floating IP, where traffic comes in on the main network interface but to a secondary address. In all cases the client was iOS 13.1.2.

Also tested on Lightsail with `wireguard_port: 53`.

More testing should be done. Please help test this, fellow Algo users.

This should also be reviewed for how it uses `iptables`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
