### PR TITLE
Use user-defined hostname for SSH hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can now set up clients to connect to your VPN. Proceed to [Configure the VPN
     "#                     Local DNS resolver 172.16.0.1                    #"
     "#        The p12 and SSH keys password for new users is XXXXXXXX       #"
     "#        The CA key password is XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX       #"
-    "#      Shell access: ssh -F configs/<server_ip>/ssh_config algo        #"
+    "#      Shell access: ssh -F configs/<server_ip>/ssh_config <hostname>  #"
 ```
 
 ## Configure the VPN Clients
@@ -159,7 +159,7 @@ Use the example command below to start an SSH tunnel by replacing `<user>` and `
 
 Your Algo server is configured for key-only SSH access for administrative purposes. Open the Terminal app, `cd` into the `algo-master` directory where you originally downloaded Algo, and then use the command listed on the success message:
 
- `ssh -F configs/<ip>/ssh_config algo`
+`ssh -F configs/<ip>/ssh_config <hostname>`
 
 where `<ip>` is the IP address of your Algo server. If you find yourself regularly logging into the server then it will be useful to load your Algo ssh key automatically. Add the following snippet to the bottom of `~/.bash_profile` to add it to your shell environment permanently.
 

--- a/config.cfg
+++ b/config.cfg
@@ -146,7 +146,7 @@ congrats:
   ca_key_pass: |
     "#        The CA key password is {{ CA_password|default(omit) }}       #"
   ssh_access: |
-    "#      Shell access: ssh -F configs/{{ ansible_ssh_host|default(omit) }}/ssh_config algo        #"
+    "#      Shell access: ssh -F configs/{{ ansible_ssh_host|default(omit) }}/ssh_config {{ algo_server_name }}        #"
 
 SSH_keys:
   comment: algo@ssh

--- a/server.yml
+++ b/server.yml
@@ -28,7 +28,7 @@
             dest: "configs/{{ IP_subject_alt_name }}/ssh_config"
             mode: "0600"
             content: |
-              Host {{ IP_subject_alt_name }} algo
+              Host {{ IP_subject_alt_name }} {{ algo_server_name }}
                 HostName {{ IP_subject_alt_name }}
                 User {{ ansible_ssh_user }}
                 Port {{ ansible_ssh_port }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

As the user defines their own hostname, it'd be nice to allow them to SSH in via that hostname as an alias instead of always being called `algo`.

## Description

Replaces the `algo` hardcoded value in the SSH config template with `{{ algo_server_name }}`.

## Motivation and Context

Just a nice to have.

## How Has This Been Tested?

I haven't yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
