### PR TITLE
Support Ubuntu 19.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,12 +112,18 @@ matrix:
     - <<: *deploy-local
       name: 'Ubuntu 19.04: local deployment from docker'
       env: DEPLOY=docker UBUNTU_VERSION=19.04
+    - <<: *deploy-local
+      name: 'Ubuntu 19.10: local deployment from docker'
+      env: DEPLOY=docker UBUNTU_VERSION=19.10
     - <<: *deploy-cloudinit
       name: 'Ubuntu 18.04: cloud-init deployment'
       env: DEPLOY=cloud-init UBUNTU_VERSION=18.04
     - <<: *deploy-cloudinit
       name: 'Ubuntu 19.04: cloud-init deployment'
       env: DEPLOY=cloud-init UBUNTU_VERSION=19.04
+    - <<: *deploy-cloudinit
+      name: 'Ubuntu 19.10: cloud-init deployment'
+      env: DEPLOY=cloud-init UBUNTU_VERSION=19.10
 
 notifications:
   email: false

--- a/docs/deploy-to-ubuntu.md
+++ b/docs/deploy-to-ubuntu.md
@@ -4,7 +4,7 @@ You can use Algo to configure a pre-existing server as an AlgoVPN rather than us
 
 Install the Algo scripts following the normal installation instructions, then choose:
 ```
-Install to existing Ubuntu 18.04 or 19.04 server (Advanced)
+Install to existing Ubuntu 18.04, 19.04, or 19.10 server (Advanced)
 ```
 Make sure your target server is running an unmodified copy of the operating system version specified. The target can be the same system where you've installed the Algo scripts, or a remote system that you are able to access as root via SSH without needing to enter the SSH key passphrase (such as when using `ssh-agent`).
 

--- a/docs/deploy-to-unsupported-cloud.md
+++ b/docs/deploy-to-unsupported-cloud.md
@@ -2,7 +2,7 @@
 
 Algo officially supports the [cloud providers listed here](https://github.com/trailofbits/algo/blob/master/README.md#deploy-the-algo-server). If you want to deploy Algo on another virtual hosting provider, that provider must support:
 
-1. the base operating system image that Algo uses (Ubuntu 18.04, 19.04), and
+1. the base operating system image that Algo uses (Ubuntu 18.04, 19.04, or 19.10), and
 2. a minimum of certain kernel modules required for the strongSwan IPsec server.
 
 Please see the [Required Kernel Modules](https://wiki.strongswan.org/projects/strongswan/wiki/KernelModules) documentation from strongSwan for a list of the specific required modules and a script to check for them. As a first step, we recommend running their shell script to determine initial compatibility with your new hosting provider.

--- a/input.yml
+++ b/input.yml
@@ -21,7 +21,7 @@
       - { name: Scaleway, alias: scaleway}
       - { name: OpenStack (DreamCompute optimised), alias: openstack }
       - { name: CloudStack (Exoscale optimised), alias: cloudstack }
-      - { name: Install to existing Ubuntu 18.04 or 19.04 server (Advanced), alias: local }
+      - { name: Install to existing Ubuntu 18.04, 19.04, or 19.10 server (Advanced), alias: local }
   vars_files:
     - config.cfg
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes documentation, prompts, and CI tests to support Ubuntu 19.10 (eoan). No other changes were required. It does not make 19.10 the default for any cloud providers at this time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ubuntu 19.04 (disco) will EOL on 2020-01-18, well before the release of 20.04 LTS (focal) on 2020-04-23.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Performed a cloud deployment from a 19.10 client to a 19.10 Droplet on DigitalOcean. Performed a local installation on a 19.10 Droplet on DigitalOcean. Tested each from iOS using both WireGuard and IPsec.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
