### PR TITLE
Initial support for Ubuntu 20.04

### DIFF
--- a/roles/strongswan/defaults/main.yml
+++ b/roles/strongswan/defaults/main.yml
@@ -3,6 +3,7 @@ ipsec_config_path: "configs/{{ IP_subject_alt_name }}/ipsec/"
 ipsec_pki_path: "{{ ipsec_config_path }}/.pki/"
 strongswan_shell: /usr/sbin/nologin
 strongswan_home: /var/lib/strongswan
+strongswan_service: "{{ 'strongswan-starter' if ansible_distribution_major_version|int > 19 else 'strongswan' }}"
 BetweenClients_DROP: true
 algo_ondemand_cellular: false
 algo_ondemand_wifi: false

--- a/roles/strongswan/handlers/main.yml
+++ b/roles/strongswan/handlers/main.yml
@@ -1,5 +1,5 @@
 - name: restart strongswan
-  service: name=strongswan state=restarted
+  service: name={{ strongswan_service }} state=restarted
 
 - name: daemon-reload
   systemd: daemon_reload=true

--- a/roles/strongswan/tasks/main.yml
+++ b/roles/strongswan/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: strongSwan started
   service:
-    name: strongswan
+    name: "{{ strongswan_service }}"
     state: started
     enabled: true
 

--- a/roles/strongswan/tasks/ubuntu.yml
+++ b/roles/strongswan/tasks/ubuntu.yml
@@ -35,12 +35,12 @@
   service: name={{ item }} enabled=yes
   with_items:
     - apparmor
-    - strongswan
+    - "{{ strongswan_service }}"
     - netfilter-persistent
 
 - name: Ubuntu | Ensure that the strongswan service directory exists
   file:
-    path: /etc/systemd/system/strongswan.service.d/
+    path: /etc/systemd/system/{{ strongswan_service }}.service.d/
     state: directory
     mode: 0755
     owner: root
@@ -49,7 +49,7 @@
 - name: Ubuntu | Setup the cgroup limitations for the ipsec daemon
   template:
     src: 100-CustomLimitations.conf.j2
-    dest: /etc/systemd/system/strongswan.service.d/100-CustomLimitations.conf
+    dest: /etc/systemd/system/{{ strongswan_service }}.service.d/100-CustomLimitations.conf
   notify:
     - daemon-reload
     - restart strongswan


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In Ubuntu Server 20.04 LTS (currently in Beta) the `systemd` service for strongSwan has been renamed from `strongswan.service` to `strongswan-starter.service`. This PR determines the service name to use based on the Ubuntu version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deployed to 18.04 and 19.10 on DigitalOcean, and deployed locally to 20.04 Beta.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
