### PR TITLE
Update dnscrypt-proxy cache settings for improved performance and privacy

### DIFF
--- a/roles/dns/templates/dnscrypt-proxy.toml.j2
+++ b/roles/dns/templates/dnscrypt-proxy.toml.j2
@@ -302,12 +302,12 @@ cache = true
 
 ## Cache size
 
-cache_size = 512
+cache_size = 4096
 
 
 ## Minimum TTL for cached entries
 
-cache_min_ttl = 600
+cache_min_ttl = 2400
 
 
 ## Maximum TTL for cached entries


### PR DESCRIPTION
These values match those recommended by the author of DNSCrypt-proxy

See:
https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Caching#dns-cache
https://00f.net/2019/11/03/stop-using-low-dns-ttls/

<!--- Provide a general summary of your changes in the Title above -->

## Description
The caching default for dnscrypt-proxy haven't been updated in a while in Algo's copy of the configuration file.

By changing the caching configuration, there's a nice performance bump, as well as a privacy increase. I suggest reading the author's blog post for more detail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better privacy and DNS performance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested it on my local installs of dnscrypt-proxy, as well as my own algo server in the cloud.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
