### PR TITLE
support armbian buster targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,9 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements.txt
 
+          ansible-galaxy install dev-sec.os-hardening
+          ansible-galaxy install dev-sec.ssh-hardening
+
       - name: Provision
         env:
           DEPLOY: cloud-init
@@ -135,6 +138,9 @@ jobs:
 
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements.txt
+
+          ansible-galaxy install dev-sec.os-hardening
+          ansible-galaxy install dev-sec.ssh-hardening
 
       - name: Provision
         env:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ The easiest way to get an Algo server running is to run it on your local system 
       source .env/bin/activate &&
       python3 -m pip install -U pip virtualenv &&
       python3 -m pip install -r requirements.txt
+
+      ansible-galaxy install dev-sec.os-hardening
+      ansible-galaxy install dev-sec.ssh-hardening
     ```
     On Fedora add the option `--system-site-packages` to the first command above. On macOS install the C compiler if prompted.
 

--- a/input.yml
+++ b/input.yml
@@ -10,6 +10,7 @@
       dns_adblocking: false
       ssh_tunneling: false
       store_pki: false
+      armbian: false
     providers_map:
       - { name: DigitalOcean, alias: digitalocean }
       - { name: Amazon Lightsail, alias: lightsail }
@@ -52,6 +53,7 @@
         when:
           - server_name is undefined
           - algo_provider != "local"
+
       - block:
         - name: Cellular On Demand prompt
           pause:
@@ -138,5 +140,6 @@
             {% if ipsec_enabled %}{%- if store_pki is defined %}{{ store_pki | bool }}
             {%- elif _store_pki.user_input is defined  %}{{ booleans_map[_store_pki.user_input] | default(defaults['store_pki']) }}
             {%- else %}false{% endif %}{% endif %}
+
       rescue:
         - include_tasks: playbooks/rescue.yml

--- a/playbooks/cloud-post.yml
+++ b/playbooks/cloud-post.yml
@@ -19,6 +19,7 @@
     algo_dns_adblocking: "{{ algo_dns_adblocking }}"
     algo_ssh_tunneling: "{{ algo_ssh_tunneling }}"
     algo_store_pki: "{{ algo_store_pki }}"
+    algo_armbian: "{{ algo_armbian }}"
     IP_subject_alt_name: "{{ IP_subject_alt_name }}"
     cloudinit: "{{ cloudinit|default(false) }}"
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Sysctl tuning
   sysctl: name="{{ item.item }}" value="{{ item.value }}"
-  when: item.item
+  when: item and item.item
   with_items:
     - "{{ sysctl|default([]) }}"
   tags:

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -36,6 +36,32 @@
       become: false
   when: algo_provider != "local"
 
+# the dev-sec.os-hardening role overwrites our users fact in 'Get user accounts | os-09'.  It's not clear why this is
+# happening, but as a workaround, save a temporary copy of the users variable so that it can be restored afterwards
+
+- name: save a temporary copy of users
+  set_fact:
+    algo_users: "{{ users }}"
+
+- name: dev-sec.os-hardening
+  import_role:
+    name: dev-sec.os-hardening
+  vars:
+    sysctl_overwrite:
+      net.ipv4.ip_forward: 1
+      net.ipv4.conf.all.forwarding: 1
+      net.ipv6.conf.all.forwarding: "{{ '1' if ipv6_support else '0' }}"
+  tags: os-hardening
+
+- name: restore users variable to its proper value
+  set_fact:
+    users: "{{ algo_users }}"
+
+- name: dev-sec.ssh-hardening
+  import_role:
+    name: dev-sec.ssh-hardening
+  tags: ssh-hardening
+
 - name: Include unatteded upgrades configuration
   import_tasks: unattended-upgrades.yml
 
@@ -72,8 +98,7 @@
 
 - name: Set fact if apparmor enabled
   set_fact:
-    apparmor_enabled: true
-  when: '"profiles are in enforce mode" in apparmor_status.stdout'
+    apparmor_enabled: "{{ not apparmor_status.failed and 'profiles are in enforce mode' in apparmor_status.stdout }} "
 
 - name: Gather additional facts
   import_tasks: facts.yml
@@ -110,7 +135,9 @@
       - linux-headers-generic
       - "linux-headers-{{ ansible_kernel }}"
     state: present
-  when: install_headers
+  when:
+    - not algo_armbian
+    - install_headers
 
 - include_tasks: iptables.yml
   tags: iptables

--- a/roles/dns/tasks/ubuntu.yml
+++ b/roles/dns/tasks/ubuntu.yml
@@ -8,6 +8,7 @@
   until: result is succeeded
   retries: 10
   delay: 3
+  when: not algo_armbian
 
 - name: Install dnscrypt-proxy
   apt:
@@ -22,6 +23,7 @@
     owner: root
     group: root
     mode: 0644
+  when: not algo_armbian
 
 - block:
   - name: Ubuntu | Configure AppArmor policy for dnscrypt-proxy

--- a/roles/local/tasks/prompts.yml
+++ b/roles/local/tasks/prompts.yml
@@ -21,12 +21,23 @@
     register: _algo_ssh_user
     when: ssh_user is undefined
 
+  - name: Armbian prompt
+    pause:
+      prompt: |
+        Is this an Armbian host?
+        [y/N]
+    register: _armbian
+    when:
+      - armbian is undefined
+      - algo_provider == "local"
+
   - name: Set the facts
     set_fact:
       ansible_ssh_user: >-
         {% if ssh_user is defined %}{{ ssh_user }}
         {%- elif _algo_ssh_user.user_input %}{{ _algo_ssh_user.user_input }}
         {%- else %}root{% endif %}
+
   when: cloud_instance_ip != "localhost"
 
 - pause:
@@ -42,3 +53,7 @@
       {% if endpoint is defined %}{{ endpoint }}
       {%- elif _endpoint.user_input %}{{ _endpoint.user_input }}
       {%- else %}{{ cloud_instance_ip }}{% endif %}
+    algo_armbian: >-
+      {% if armbian is defined %}{{ armbian | bool }}
+      {%- elif _armbian.user_input is defined %}{{ booleans_map[_armbian.user_input] | default(defaults['armbian']) }}
+      {%- else %}false{% endif %}

--- a/roles/wireguard/tasks/armbian.yml
+++ b/roles/wireguard/tasks/armbian.yml
@@ -1,0 +1,16 @@
+---
+- name: WireGuard installed
+  apt:
+    name: wireguard-tools
+    state: present
+    update_cache: true
+
+- name: WireGuard reload-module-on-update
+  file:
+    dest: /etc/wireguard/.reload-module-on-update
+    state: touch
+
+- name: Set OS specific facts
+  set_fact:
+    service_name: "wg-quick@{{ wireguard_interface }}"
+  tags: always

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -12,9 +12,14 @@
   delegate_to: localhost
   become: false
 
+- name: Include tasks for Armbian
+  include_tasks: armbian.yml
+  when: algo_armbian and (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu')
+  tags: always
+
 - name: Include tasks for Ubuntu
   include_tasks: ubuntu.yml
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: not algo_armbian and (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu')
   tags: always
 
 - name: Include tasks for FreeBSD

--- a/server.yml
+++ b/server.yml
@@ -83,6 +83,7 @@
               algo_dns_adblocking: {{ algo_dns_adblocking }}
               algo_ssh_tunneling: {{ algo_ssh_tunneling }}
               algo_store_pki: {{ algo_store_pki }}
+              algo_armbian: {{ algo_armbian }}
               IP_subject_alt_name: {{ IP_subject_alt_name }}
               ipsec_enabled: {{ ipsec_enabled }}
               wireguard_enabled: {{ wireguard_enabled }}


### PR DESCRIPTION
-modifications to support installing to armbian based targets
-adding OS and SSHD hardening to Ubuntu/Debian based targets to provide a base level of hardening for a server which will likely be exposed on the internet

<!--- Provide a general summary of your changes in the Title above -->

## Description
implementation of feature request #1692

## Motivation and Context
To allow algo to be used to build out Arbian Buster based targets

## How Has This Been Tested?
deployed various configurations to Armbian Buster targets running on a Nanopi Neo2.  Configurations tested include:
  -with/without DNS encryption
  -with/without ipsec
  -with/without ad blocking

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
[X] - New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
