### PR TITLE
client-linux-wireguard.md: add nscd to packages

### DIFF
--- a/docs/client-linux-wireguard.md
+++ b/docs/client-linux-wireguard.md
@@ -14,7 +14,7 @@ sudo add-apt-repository ppa:wireguard/wireguard
 sudo apt update
 
 # Install the tools and kernel module:
-sudo apt install wireguard openresolv
+sudo apt install wireguard openresolv nscd
 ```
 
 For installation on other Linux distributions, see the [Installation](https://www.wireguard.com/install/) page on the WireGuard site.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Small update to documentation which add `nscd` to needed packages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`nscd` or `unbound` packages are needed to be present on the system or else the
unit file will not start as described.


This is what happens when following the guide and `ncsd` package is not present.
```
$ sudo systemctl start wg-quick@wg0
Job for wg-quick@wg0.service failed because the control process exited with error code. See "systemctl status wg-quick@wg0.service" and "journalctl -xe" for details.

$ sudo systemctl status wg-quick@wg0                                     
● wg-quick@wg0.service - WireGuard via wg-quick(8) for wg0
   Loaded: loaded (/lib/systemd/system/wg-quick@.service; disabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Ne 2020-02-23 15:02:28 CET; 7s ago
     Docs: man:wg-quick(8)
           man:wg(8)
           https://www.wireguard.com/
           https://www.wireguard.com/quickstart/
           https://git.zx2c4.com/wireguard-tools/about/src/man/wg-quick.8
           https://git.zx2c4.com/wireguard-tools/about/src/man/wg.8
  Process: 10539 ExecStart=/usr/bin/wg-quick up %i (code=exited, status=5)
 Main PID: 10539 (code=exited, status=5)

úno 23 15:02:28 kachnak wg-quick[10539]: [#] ip -4 address add 10.19.49.3/24 dev wg0
úno 23 15:02:28 kachnak wg-quick[10539]: [#] ip link set mtu 1380 up dev wg0
úno 23 15:02:28 kachnak wg-quick[10539]: [#] resolvconf -a tun.wg0 -m 0 -x
úno 23 15:02:28 kachnak wg-quick[10539]: Failed to try-restart nscd.service: Unit nscd.service not found.
úno 23 15:02:28 kachnak wg-quick[10539]: Failed to try-restart unbound.service: Unit unbound.service not found.
úno 23 15:02:28 kachnak wg-quick[10539]: [#] ip link delete dev wg0
úno 23 15:02:28 kachnak systemd[1]: wg-quick@wg0.service: Main process exited, code=exited, status=5/NOTINSTALLED
úno 23 15:02:28 kachnak systemd[1]: Failed to start WireGuard via wg-quick(8) for wg0.
úno 23 15:02:28 kachnak systemd[1]: wg-quick@wg0.service: Unit entered failed state.
úno 23 15:02:28 kachnak systemd[1]: wg-quick@wg0.service: Failed with result 'exit-code'.
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Minor documentation change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor documentation change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have read the **CONTRIBUTING** document.
- [] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
