### PR TITLE
Remove some commas from input.yml

### DIFF
--- a/input.yml
+++ b/input.yml
@@ -21,7 +21,7 @@
       - { name: Scaleway, alias: scaleway}
       - { name: OpenStack (DreamCompute optimised), alias: openstack }
       - { name: CloudStack (Exoscale optimised), alias: cloudstack }
-      - { name: Install to existing Ubuntu 18.04 19.04 or 19.10 server (Advanced), alias: local }
+      - { name: "Install to existing Ubuntu 18.04, 19.04, or 19.10 server (Advanced)", alias: local }
   vars_files:
     - config.cfg
 

--- a/input.yml
+++ b/input.yml
@@ -21,7 +21,7 @@
       - { name: Scaleway, alias: scaleway}
       - { name: OpenStack (DreamCompute optimised), alias: openstack }
       - { name: CloudStack (Exoscale optimised), alias: cloudstack }
-      - { name: Install to existing Ubuntu 18.04, 19.04, or 19.10 server (Advanced), alias: local }
+      - { name: Install to existing Ubuntu 18.04 19.04 or 19.10 server (Advanced), alias: local }
   vars_files:
     - config.cfg
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I previously added some commas to the local install prompt in `input.yml` as part of #1630, but it turns out the commas cause the prompt to be truncated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The prompt is wrong.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Initiated a local install on a new Droplet and observed the proper prompt.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] All new and existing tests passed.
