### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/fold_left.svg?style=social&label=Follow%20%40AlgoVPN)](https://twitter.com/AlgoVPN)
 [![TravisCI Status](https://api.travis-ci.org/trailofbits/algo.svg?branch=master)](https://travis-ci.org/trailofbits/algo)
 
-Algo VPN is a set of Ansible scripts that simplify the setup of a personal Wireguard and IPSEC VPN. It uses the most secure defaults available, works with common cloud providers, and does not require client software on most devices. See our [release announcement](https://blog.trailofbits.com/2016/12/12/meet-algo-the-vpn-that-works/) for more information.
+Algo VPN is a set of Ansible scripts that simplify the setup of a personal Wireguard and IPSEC VPN. It uses the most secure defaults available and works with common cloud providers. See our [release announcement](https://blog.trailofbits.com/2016/12/12/meet-algo-the-vpn-that-works/) for more information.
 
 ## Features
 
@@ -21,7 +21,6 @@ Algo VPN is a set of Ansible scripts that simplify the setup of a personal Wireg
 * Does not support legacy cipher suites or protocols like L2TP, IKEv1, or RSA
 * Does not install Tor, OpenVPN, or other risky servers
 * Does not depend on the security of [TLS](https://tools.ietf.org/html/rfc7457)
-* Does not require client software on most platforms
 * Does not claim to provide anonymity or censorship avoidance
 * Does not claim to protect you from the [FSB](https://en.wikipedia.org/wiki/Federal_Security_Service), [MSS](https://en.wikipedia.org/wiki/Ministry_of_State_Security_(China)), [DGSE](https://en.wikipedia.org/wiki/Directorate-General_for_External_Security), or [FSM](https://en.wikipedia.org/wiki/Flying_Spaghetti_Monster)
 
@@ -71,7 +70,7 @@ The easiest way to get an Algo server running is to run it on your local system 
     ```
     On Fedora add the option `--system-site-packages` to the first command above. On macOS install the C compiler if prompted.
 
-5. **List the users to create.** Open the file `config.cfg` in your favorite text editor. Specify the users you wish to create in the `users` list. Create a unique user for each device you plan to connect to your VPN. If you want to be able to add or delete users later, you **must** select `yes` at the `Do you want to retain the keys (PKI)?` prompt during the deployment.
+5. **Set your configuration options.** Open the file `config.cfg` in your favorite text editor. Specify the users you wish to create in the `users` list. Create a unique user for each device you plan to connect to your VPN. If you want to be able to add or delete users later, you **must** select `yes` at the `Do you want to retain the keys (PKI)?` prompt during the deployment. You should also review the other options before deployment, as changing your mind about them later [may require you to deploy a brand new server](https://github.com/trailofbits/algo/blob/master/docs/faq.md#i-deployed-an-algo-server-can-you-update-it-with-new-features).
 
 6. **Start the deployment.** Return to your terminal. In the Algo directory, run `./algo` and follow the instructions. There are several optional features available. None are required for a fully functional VPN server. These optional features are described in greater detail in [here](docs/deploy-from-ansible.md).
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ The easiest way to get an Algo server running is to run it on your local system 
 
     - Run the command `git clone https://github.com/trailofbits/algo.git` to create a directory named `algo` containing the Algo scripts.
 
-3. **Install Algo's core dependencies.** Algo requires that **Python 3** and at least one supporting package are installed on your system.
+3. **Install Algo's core dependencies.** Algo requires that **Python 3.6 or later** and at least one supporting package are installed on your system.
 
     - **macOS:** Apple does not provide Python 3 with macOS. There are two ways to obtain it:
         * Use the [Homebrew](https://brew.sh) package manager. After installing Homebrew install Python 3 by running `brew install python3`.
 
-        * Download and install the latest stable [Python 3 package](https://www.python.org/downloads/mac-osx/). Be sure to run the included *Install Certificates* command from Finder.
+        * Download and install the latest stable [Python 3.7.x package](https://www.python.org/downloads/mac-osx/) (currently Python 3.8 will not work). Be sure to run the included *Install Certificates* command from Finder.
 
         Once Python 3 is installed on your Mac, from Terminal run:
         ```bash

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/fold_left.svg?style=social&label=Follow%20%40AlgoVPN)](https://twitter.com/AlgoVPN)
 [![TravisCI Status](https://api.travis-ci.org/trailofbits/algo.svg?branch=master)](https://travis-ci.org/trailofbits/algo)
 
-Algo VPN is a set of Ansible scripts that simplify the setup of a personal Wireguard and IPSEC VPN. It uses the most secure defaults available and works with common cloud providers. See our [release announcement](https://blog.trailofbits.com/2016/12/12/meet-algo-the-vpn-that-works/) for more information.
+Algo VPN is a set of Ansible scripts that simplify the setup of a personal WireGuard and IPsec VPN. It uses the most secure defaults available and works with common cloud providers. See our [release announcement](https://blog.trailofbits.com/2016/12/12/meet-algo-the-vpn-that-works/) for more information.
 
 ## Features
 
-* Supports only IKEv2 with strong crypto (AES-GCM, SHA2, and P-256) and [WireGuard](https://www.wireguard.com/)
-* Generates Apple profiles to auto-configure iOS and macOS devices
+* Supports only IKEv2 with strong crypto (AES-GCM, SHA2, and P-256) for iOS, macOS, and Linux
+* Supports [WireGuard](https://www.wireguard.com/) for all of the above, in addition to Android and Windows 10
+* Generates .conf files and QR codes for iOS, macOS, Android, and Windows WireGuard clients
+* Generates Apple profiles to auto-configure iOS and macOS devices for IPsec - no client software required
 * Includes a helper script to add and remove users
 * Blocks ads with a local DNS resolver (optional)
 * Sets up limited SSH users for tunneling traffic (optional)

--- a/config.cfg
+++ b/config.cfg
@@ -9,39 +9,14 @@ users:
   - laptop
   - desktop
 
-### Advanced users only below this line ###
-
-# Store the PKI in a ram disk. Enabled only if store_pki (retain the PKI) is set to false
-# Supports on MacOS and Linux only (including Windows Subsystem for Linux)
-pki_in_tmpfs: true
-
-# If True re-init all existing certificates. Boolean
-keys_clean_all: False
+### Review these options BEFORE you run Algo, as they are very difficult/impossible to change after the server is deployed.
 
 # Deploy StrongSwan to enable IPsec support
 ipsec_enabled: true
 
-# StrongSwan log level
-# https://wiki.strongswan.org/projects/strongswan/wiki/LoggerConfiguration
-strongswan_log_level: 2
-
-# rightsourceip for ipsec
-# ipv4
-strongswan_network: 10.19.48.0/24
-# ipv6
-strongswan_network_ipv6: 'fd9d:bc11:4020::/48'
-
 # Deploy WireGuard
 wireguard_enabled: true
 wireguard_port: 51820
-# If you're behind NAT or a firewall and you want to receive incoming connections long after network traffic has gone silent.
-# This option will keep the "connection" open in the eyes of NAT.
-# See: https://www.wireguard.com/quickstart/#nat-and-firewall-traversal-persistence
-wireguard_PersistentKeepalive: 0
-
-# WireGuard network configuration
-wireguard_network_ipv4: 10.19.49.0/24
-wireguard_network_ipv6: fd9d:bc11:4021::/48
 
 # Reduce the MTU of the VPN tunnel
 # Some cloud and internet providers use a smaller MTU (Maximum Transmission
@@ -65,6 +40,46 @@ adblock_lists:
 # If 'false', 'dns_servers' should be specified below.
 # DNS encryption can not be disabled if DNS adblocking is enabled
 dns_encryption: true
+
+# Block traffic between connected clients. Change this to false to enable
+# connected clients to reach each other, as well as other computers on the
+# same LAN as your Algo server (i.e. the "road warrior" setup). In this
+# case, you may also want to enable SMB/CIFS and NETBIOS traffic below.
+BetweenClients_DROP: true
+
+# Block SMB/CIFS traffic
+block_smb: true
+
+# Block NETBIOS traffic
+block_netbios: true
+
+### Advanced users only below this line ###
+
+# Store the PKI in a ram disk. Enabled only if store_pki (retain the PKI) is set to false
+# Supports on MacOS and Linux only (including Windows Subsystem for Linux)
+pki_in_tmpfs: true
+
+# If True re-init all existing certificates. Boolean
+keys_clean_all: False
+
+# StrongSwan log level
+# https://wiki.strongswan.org/projects/strongswan/wiki/LoggerConfiguration
+strongswan_log_level: 2
+
+# rightsourceip for ipsec
+# ipv4
+strongswan_network: 10.19.48.0/24
+# ipv6
+strongswan_network_ipv6: 'fd9d:bc11:4020::/48'
+
+# If you're behind NAT or a firewall and you want to receive incoming connections long after network traffic has gone silent.
+# This option will keep the "connection" open in the eyes of NAT.
+# See: https://www.wireguard.com/quickstart/#nat-and-firewall-traversal-persistence
+wireguard_PersistentKeepalive: 0
+
+# WireGuard network configuration
+wireguard_network_ipv4: 10.19.49.0/24
+wireguard_network_ipv6: fd9d:bc11:4021::/48
 
 # DNS servers which will be used if 'dns_encryption' is 'true'. Multiple
 # providers may be specified, but avoid mixing providers that filter results
@@ -102,17 +117,6 @@ unattended_reboot:
   enabled: false
   time: 06:00
 
-# Block traffic between connected clients. Change this to false to enable
-# connected clients to reach each other, as well as other computers on the
-# same LAN as your Algo server (i.e. the "road warrior" setup). In this
-# case, you may also want to enable SMB/CIFS and NETBIOS traffic below.
-BetweenClients_DROP: true
-
-# Block SMB/CIFS traffic
-block_smb: true
-
-# Block NETBIOS traffic
-block_netbios: true
 
 congrats:
   common: |
@@ -142,7 +146,7 @@ cloud_providers:
     size: s-1vcpu-1gb
     image: "ubuntu-19-04-x64"
   ec2:
-    # Change the encrypted flag to "true" to enable AWS volume encryption, for encryption of data at rest.
+    # Change the encrypted flag to "false" to disable AWS volume encryption.
     encrypted: true
     # Set use_existing_eip to "true" if you want to use a pre-allocated Elastic IP
     # Additional prompt will be raised to determine which IP to use

--- a/config.cfg
+++ b/config.cfg
@@ -102,7 +102,10 @@ unattended_reboot:
   enabled: false
   time: 06:00
 
-# Block traffic between connected clients
+# Block traffic between connected clients. Change this to false to enable
+# connected clients to reach each other, as well as other computers on the
+# same LAN as your Algo server (i.e. the "road warrior" setup). In this
+# case, you may also want to enable SMB/CIFS and NETBIOS traffic below.
 BetweenClients_DROP: true
 
 # Block SMB/CIFS traffic

--- a/config.cfg
+++ b/config.cfg
@@ -53,33 +53,16 @@ block_smb: true
 # Block NETBIOS traffic
 block_netbios: true
 
+# Your Algo server will automatically install security updates. Some updates
+# require a reboot to take effect but your Algo server will not reboot itself
+# automatically unless you change 'enabled' below from 'false' to 'true', in
+# which case a reboot will take place if necessary at the time specified (as
+# HH:MM) in the time zone of your Algo server. The default time zone is UTC.
+unattended_reboot:
+  enabled: false
+  time: 06:00
+
 ### Advanced users only below this line ###
-
-# Store the PKI in a ram disk. Enabled only if store_pki (retain the PKI) is set to false
-# Supports on MacOS and Linux only (including Windows Subsystem for Linux)
-pki_in_tmpfs: true
-
-# If True re-init all existing certificates. Boolean
-keys_clean_all: False
-
-# StrongSwan log level
-# https://wiki.strongswan.org/projects/strongswan/wiki/LoggerConfiguration
-strongswan_log_level: 2
-
-# rightsourceip for ipsec
-# ipv4
-strongswan_network: 10.19.48.0/24
-# ipv6
-strongswan_network_ipv6: 'fd9d:bc11:4020::/48'
-
-# If you're behind NAT or a firewall and you want to receive incoming connections long after network traffic has gone silent.
-# This option will keep the "connection" open in the eyes of NAT.
-# See: https://www.wireguard.com/quickstart/#nat-and-firewall-traversal-persistence
-wireguard_PersistentKeepalive: 0
-
-# WireGuard network configuration
-wireguard_network_ipv4: 10.19.49.0/24
-wireguard_network_ipv6: fd9d:bc11:4021::/48
 
 # DNS servers which will be used if 'dns_encryption' is 'true'. Multiple
 # providers may be specified, but avoid mixing providers that filter results
@@ -104,18 +87,35 @@ dns_servers:
     - 2606:4700:4700::1111
     - 2606:4700:4700::1001
 
+# Store the PKI in a ram disk. Enabled only if store_pki (retain the PKI) is set to false
+# Supports on MacOS and Linux only (including Windows Subsystem for Linux)
+pki_in_tmpfs: true
+
+# Set this to 'true' when running './algo update-users' if you want ALL users to get new certs, not just new users. 
+keys_clean_all: false
+
+# StrongSwan log level
+# https://wiki.strongswan.org/projects/strongswan/wiki/LoggerConfiguration
+strongswan_log_level: 2
+
+# rightsourceip for ipsec
+# ipv4
+strongswan_network: 10.19.48.0/24
+# ipv6
+strongswan_network_ipv6: 'fd9d:bc11:4020::/48'
+
+# If you're behind NAT or a firewall and you want to receive incoming connections long after network traffic has gone silent.
+# This option will keep the "connection" open in the eyes of NAT.
+# See: https://www.wireguard.com/quickstart/#nat-and-firewall-traversal-persistence
+wireguard_PersistentKeepalive: 0
+
+# WireGuard network configuration
+wireguard_network_ipv4: 10.19.49.0/24
+wireguard_network_ipv6: fd9d:bc11:4021::/48
+
 # Randomly generated IP address for the local dns resolver
 local_service_ip: "{{ '172.16.0.1' | ipmath(1048573 | random(seed=algo_server_name + ansible_fqdn)) }}"
 local_service_ipv6: "{{ 'fd00::1' | ipmath(1048573 | random(seed=algo_server_name + ansible_fqdn)) }}"
-
-# Your Algo server will automatically install security updates. Some updates
-# require a reboot to take effect but your Algo server will not reboot itself
-# automatically unless you change 'enabled' below from 'false' to 'true', in
-# which case a reboot will take place if necessary at the time specified (as
-# HH:MM) in the time zone of your Algo server. The default time zone is UTC.
-unattended_reboot:
-  enabled: false
-  time: 06:00
 
 
 congrats:

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -31,7 +31,7 @@ See below for more information about variables and roles.
 - `ondemand_wifi_exclude` (Required if `ondemand_wifi` set) - WiFi networks to exclude from using the VPN. Comma-separated values
 - `dns_adblocking` - (Optional) Enables dnscrypt-proxy adblocking. Default: false
 - `ssh_tunneling` - (Optional) Enable SSH tunneling for each user. Default: false
-- `store_cakey` - (Optional) Whether or not keep the CA key (required to add users in the future, but less secure). Default: false
+- `store_pki` - (Optional) Whether or not keep the CA key (required to add users in the future, but less secure). Default: false
 
 If any of the above variables are unspecified, ansible will ask the user to input them.
 

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -26,8 +26,8 @@ See below for more information about variables and roles.
 
 - `provider` - (Required) The provider to use. See possible values below
 - `server_name` - (Required) Server name. Default: algo
-- `ondemand_cellular` (Optional) VPN On Demand when connected to cellular networks with IPsec. Default: false
-- `ondemand_wifi` - (Optional. See `ondemand_wifi_exclude`) VPN On Demand when connected to WiFi networks with IPsec. Default: false
+- `ondemand_cellular` (Optional) Enables VPN On Demand when connected to cellular networks for iOS/macOS clients using IPsec. Default: false
+- `ondemand_wifi` - (Optional. See `ondemand_wifi_exclude`) Enables VPN On Demand when connected to WiFi networks for iOS/macOS clients using IPsec. Default: false
 - `ondemand_wifi_exclude` (Required if `ondemand_wifi` set) - WiFi networks to exclude from using the VPN. Comma-separated values
 - `dns_adblocking` - (Optional) Enables dnscrypt-proxy adblocking. Default: false
 - `ssh_tunneling` - (Optional) Enable SSH tunneling for each user. Default: false

--- a/docs/deploy-from-script-or-cloud-init-to-localhost.md
+++ b/docs/deploy-from-script-or-cloud-init-to-localhost.md
@@ -1,8 +1,7 @@
 # Deploy from script or cloud-init
 
 You can use `install.sh` to prepare the environment and deploy AlgoVPN on the local Ubuntu server in one shot using cloud-init, or run the script directly on the server after it's been created. 
-
-The script doesn't configure any parameters in your cloud, so you're on your own to configure related [firewall rules](/docs/firewalls.md), a floating IP address and other resources you may need. The output of the install script (including the p12 and CA passwords) can be found at `/var/log/algo.log`, and user config files will be installed into the `/opt/algo/configs/localhost` directory. If you need to update users later, change the user list in `/opt/algo/config.cfg` and run `./algo update-users` from that directory.
+The script doesn't configure any parameters in your cloud, so you're on your own to configure related [firewall rules](/docs/firewalls.md), a floating IP address and other resources you may need. The output of the install script (including the p12 and CA passwords) can be found at `/var/log/algo.log`, and user config files will be installed into the `/opt/algo/configs/localhost` directory. If you need to update users later, `cd /opt/algo`, change the user list in `config.cfg`, install additional dependencies as in step 4 of the [main README](https://github.com/trailofbits/algo/blob/master/README.md), and run `./algo update-users` from that directory.
 
 ## Cloud init deployment
 

--- a/docs/deploy-from-script-or-cloud-init-to-localhost.md
+++ b/docs/deploy-from-script-or-cloud-init-to-localhost.md
@@ -2,7 +2,7 @@
 
 You can use `install.sh` to prepare the environment and deploy AlgoVPN on the local Ubuntu server in one shot using cloud-init, or run the script directly on the server after it's been created. 
 
-The script doesn't configure any parameters in your cloud, so it's on your own to configure related [firewall rules](/docs/firewalls.md), a floating ip address and other resources you may need. The output of the install script (including the p12 and CA passwords) and user config files will be installed into the `/opt/algo` directory.
+The script doesn't configure any parameters in your cloud, so you're on your own to configure related [firewall rules](/docs/firewalls.md), a floating IP address and other resources you may need. The output of the install script (including the p12 and CA passwords) and user config files will be installed into the `/opt/algo` directory. If you need to update users later, change the user list in `/opt/algo/config.cfg` and run `./algo update-users` from that directory.
 
 ## Cloud init deployment
 

--- a/docs/deploy-from-script-or-cloud-init-to-localhost.md
+++ b/docs/deploy-from-script-or-cloud-init-to-localhost.md
@@ -2,7 +2,7 @@
 
 You can use `install.sh` to prepare the environment and deploy AlgoVPN on the local Ubuntu server in one shot using cloud-init, or run the script directly on the server after it's been created. 
 
-The script doesn't configure any parameters in your cloud, so you're on your own to configure related [firewall rules](/docs/firewalls.md), a floating IP address and other resources you may need. The output of the install script (including the p12 and CA passwords) and user config files will be installed into the `/opt/algo` directory. If you need to update users later, change the user list in `/opt/algo/config.cfg` and run `./algo update-users` from that directory.
+The script doesn't configure any parameters in your cloud, so you're on your own to configure related [firewall rules](/docs/firewalls.md), a floating IP address and other resources you may need. The output of the install script (including the p12 and CA passwords) can be found at `/var/log/algo.log`, and user config files will be installed into the `/opt/algo/configs/localhost` directory. If you need to update users later, change the user list in `/opt/algo/config.cfg` and run `./algo update-users` from that directory.
 
 ## Cloud init deployment
 

--- a/docs/deploy-to-ubuntu.md
+++ b/docs/deploy-to-ubuntu.md
@@ -11,7 +11,7 @@ Make sure your target server is running an unmodified copy of the operating syst
 # Road Warrior setup
 
 Some may find it useful to set up an Algo server on an Ubuntu box on your home LAN, with the intention of being able to securely access your LAN and any resources on it when you're traveling elsewhere (the ["road warrior" setup](https://en.wikipedia.org/wiki/Road_warrior_(computing))). A few tips if you're doing so:
-- Make sure you redirect any relevant incoming ports (UDP/500, UDP/4500, and UDP/51820) to the Algo server from your router;
+- Make sure you forward any [relevant incoming ports](/docs/firewalls.md#external-firewall) to the Algo server from your router;
 - Change `BetweenClients_DROP` in `config.cfg` to `false`, and also consider changing `block_smb` and `block_netbios` to `false`;
 - If you want to use a DNS server on your LAN to resolve local domain names properly (e.g. a Pi-hole), set the `dns_encryption` flag in `config.cfg` to `false`, and change `dns_servers` to the local DNS server IP (i.e. `192.168.1.2`).
 

--- a/docs/deploy-to-ubuntu.md
+++ b/docs/deploy-to-ubuntu.md
@@ -8,4 +8,11 @@ Install to existing Ubuntu 18.04 or 19.04 server (Advanced)
 ```
 Make sure your target server is running an unmodified copy of the operating system version specified. The target can be the same system where you've installed the Algo scripts, or a remote system that you are able to access as root via SSH without needing to enter the SSH key passphrase (such as when using `ssh-agent`).
 
+# Road Warrior setup
+
+Some may find it useful to set up an Algo server on an Ubuntu box on your home LAN, with the intention of being able to securely access your LAN and any resources on it when you're traveling elsewhere (the ["road warrior" setup](https://en.wikipedia.org/wiki/Road_warrior_(computing))). A few tips if you're doing so:
+- Make sure you redirect any relevant incoming ports (UDP/500, UDP/4500, and UDP/51820) to the Algo server from your router;
+- Change `BetweenClients_DROP` in `config.cfg` to `false`, and also consider changing `block_smb` and `block_netbios` to `false`;
+- If you want to use a DNS server on your LAN to resolve local domain names properly (e.g. a Pi-hole), set the `dns_encryption` flag in `config.cfg` to `false`, and change `dns_servers` to the local DNS server IP (i.e. `192.168.1.2`).
+
 **PLEASE NOTE**: Algo is intended for use to create a _dedicated_ VPN server. No uninstallation option is provided. If you install Algo on an existing server any existing services might break. In particular, the firewall rules will be overwritten. See [AlgoVPN and Firewalls](/docs/firewalls.md) for more information.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,7 @@
 # FAQ
 
 * [Has Algo been audited?](#has-algo-been-audited)
+* [What's the current status of WireGuard?](#whats-the-current-status-of-wireguard)
 * [Why aren't you using Tor?](#why-arent-you-using-tor)
 * [Why aren't you using Racoon, LibreSwan, or OpenSwan?](#why-arent-you-using-racoon-libreswan-or-openswan)
 * [Why aren't you using a memory-safe or verified IKE daemon?](#why-arent-you-using-a-memory-safe-or-verified-ike-daemon)
@@ -19,7 +20,7 @@ No. This project is under active development. We're happy to [accept and fix iss
 
 ## What's the current status of WireGuard?
 
-[WireGuard is a work in progress](https://www.wireguard.com/#work-in-progress). It has undergone [substantial](https://www.wireguard.com/formal-verification/) security review, however, its authors are appropriately cautious about its safety and the protocol is subject to change. As a result, WireGuard does not yet have a "stable" 1.0 release. Releases are tagged with their build date -- "0.0.YYYYMMDD" -- and users should be advised to apply new updates when they are available. Your Algo server will automatically upgrade and restart WireGuard from the [official WireGuard PPA for Ubuntu] https://launchpad.net/~wireguard/+archive/ubuntu/wireguard by default.
+[WireGuard is a work in progress](https://www.wireguard.com/#work-in-progress). It has undergone [substantial](https://www.wireguard.com/formal-verification/) security review, however, its authors are appropriately cautious about its safety and the protocol is subject to change. As a result, WireGuard does not yet have a "stable" 1.0 release. Releases are tagged with their build date -- "0.0.YYYYMMDD" -- and users should be advised to apply new updates when they are available. Your Algo server will automatically upgrade and restart WireGuard from the [official WireGuard PPA for Ubuntu](https://launchpad.net/~wireguard/+archive/ubuntu/wireguard) by default.
 
 ## Why aren't you using Tor?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -11,6 +11,7 @@
 * [Can DNS filtering be disabled?](#can-dns-filtering-be-disabled)
 * [Wasn't IPSEC backdoored by the US government?](#wasnt-ipsec-backdoored-by-the-us-government)
 * [What inbound ports are used?](#what-inbound-ports-are-used)
+* [How do I monitor user activity?](#how-do-i-monitor-user-activity)
 
 ## Has Algo been audited?
 
@@ -79,3 +80,7 @@ No.
 ## What inbound ports are used?
 
 You should only need 22/TCP, 500/UDP, 4500/UDP, and 51820/UDP opened on any firewall that sits between your clients and your Algo server. See [AlgoVPN and Firewalls](/docs/firewalls.md) for more information.
+
+## How do I monitor user activity?
+
+Your Algo server will track IPsec client logins by default in `/var/log/syslog`. This will give you client names, date/time of connection and reconnection, and what IP addresses they're connecting from. This can be disabled entirely by setting `strongswan_log_level` to `-1` in `config.cfg`. Wireguard doesn't save any logs, but entering `sudo wg` on the server will give you the last endpoint and contact time of each client. Disabling this is [paradoxically difficult](https://git.zx2c4.com/blind-operator-mode/about/). There isn't any out-of-the-box way to monitor actual user _activity_ (e.g. websites browsed, etc.)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,7 +43,7 @@ Alpine Linux is not supported out-of-the-box by any major cloud provider. We are
 
 ## I deployed an Algo server. Can you update it with new features?
 
-No. By design, the Algo development team has no access to any Algo server that our users haved deployed. We cannot modify the configuration, update the software, or sniff the traffic that goes through your personal Algo VPN server. This prevents scenarios where we are legally compelled or hacked to push down backdoored updates that surveil our users.
+No. By design, the Algo development team has no access to any Algo server that our users have deployed. We cannot modify the configuration, update the software, or sniff the traffic that goes through your personal Algo VPN server. This prevents scenarios where we are legally compelled or hacked to push down backdoored updates that surveil our users.
 
 As a result, once your Algo server has been deployed, it is yours to maintain. If you want to take advantage of new features available in the current release of Algo, then you have two options. You can use the [SSH administrative interface](/README.md#ssh-into-algo-server) to make the changes you want on your own or you can shut down the server and deploy a new one (recommended).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,7 +46,7 @@ No. By design, the Algo development team has no access to any Algo server that o
 
 As a result, once your Algo server has been deployed, it is yours to maintain. If you want to take advantage of new features available in the current release of Algo, then you have two options. You can use the [SSH administrative interface](/README.md#ssh-into-algo-server) to make the changes you want on your own or you can shut down the server and deploy a new one (recommended).
 
-In the future, we will make it easier for users who want to update their own servers by providing official releases of Algo. Each official release will summarize the changes from the last release to make it easier to follow along with them.
+As an extension of this rationale, most configuration options (other than users) available in `config.cfg` can only be set at the time of initial deployment.
 
 ## Where did the name "Algo" come from?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,7 +19,7 @@ No. This project is under active development. We're happy to [accept and fix iss
 
 ## What's the current status of WireGuard?
 
-[WireGuard is a work in progress](https://www.wireguard.com/#work-in-progress). It has undergone [substantial](https://www.wireguard.com/formal-verification/) security review, however, its authors are appropriately cautious about its safety and the protocol is subject to change. As a result, WireGuard does not yet have a "stable" 1.0 release. Releases are tagged with their build date -- "0.0.YYYYMMDD" -- and users should be advised to apply new updates when they are available.
+[WireGuard is a work in progress](https://www.wireguard.com/#work-in-progress). It has undergone [substantial](https://www.wireguard.com/formal-verification/) security review, however, its authors are appropriately cautious about its safety and the protocol is subject to change. As a result, WireGuard does not yet have a "stable" 1.0 release. Releases are tagged with their build date -- "0.0.YYYYMMDD" -- and users should be advised to apply new updates when they are available. Your Algo server will automatically upgrade and restart WireGuard from the [official WireGuard PPA for Ubuntu] https://launchpad.net/~wireguard/+archive/ubuntu/wireguard by default.
 
 ## Why aren't you using Tor?
 
@@ -45,7 +45,7 @@ Alpine Linux is not supported out-of-the-box by any major cloud provider. We are
 
 No. By design, the Algo development team has no access to any Algo server that our users have deployed. We cannot modify the configuration, update the software, or sniff the traffic that goes through your personal Algo VPN server. This prevents scenarios where we are legally compelled or hacked to push down backdoored updates that surveil our users.
 
-As a result, once your Algo server has been deployed, it is yours to maintain. If you want to take advantage of new features available in the current release of Algo, then you have two options. You can use the [SSH administrative interface](/README.md#ssh-into-algo-server) to make the changes you want on your own or you can shut down the server and deploy a new one (recommended).
+As a result, once your Algo server has been deployed, it is yours to maintain. It will use unattended-upgrades by default to apply security and feature updates to Ubuntu, as well as to the core VPN software of strongSwan, dnscrypt-proxy and WireGuard. However, if you want to take advantage of new features available in the current release of Algo, then you have two options. You can use the [SSH administrative interface](/README.md#ssh-into-algo-server) to make the changes you want on your own or you can shut down the server and deploy a new one (recommended).
 
 As an extension of this rationale, most configuration options (other than users) available in `config.cfg` can only be set at the time of initial deployment.
 
@@ -55,7 +55,7 @@ Algo is short for "Al Gore", the **V**ice **P**resident of **N**etworks everywhe
 
 ## Can DNS filtering be disabled?
 
-You can temporarily disable DNS filtering for all IPsec clients at once with the following workaround: SSH to your Algo server (using the 'shell access' command printed upon a successful deployment), edit `/etc/ipsec.conf`, and change `rightdns=<random_ip>` to `rightdns=8.8.8.8`. Then run `sudo systemctl restart strongswan`. DNS filtering for Wireguard clients has to be disabled on each client device separately by modifying the settings in the app, or by directly modifying the `DNS` setting on the `clientname.conf` file. If all else fails, we recommend deploying a new Algo server without the adblocking feature enabled.
+You can temporarily disable DNS filtering for all IPsec clients at once with the following workaround: SSH to your Algo server (using the 'shell access' command printed upon a successful deployment), edit `/etc/ipsec.conf`, and change `rightdns=<random_ip>` to `rightdns=8.8.8.8`. Then run `sudo systemctl restart strongswan`. DNS filtering for WireGuard clients has to be disabled on each client device separately by modifying the settings in the app, or by directly modifying the `DNS` setting on the `clientname.conf` file. If all else fails, we recommend deploying a new Algo server without the adblocking feature enabled.
 
 ## Wasn't IPSEC backdoored by the US government?
 
@@ -83,4 +83,4 @@ You should only need 22/TCP, 500/UDP, 4500/UDP, and 51820/UDP opened on any fire
 
 ## How do I monitor user activity?
 
-Your Algo server will track IPsec client logins by default in `/var/log/syslog`. This will give you client names, date/time of connection and reconnection, and what IP addresses they're connecting from. This can be disabled entirely by setting `strongswan_log_level` to `-1` in `config.cfg`. Wireguard doesn't save any logs, but entering `sudo wg` on the server will give you the last endpoint and contact time of each client. Disabling this is [paradoxically difficult](https://git.zx2c4.com/blind-operator-mode/about/). There isn't any out-of-the-box way to monitor actual user _activity_ (e.g. websites browsed, etc.)
+Your Algo server will track IPsec client logins by default in `/var/log/syslog`. This will give you client names, date/time of connection and reconnection, and what IP addresses they're connecting from. This can be disabled entirely by setting `strongswan_log_level` to `-1` in `config.cfg`. WireGuard doesn't save any logs, but entering `sudo wg` on the server will give you the last endpoint and contact time of each client. Disabling this is [paradoxically difficult](https://git.zx2c4.com/blind-operator-mode/about/). There isn't any out-of-the-box way to monitor actual user _activity_ (e.g. websites browsed, etc.)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,6 +13,7 @@
 * [Wasn't IPSEC backdoored by the US government?](#wasnt-ipsec-backdoored-by-the-us-government)
 * [What inbound ports are used?](#what-inbound-ports-are-used)
 * [How do I monitor user activity?](#how-do-i-monitor-user-activity)
+* [How do I reach another connected client?](#how-do-i-reach-another-connected-client)
 
 ## Has Algo been audited?
 
@@ -85,3 +86,7 @@ You should only need 22/TCP, 500/UDP, 4500/UDP, and 51820/UDP opened on any fire
 ## How do I monitor user activity?
 
 Your Algo server will track IPsec client logins by default in `/var/log/syslog`. This will give you client names, date/time of connection and reconnection, and what IP addresses they're connecting from. This can be disabled entirely by setting `strongswan_log_level` to `-1` in `config.cfg`. WireGuard doesn't save any logs, but entering `sudo wg` on the server will give you the last endpoint and contact time of each client. Disabling this is [paradoxically difficult](https://git.zx2c4.com/blind-operator-mode/about/). There isn't any out-of-the-box way to monitor actual user _activity_ (e.g. websites browsed, etc.)
+
+## How do I reach another connected client?
+
+By default, your Algo server doesn't allow connections between connected clients. This can be changed at the time of deployment by enabling the `BetweenClients_DROP` flag in `config.cfg`. See the ["Road Warrior" instructions](/docs/deploy-to-ubuntu.md#road-warrior-setup) for more details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,14 +5,14 @@
   - Deploy from [Windows](deploy-from-windows.md)
   - Deploy from a [Docker container](deploy-from-docker.md)
   - Deploy from [Ansible](deploy-from-ansible.md) non-interactively
-  - Deploy onto a [cloud server at time of creation](deploy-from-script-or-cloud-init-to-localhost.md)
+  - Deploy onto a [cloud server at time of creation with shell script or cloud-init](deploy-from-script-or-cloud-init-to-localhost.md)
 * Client setup
   - Setup [Android](client-android.md) clients
   - Setup [Generic/Linux](client-linux.md) clients with Ansible
   - Setup Ubuntu clients to use [WireGuard](client-linux-wireguard.md)
-  - Setup Linux clients to use [IPSEC](client-linux-ipsec.md)
-  - Setup Apple devices to use [IPSEC](client-apple-ipsec.md)
-  - Setup Macs running macOS 10.13 or older to use [Wireguard](client-macos-wireguard.md)
+  - Setup Linux clients to use [IPsec](client-linux-ipsec.md)
+  - Setup Apple devices to use [IPsec](client-apple-ipsec.md)
+  - Setup Macs running macOS 10.13 or older to use [WireGuard](client-macos-wireguard.md)
 * Cloud provider setup
   - Configure [Amazon EC2](cloud-amazon-ec2.md)
   - Configure [Azure](cloud-azure.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@
   - Configure [Hetzner Cloud](cloud-hetzner.md)
 * Advanced Deployment
   - Deploy to your own [FreeBSD](deploy-to-freebsd.md) server
-  - Deploy to your own [Ubuntu](deploy-to-ubuntu.md) server
+  - Deploy to your own [Ubuntu](deploy-to-ubuntu.md) server, and road warrior setup
   - Deploy to an [unsupported cloud provider](deploy-to-unsupported-cloud.md)
 * [FAQ](faq.md)
 * [Firewalls](firewalls.md)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fixes the new variable name (`store_cakey` -> `store_pki`) in the deploy from Ansible docs
- Updates "mission statement" paragraph to reflect the primary use of Wireguard (and its client apps)
- Clarifies the FAQ about clients connecting to each other.
- Clarifies the prompts about VPN On Demand apply only to Apple IPsec clients.
- Encourages people to set their config options and review `config.cfg` _before_ deployment.
- Clarifies that servers (mostly) can't be upgraded to take advantage of "new Algo features".
- Adds instructions to the cloud-init docs about updating user list, and adds the correct locations of install log and configs.
- Adds a FAQ about monitoring user activity.
- Documents Python version incompatibilities described in #1622 
- Adds Road warrior instructions to the "deploy to Ubuntu" instructions.
- Reorganizes `config.cfg` and (again) encourages setting options before deployment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1606.
Fixes question asked in #624 (and in the Gitter chat, numerous times)
Attempts to address #1538 (again)
Closes #1596 .
Nice callback to #1291 .
Addresses #1283, #1216, #1555, closes #1600 , and again numerous questions in Gitter chat
Through a time warp, closes #1610 _before_ it was raised.
Closes #1622 .
Closes #1609 .
Documents the "BetweenClients_DROP" option brought up in #1516, #821, #1171 among others.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Only way to test if documentation works is to see if people still have questions.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
