### PR TITLE
Apply netplan for digitalocean only

### DIFF
--- a/roles/common/tasks/aip/digitalocean.yml
+++ b/roles/common/tasks/aip/digitalocean.yml
@@ -11,3 +11,13 @@
 - name: Set SNAT IP as a fact
   set_fact:
     snat_aipv4: "{{ anchor_ipv4.content }}"
+
+- name: IPv6 egress alias configured
+  template:
+    src: 99-algo-ipv6-egress.yaml.j2
+    dest: /etc/netplan/99-algo-ipv6-egress.yaml
+  when:
+    - ipv6_support
+    - ipv6_subnet_size|int > 1
+  notify:
+    - netplan apply

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -78,16 +78,6 @@
 - name: Gather additional facts
   import_tasks: facts.yml
 
-- name: IPv6 egress alias configured
-  template:
-    src: 99-algo-ipv6-egress.yaml.j2
-    dest: /etc/netplan/99-algo-ipv6-egress.yaml
-  when:
-    - ipv6_support
-    - ipv6_subnet_size|int > 1
-  notify:
-    - netplan apply
-
 - name: Set OS specific facts
   set_fact:
     tools:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
netplan is used to configure ipv6 alternative egress ip, and it appears not available on soecloud providers. For now let's apply this task for DigitalOcean only and find out an alternative solution.

## Motivation and Context
Fixes #1721

## How Has This Been Tested?
Deployed to Hetzner and DigitalOcean

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
