### PR TITLE
Fix IPsec DNS when WireGuard uses port 53

### DIFF
--- a/roles/common/templates/rules.v4.j2
+++ b/roles/common/templates/rules.v4.j2
@@ -32,7 +32,7 @@ COMMIT
 {% if wireguard_enabled and wireguard_port|int == wireguard_port_avoid|int %}
 # Handle the special case of allowing access to WireGuard over an already used
 # port like 53
--A PREROUTING -s {{ subnets|join(',') }} -p udp --dport {{ wireguard_port_avoid }} -j ACCEPT
+-A PREROUTING -s {{ subnets|join(',') }} -p udp --dport {{ wireguard_port_avoid }} -j RETURN
 -A PREROUTING --in-interface {{ ansible_default_ipv4['interface'] }} -p udp --dport {{ wireguard_port_avoid }} -j REDIRECT --to-port {{ wireguard_port_actual }}
 {% endif %}
 # Allow traffic from the VPN network to the outside world, and replies

--- a/roles/common/templates/rules.v4.j2
+++ b/roles/common/templates/rules.v4.j2
@@ -32,6 +32,7 @@ COMMIT
 {% if wireguard_enabled and wireguard_port|int == wireguard_port_avoid|int %}
 # Handle the special case of allowing access to WireGuard over an already used
 # port like 53
+-A PREROUTING -s {{ subnets|join(',') }} -p udp --dport {{ wireguard_port_avoid }} -j ACCEPT
 -A PREROUTING --in-interface {{ ansible_default_ipv4['interface'] }} -p udp --dport {{ wireguard_port_avoid }} -j REDIRECT --to-port {{ wireguard_port_actual }}
 {% endif %}
 # Allow traffic from the VPN network to the outside world, and replies

--- a/roles/common/templates/rules.v6.j2
+++ b/roles/common/templates/rules.v6.j2
@@ -31,6 +31,7 @@ COMMIT
 {% if wireguard_enabled and wireguard_port|int == wireguard_port_avoid|int %}
 # Handle the special case of allowing access to WireGuard over an already used
 # port like 53
+-A PREROUTING -s {{ subnets|join(',') }} -p udp --dport {{ wireguard_port_avoid }} -j ACCEPT
 -A PREROUTING --in-interface {{ ansible_default_ipv6['interface'] }} -p udp --dport {{ wireguard_port_avoid }} -j REDIRECT --to-port {{ wireguard_port_actual }}
 {% endif %}
 # Allow traffic from the VPN network to the outside world, and replies

--- a/roles/common/templates/rules.v6.j2
+++ b/roles/common/templates/rules.v6.j2
@@ -31,7 +31,7 @@ COMMIT
 {% if wireguard_enabled and wireguard_port|int == wireguard_port_avoid|int %}
 # Handle the special case of allowing access to WireGuard over an already used
 # port like 53
--A PREROUTING -s {{ subnets|join(',') }} -p udp --dport {{ wireguard_port_avoid }} -j ACCEPT
+-A PREROUTING -s {{ subnets|join(',') }} -p udp --dport {{ wireguard_port_avoid }} -j RETURN
 -A PREROUTING --in-interface {{ ansible_default_ipv6['interface'] }} -p udp --dport {{ wireguard_port_avoid }} -j REDIRECT --to-port {{ wireguard_port_actual }}
 {% endif %}
 # Allow traffic from the VPN network to the outside world, and replies


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add firewall rules so that DNS traffic from IPsec clients does not get forwarded to WireGuard in the special case when Algo is configured to accept WireGuard connections on port 53.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1717.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deployed to Vultr with `wireguard_port: 53`. Tested WireGuard and IPsec from iOS.

I'm not sure if this is the best way to fix this issue. Please review the firewall rules for correctness.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
