### PR TITLE
Ca certificate name constraints

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -4,6 +4,7 @@
 # Every device must have a unique username.
 # You can generate up to 250 users at one time.
 # Usernames with leading 0's or containing only numbers should be escaped in double quotes, e.g. "000dan" or "123".
+# Emails are not allowed
 users:
   - phone
   - laptop

--- a/roles/strongswan/defaults/main.yml
+++ b/roles/strongswan/defaults/main.yml
@@ -11,9 +11,9 @@ algo_dns_adblocking: false
 ipv6_support: false
 dns_encryption: true
 domain: false
-openssl_user_domain: algo.vpn
+openssl_constraint_random_id: "{{ IP_subject_alt_name | to_uuid }}"
 subjectAltName_IP: "{{ 'DNS:' if IP_subject_alt_name|regex_search('[a-z]') else 'IP:' }}{{ IP_subject_alt_name }}"
-subjectAltName_USER: "email:{{ item }}@{{ openssl_user_domain }}"
+subjectAltName_USER: "email:{{ item }}@{{ openssl_constraint_random_id }}"
 openssl_bin: openssl
 strongswan_enabled_plugins:
   - aes

--- a/roles/strongswan/defaults/main.yml
+++ b/roles/strongswan/defaults/main.yml
@@ -11,8 +11,9 @@ algo_dns_adblocking: false
 ipv6_support: false
 dns_encryption: true
 domain: false
+openssl_user_domain: algo.vpn
 subjectAltName_IP: "{{ 'DNS:' if IP_subject_alt_name|regex_search('[a-z]') else 'IP:' }}{{ IP_subject_alt_name }}"
-subjectAltName_USER: "{% if '@' in item %}email:{{ item }}{% else %}DNS:{{ item }}{% endif %}"
+subjectAltName_USER: "email:{{ item }}@{{ openssl_user_domain }}"
 openssl_bin: openssl
 strongswan_enabled_plugins:
   - aes

--- a/roles/strongswan/defaults/main.yml
+++ b/roles/strongswan/defaults/main.yml
@@ -10,10 +10,25 @@ algo_ondemand_wifi_exclude: '_null'
 algo_dns_adblocking: false
 ipv6_support: false
 dns_encryption: true
-domain: false
 openssl_constraint_random_id: "{{ IP_subject_alt_name | to_uuid }}.algo"
-subjectAltName_IP: "{{ 'DNS:' if IP_subject_alt_name|regex_search('[a-z]') else 'IP:' }}{{ IP_subject_alt_name }}"
+subjectAltName_type: "{{ 'DNS' if IP_subject_alt_name|regex_search('[a-z]') else 'IP' }}"
+subjectAltName: >-
+  {{ subjectAltName_type }}:{{ IP_subject_alt_name }}
+  {%- if ipv6_support -%},IP:{{ ansible_default_ipv6['address'] }}{%- endif -%}
 subjectAltName_USER: "email:{{ item }}@{{ openssl_constraint_random_id }}"
+nameConstraints: >-
+  permitted;{{ subjectAltName_type }}:{{ IP_subject_alt_name }}{{- '/255.255.255.255' if subjectAltName_type == 'IP' else '' -}}
+  {%- if subjectAltName_type == 'IP' -%}
+  ,permitted;DNS:{{ openssl_constraint_random_id }}
+  {%- else -%}
+  ,excluded;IP:0.0.0.0/0.0.0.0
+  {%- endif -%}
+  ,permitted;email:{{ openssl_constraint_random_id }}
+  {%- if ipv6_support -%}
+  ,permitted;IP:{{ ansible_default_ipv6['address'] }}/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+  {%- else -%}
+  ,excluded;IP:0:0:0:0:0:0:0:0/0:0:0:0:0:0:0:0
+  {%- endif -%}
 openssl_bin: openssl
 strongswan_enabled_plugins:
   - aes

--- a/roles/strongswan/defaults/main.yml
+++ b/roles/strongswan/defaults/main.yml
@@ -17,7 +17,7 @@ subjectAltName: >-
   {%- if ipv6_support -%},IP:{{ ansible_default_ipv6['address'] }}{%- endif -%}
 subjectAltName_USER: "email:{{ item }}@{{ openssl_constraint_random_id }}"
 nameConstraints: >-
-  permitted;{{ subjectAltName_type }}:{{ IP_subject_alt_name }}{{- '/255.255.255.255' if subjectAltName_type == 'IP' else '' -}}
+  critical,permitted;{{ subjectAltName_type }}:{{ IP_subject_alt_name }}{{- '/255.255.255.255' if subjectAltName_type == 'IP' else '' -}}
   {%- if subjectAltName_type == 'IP' -%}
   ,permitted;DNS:{{ openssl_constraint_random_id }}
   {%- else -%}

--- a/roles/strongswan/defaults/main.yml
+++ b/roles/strongswan/defaults/main.yml
@@ -11,7 +11,7 @@ algo_dns_adblocking: false
 ipv6_support: false
 dns_encryption: true
 domain: false
-openssl_constraint_random_id: "{{ IP_subject_alt_name | to_uuid }}"
+openssl_constraint_random_id: "{{ IP_subject_alt_name | to_uuid }}.algo"
 subjectAltName_IP: "{{ 'DNS:' if IP_subject_alt_name|regex_search('[a-z]') else 'IP:' }}{{ IP_subject_alt_name }}"
 subjectAltName_USER: "email:{{ item }}@{{ openssl_constraint_random_id }}"
 openssl_bin: openssl

--- a/roles/strongswan/tasks/openssl.yml
+++ b/roles/strongswan/tasks/openssl.yml
@@ -132,6 +132,30 @@
       executable: bash
     with_items: "{{ users }}"
 
+  - name: Build the tests pair
+    shell: >
+      umask 077;
+      {{ openssl_bin }} req -utf8 -new
+      -newkey ec:ecparams/secp384r1.pem
+      -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName=DNS:google-algo-test-pair.com"))
+      -keyout private/google-algo-test-pair.com.key
+      -out reqs/google-algo-test-pair.com.req -nodes
+      -passin pass:"{{ CA_password }}"
+      -subj "/CN=google-algo-test-pair.com" -batch &&
+      {{ openssl_bin }} ca -utf8
+      -in reqs/google-algo-test-pair.com.req
+      -out certs/google-algo-test-pair.com.crt
+      -config <(cat openssl.cnf <(printf "[basic_exts]\nsubjectAltName=DNS:google-algo-test-pair.com"))
+      -days 3650 -batch
+      -passin pass:"{{ CA_password }}"
+      -subj "/CN=google-algo-test-pair.com" &&
+      touch certs/google-algo-test-pair.com_crt_generated
+    args:
+      chdir: "{{ ipsec_pki_path }}"
+      creates: certs/google-algo-test-pair.com_crt_generated
+      executable: bash
+    when: tests|default(false)|bool
+
   - name: Build openssh public keys
     openssl_publickey:
       path:  "{{ ipsec_pki_path }}/public/{{ item }}.pub"
@@ -201,7 +225,7 @@
       chdir: "{{ ipsec_pki_path }}"
       creates: crl/{{ item }}.crt
       executable: bash
-    when: item not in users
+    when: item.split('@')[0] not in users
     with_items: "{{ valid_certs.stdout_lines }}"
 
   - name: Genereate new CRL file

--- a/roles/strongswan/tasks/openssl.yml
+++ b/roles/strongswan/tasks/openssl.yml
@@ -1,13 +1,5 @@
 ---
 - block:
-  - name: Set subjectAltName as a fact
-    set_fact:
-      subjectAltName: >-
-        {{ subjectAltName_IP }}
-        {%- if ipv6_support -%},IP:{{ ansible_default_ipv6['address'] }}{%- endif -%}
-        {%- if domain and subjectAltName_DNS -%},DNS:{{ subjectAltName_DNS }}{%- endif -%}
-    tags: always
-
   - debug: var=subjectAltName
 
   - name: Ensure the pki directory does not exist

--- a/roles/strongswan/templates/charon.conf.j2
+++ b/roles/strongswan/templates/charon.conf.j2
@@ -358,7 +358,7 @@ charon {
     x509 {
 
         # Discard certificates with unsupported or unknown critical extensions.
-        # enforce_critical = yes
+        enforce_critical = no
 
     }
 

--- a/roles/strongswan/templates/mobileconfig.j2
+++ b/roles/strongswan/templates/mobileconfig.j2
@@ -93,7 +93,7 @@
                     <integer>1440</integer>
                 </dict>
                 <key>LocalIdentifier</key>
-                <string>{{ item.0 }}</string>
+                <string>{{ item.0 }}@{{ openssl_user_domain }}</string>
                 <key>PayloadCertificateUUID</key>
                 <string>{{ pkcs12_PayloadCertificateUUID }}</string>
                 <key>CertificateType</key>

--- a/roles/strongswan/templates/mobileconfig.j2
+++ b/roles/strongswan/templates/mobileconfig.j2
@@ -93,7 +93,7 @@
                     <integer>1440</integer>
                 </dict>
                 <key>LocalIdentifier</key>
-                <string>{{ item.0 }}@{{ openssl_user_domain }}</string>
+                <string>{{ item.0 }}@{{ openssl_constraint_random_id }}</string>
                 <key>PayloadCertificateUUID</key>
                 <string>{{ pkcs12_PayloadCertificateUUID }}</string>
                 <key>CertificateType</key>

--- a/roles/strongswan/templates/openssl.cnf.j2
+++ b/roles/strongswan/templates/openssl.cnf.j2
@@ -120,7 +120,7 @@ subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid:always,issuer:always
 
 basicConstraints = critical,CA:true,pathlen:0
-nameConstraints = critical,permitted;{{ subjectAltName_IP }}/255.255.255.255{{ ',permitted;IP:' + ansible_default_ipv6['address'] + '/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' if ipv6_support else '' }}{{ ',permitted;DNS:' + subjectAltName_DNS if domain and subjectAltName_DNS else '' }},permitted;DNS:algo.local,permitted;email:{{ openssl_user_domain }}
+nameConstraints = critical,permitted;{{ subjectAltName_IP }}/255.255.255.255{{ ',permitted;IP:' + ansible_default_ipv6['address'] + '/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' if ipv6_support else '' }}{{ ',permitted;DNS:' + subjectAltName_DNS if domain and subjectAltName_DNS else '' }},permitted;DNS:{{ openssl_constraint_random_id }},permitted;email:{{ openssl_constraint_random_id }}
 
 # Limit key usage to CA tasks. If you really want to use the generated pair as
 # a self-signed cert, comment this out.

--- a/roles/strongswan/templates/openssl.cnf.j2
+++ b/roles/strongswan/templates/openssl.cnf.j2
@@ -119,9 +119,8 @@ keyUsage = digitalSignature, keyEncipherment
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid:always,issuer:always
 
-# This could be marked critical, but it's nice to support reading by any
-# broken clients who attempt to do so.
-basicConstraints = CA:true
+basicConstraints = critical,CA:true,pathlen:0
+nameConstraints = critical,permitted;{{ subjectAltName_IP }}/255.255.255.255{{ ',permitted;IP:' + ansible_default_ipv6['address'] + '/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' if ipv6_support else '' }}{{ ',permitted;DNS:' + subjectAltName_DNS if domain and subjectAltName_DNS else '' }},permitted;DNS:algo.local,permitted;email:{{ openssl_user_domain }}
 
 # Limit key usage to CA tasks. If you really want to use the generated pair as
 # a self-signed cert, comment this out.

--- a/roles/strongswan/templates/openssl.cnf.j2
+++ b/roles/strongswan/templates/openssl.cnf.j2
@@ -120,7 +120,8 @@ subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid:always,issuer:always
 
 basicConstraints = critical,CA:true,pathlen:0
-nameConstraints = critical,permitted;{{ subjectAltName_IP }}/255.255.255.255{{ ',permitted;IP:' + ansible_default_ipv6['address'] + '/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' if ipv6_support else '' }}{{ ',permitted;DNS:' + subjectAltName_DNS if domain and subjectAltName_DNS else '' }},permitted;DNS:{{ openssl_constraint_random_id }},permitted;email:{{ openssl_constraint_random_id }}
+nameConstraints = {{ nameConstraints }}
+
 
 # Limit key usage to CA tasks. If you really want to use the generated pair as
 # a self-signed cert, comment this out.

--- a/tests/ipsec-client.sh
+++ b/tests/ipsec-client.sh
@@ -4,6 +4,16 @@ set -euxo pipefail
 
 xmllint --noout ./configs/10.0.8.100/ipsec/apple/user1.mobileconfig
 
+CA_CONSTRAINTS="$(openssl verify -verbose \
+  -CAfile ./configs/10.0.8.100/ipsec/.pki/cacert.pem \
+  ./configs/10.0.8.100/ipsec/.pki/certs/google-algo-test-pair.com.crt 2>&1)" || true
+
+echo "$CA_CONSTRAINTS" | grep "permitted subtree violation" >/dev/null && \
+  echo "Name Constraints test passed" || \
+  (echo "Name Constraints test failed" && exit 1)
+
+echo "$CA_CONSTRAINTS"
+
 ansible-playbook deploy_client.yml \
   -e client_ip=localhost \
   -e vpn_user=desktop \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- changes the basic constraints to critical with `pathlen:0`:
```
X509v3 Basic Constraints: critical
    CA:TRUE, pathlen:0
```

- Generates a random id for every deployment and adds the nameConstraints extension to the CA certificate:
```
X509v3 Name Constraints: critical
    Permitted:
      IP:34.254.198.99/255.255.255.255
      DNS:585d3e61-7be1-5170-b417-e4e5d5b4fa57.algo
      email:585d3e61-7be1-5170-b417-e4e5d5b4fa57.algo   
```

## Motivation and Context
The discussion initially started in #75 and rose up again in #1673

## How Has This Been Tested?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - emails in usernames are not allowed anymore

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
