### PR TITLE
Cloud-init script fix

### DIFF
--- a/files/cloud-init/base.sh
+++ b/files/cloud-init/base.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -eux
 
-apt-get update -y
-apt-get install sudo -y
+which sudo || until \
+  apt-get update -y && \
+  apt-get install sudo -yf --install-suggests; do
+  sleep 3
+done
 
-getent passwd algo || useradd -m -d /home/algo -s /bin/bash -G adm,netdev -p '!' algo
+getent passwd algo || useradd -m -d /home/algo -s /bin/bash -G adm -p '!' algo
 
 (umask 337 && echo "algo ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/10-algo-user)
 
@@ -15,5 +18,8 @@ EOF
 test -d /home/algo/.ssh || (umask 077 && sudo -u algo mkdir -p /home/algo/.ssh/)
 echo "{{ lookup('file', '{{ SSH_keys.public }}') }}" | (umask 177 && sudo -u algo tee /home/algo/.ssh/authorized_keys)
 
-sudo apt-get remove -y --purge sshguard || true
+dpkg -l sshguard && until apt-get remove -y --purge sshguard; do
+  sleep 3
+done || true
+
 systemctl restart sshd.service


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The cloud-init raw bash script sometime fails due the apt lock. This PR adds more retries.

## Motivation and Context
Fixes #1683

## How Has This Been Tested?
Deployed to Vultr and Lightsail

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All new and existing tests passed.
