### PR TITLE
Use absolute path for identityfile in ssh config

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ where `<ip>` is the IP address of your Algo server. If you find yourself regular
 
  `ssh-add ~/.ssh/algo > /dev/null 2>&1`
 
+Alternatively, you can choose to include the generated configuration for any Algo servers created into your SSH config. Edit the file `~/.ssh/config` to include this directive at the top:
+
+```
+Include <algodirectory>/configs/*/ssh_config
+```
+
+where `<algodirectory>` is the directory where you cloned Algo.
+
 ## Adding or Removing Users
 
 _If you chose to save the CA key during the deploy process,_ then Algo's own scripts can easily add and remove users from the VPN server.

--- a/server.yml
+++ b/server.yml
@@ -32,7 +32,7 @@
                 HostName {{ IP_subject_alt_name }}
                 User {{ ansible_ssh_user }}
                 Port {{ ansible_ssh_port }}
-                IdentityFile {{ SSH_keys.private }}
+                IdentityFile {{ SSH_keys.private | realpath }}
                 KeepAlive yes
                 ServerAliveInterval 30
         when: inventory_hostname != 'localhost'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replaces relative path IdentityFile (which only works in `algo` directory, or if the identityfile is added to `ssh-agent`) with absolute path (which works as previously but _also_ if included in SSH config):

```bash
# ~/.ssh/config
Include ~/src/github.com/dan1elhughes/algo/configs/*/ssh_config
```

## Motivation and Context

Discussion on linked issue, fixes #1713

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Edited the playbook locally to regenerate my SSH config and verified I can SSH in with this change applied.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
