### PR TITLE
Generate mobileconfigs for WireGuard

### DIFF
--- a/input.yml
+++ b/input.yml
@@ -52,41 +52,41 @@
         when:
           - server_name is undefined
           - algo_provider != "local"
-      - block:
-        - name: Cellular On Demand prompt
-          pause:
-            prompt: |
-              Do you want macOS/iOS IPsec clients to enable "Connect On Demand" when connected to cellular networks?
-              [y/N]
-          register: _ondemand_cellular
-          when: ondemand_cellular is undefined
 
-        - name: Wi-Fi On Demand prompt
-          pause:
-            prompt: |
-              Do you want macOS/iOS IPsec clients to enable "Connect On Demand" when connected to Wi-Fi?
-              [y/N]
-          register: _ondemand_wifi
-          when: ondemand_wifi is undefined
+      - name: Cellular On Demand prompt
+        pause:
+          prompt: |
+            Do you want macOS/iOS clients to enable "Connect On Demand" when connected to cellular networks?
+            [y/N]
+        register: _ondemand_cellular
+        when: ondemand_cellular is undefined
 
-        - name: Trusted Wi-Fi networks prompt
-          pause:
-            prompt: |
-              List the names of any trusted Wi-Fi networks where macOS/iOS IPsec clients should not use "Connect On Demand"
-              (e.g., your home network. Comma-separated value, e.g., HomeNet,OfficeWifi,AlgoWiFi)
-          register: _ondemand_wifi_exclude
-          when:
-            - ondemand_wifi_exclude is undefined
-            - (ondemand_wifi|default(false)|bool) or
-              (booleans_map[_ondemand_wifi.user_input|default(omit)]|default(false))
+      - name: Wi-Fi On Demand prompt
+        pause:
+          prompt: |
+            Do you want macOS/iOS clients to enable "Connect On Demand" when connected to Wi-Fi?
+            [y/N]
+        register: _ondemand_wifi
+        when: ondemand_wifi is undefined
 
-        - name: Retain the PKI prompt
-          pause:
-            prompt: |
-              Do you want to retain the keys (PKI)? (required to add users in the future, but less secure)
-              [y/N]
-          register: _store_pki
-          when: store_pki is undefined
+      - name: Trusted Wi-Fi networks prompt
+        pause:
+          prompt: |
+            List the names of any trusted Wi-Fi networks where macOS/iOS clients should not use "Connect On Demand"
+            (e.g., your home network. Comma-separated value, e.g., HomeNet,OfficeWifi,AlgoWiFi)
+        register: _ondemand_wifi_exclude
+        when:
+          - ondemand_wifi_exclude is undefined
+          - (ondemand_wifi|default(false)|bool) or
+            (booleans_map[_ondemand_wifi.user_input|default(omit)]|default(false))
+
+      - name: Retain the PKI prompt
+        pause:
+          prompt: |
+            Do you want to retain the keys (PKI)? (required to add users in the future, but less secure)
+            [y/N]
+        register: _store_pki
+        when: store_pki is undefined
         when: ipsec_enabled
 
       - name: DNS adblocking prompt

--- a/input.yml
+++ b/input.yml
@@ -86,8 +86,9 @@
             Do you want to retain the keys (PKI)? (required to add users in the future, but less secure)
             [y/N]
         register: _store_pki
-        when: store_pki is undefined
-        when: ipsec_enabled
+        when:
+          - store_pki is undefined
+          - ipsec_enabled
 
       - name: DNS adblocking prompt
         pause:

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -8,7 +8,8 @@
     - "{{ wireguard_pki_path }}/preshared"
     - "{{ wireguard_pki_path }}/private"
     - "{{ wireguard_pki_path }}/public"
-    - "{{ wireguard_config_path }}"
+    - "{{ wireguard_config_path }}/apple/ios"
+    - "{{ wireguard_config_path }}/apple/macos"
   delegate_to: localhost
   become: false
 
@@ -50,6 +51,13 @@
       when: item.1 in users
       vars:
         index: "{{ item.0 }}"
+
+    - include_tasks: mobileconfig.yml
+      loop:
+        - ios
+        - macos
+      loop_control:
+        loop_var: system
 
     - name: Generate QR codes
       shell: >

--- a/roles/wireguard/tasks/mobileconfig.yml
+++ b/roles/wireguard/tasks/mobileconfig.yml
@@ -1,0 +1,10 @@
+---
+- name: WireGuard apple mobileconfig generated
+  template:
+    src: mobileconfig.j2
+    dest: "{{ wireguard_config_path }}/apple/{{ system }}/{{ item.1 }}.mobileconfig"
+    mode: "0600"
+  with_indexed_items:  "{{ wireguard_users }}"
+  when: item.1 in users
+  vars:
+    index: "{{ item.0 }}"

--- a/roles/wireguard/templates/mobileconfig.j2
+++ b/roles/wireguard/templates/mobileconfig.j2
@@ -1,0 +1,25 @@
+#jinja2:lstrip_blocks: True
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+    {% include 'vpn-dict.j2' %}
+  </array>
+  <key>PayloadDisplayName</key>
+  <string>AlgoVPN {{ algo_server_name }} WireGuard</string>
+  <key>PayloadIdentifier</key>
+  <string>donut.local.{{ 500000 | random | to_uuid | upper }}</string>
+  <key>PayloadOrganization</key>
+  <string>AlgoVPN</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>{{ 400000 | random | to_uuid | upper }}</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/roles/wireguard/templates/vpn-dict.j2
+++ b/roles/wireguard/templates/vpn-dict.j2
@@ -1,0 +1,94 @@
+<dict>
+	<key>IPv4</key>
+  <dict>
+      <key>OverridePrimary</key>
+      <integer>1</integer>
+  </dict>
+	<key>PayloadDescription</key>
+	<string>Configures VPN settings</string>
+	<key>PayloadDisplayName</key>
+	<string>{{ algo_server_name }}</string>
+	<key>PayloadIdentifier</key>
+	<string>com.apple.vpn.managed.{{ algo_server_name + system | to_uuid | upper }}</string>
+	<key>PayloadType</key>
+	<string>com.apple.vpn.managed</string>
+	<key>PayloadUUID</key>
+	<string>{{ algo_server_name + system | to_uuid | upper }}</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+	<key>Proxies</key>
+	<dict>
+		<key>HTTPEnable</key>
+		<integer>0</integer>
+		<key>HTTPSEnable</key>
+		<integer>0</integer>
+	</dict>
+	<key>UserDefinedName</key>
+	<string>AlgoVPN {{ algo_server_name }}</string>
+	<key>VPN</key>
+	<dict>
+    <key>OnDemandEnabled</key>
+    <integer>{{ 1 if algo_ondemand_wifi or algo_ondemand_cellular else 0 }}</integer>
+    <key>OnDemandRules</key>
+    <array>
+      {% if algo_ondemand_wifi or algo_ondemand_cellular %}
+      {% if algo_ondemand_wifi_exclude|b64decode != '_null' %}
+      {% set WIFI_EXCLUDE_LIST = (algo_ondemand_wifi_exclude|b64decode|string).split(',') %}
+      <dict>
+        <key>Action</key>
+        <string>Disconnect</string>
+        <key>InterfaceTypeMatch</key>
+        <string>WiFi</string>
+        <key>SSIDMatch</key>
+        <array>
+          {% for network_name in WIFI_EXCLUDE_LIST %}
+          <string>{{ network_name|e }}</string>
+          {% endfor %}
+        </array>
+      </dict>
+      {% endif %}
+      <dict>
+        <key>Action</key>
+        {% if algo_ondemand_wifi %}
+        <string>Connect</string>
+        {% else %}
+        <string>Disconnect</string>
+        {% endif %}
+        <key>InterfaceTypeMatch</key>
+        <string>WiFi</string>
+        <key>URLStringProbe</key>
+        <string>http://captive.apple.com/hotspot-detect.html</string>
+      </dict>
+      <dict>
+        <key>Action</key>
+        {% if algo_ondemand_cellular %}
+        <string>Connect</string>
+        {% else %}
+        <string>Disconnect</string>
+        {% endif %}
+        <key>InterfaceTypeMatch</key>
+        <string>Cellular</string>
+        <key>URLStringProbe</key>
+        <string>http://captive.apple.com/hotspot-detect.html</string>
+      </dict>
+      {% endif %}
+      <dict>
+        <key>Action</key>
+        <string>{{ 'Disconnect' if algo_ondemand_wifi or algo_ondemand_cellular else 'Connect' }}</string>
+      </dict>
+    </array>
+		<key>AuthenticationMethod</key>
+		<string>Password</string>
+		<key>RemoteAddress</key>
+		<string>{{ IP_subject_alt_name }}:{{ wireguard_port }}</string>
+	</dict>
+	<key>VPNSubType</key>
+	<string>com.wireguard.{{ system }}</string>
+	<key>VPNType</key>
+	<string>VPN</string>
+	<key>VendorConfig</key>
+	<dict>
+		<key>WgQuickConfig</key>
+		<string>{{- lookup('template', 'client.conf.j2') | indent(8) }}</string>
+	</dict>
+</dict>

--- a/tests/wireguard-client.sh
+++ b/tests/wireguard-client.sh
@@ -2,6 +2,8 @@
 
 set -euxo pipefail
 
+xmllint --noout ./configs/10.0.8.100/wireguard/apple/*/*.mobileconfig
+
 crudini --set configs/10.0.8.100/wireguard/user1.conf Interface Table off
 
 wg-quick up configs/10.0.8.100/wireguard/user1.conf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Generate profiles to set up tunnels on Apple devices 
- This PR brings onDemand for WireGuard via apple profiles.

## Motivation and Context
Closes #1517

## How Has This Been Tested?
Installed to MacOS and iPhone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
