### PR TITLE
use ca_password from variable(--extra-vars) -  non-interactive installation using ansible playbook

### DIFF
--- a/roles/common/tasks/facts.yml
+++ b/roles/common/tasks/facts.yml
@@ -6,7 +6,7 @@
 
 - name: Set facts
   set_fact:
-    CA_password: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits,_,@') }}"
+    CA_password: "{{ ca_password|default(lookup('password', '/dev/null length=16 chars=ascii_letters,digits,_,@')) }}"
     IP_subject_alt_name: "{{ IP_subject_alt_name }}"
 
 - name: Set IPv6 support as a fact

--- a/tests/ca-password-fix.sh
+++ b/tests/ca-password-fix.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Refer PR #1774 for more details.
+
+set -ex
+
+DEPLOY_ARGS="provider=local server=10.0.8.100 ssh_user=ubuntu endpoint=10.0.8.100 ondemand_cellular=true ondemand_wifi=true ondemand_wifi_exclude=test dns_adblocking=true ssh_tunneling=true store_pki=true install_headers=false tests=true local_service_ip=172.16.0.1"
+
+CA_PASSWORD="test123"
+
+if [ "${DEPLOY}" == "docker" ]
+then
+  docker run -i -v $(pwd)/config.cfg:/algo/config.cfg -v ~/.ssh:/root/.ssh -v $(pwd)/configs:/algo/configs -e "DEPLOY_ARGS=${DEPLOY_ARGS}" local/algo /bin/sh -c "chown -R root: /root/.ssh && chmod -R 600 /root/.ssh && source .env/bin/activate && ansible-playbook main.yml -e \"${DEPLOY_ARGS}\" --skip-tags debug"
+else
+  ansible-playbook main.yml -e "${DEPLOY_ARGS} ca_password=${CA_PASSWORD}"
+fi
+
+CA_PASSWORD_OUT=$(grep ca_password: configs/localhost/.config.yml | awk '{print $2}' | xargs)
+
+if [ "$CA_PASSWORD" = "$CA_PASSWORD_OUT" ]; then
+  echo "ca_password tests(PR #1774) passed"
+fi

--- a/tests/ca-password-fix.sh
+++ b/tests/ca-password-fix.sh
@@ -19,4 +19,7 @@ CA_PASSWORD_OUT=$(grep ca_password: configs/localhost/.config.yml | awk '{print 
 
 if [ "$CA_PASSWORD" = "$CA_PASSWORD_OUT" ]; then
   echo "ca_password tests(PR #1774) passed"
+else
+  echo "ca_password tests(PR #1774) failed"
+  exit 1
 fi


### PR DESCRIPTION
use ca_password from variable in non-interactive installation using ansible playbook.

## Description
https://github.com/trailofbits/algo/blob/master/docs/deploy-from-ansible.md#local-installation

I tried the algo installation non-interactively using ansible-playbook command directly as per the above documentation.

I noticed even if we set `ca_password` variable in ansible `--extra-vars` it still using the auto generated password for CA password.

```ansible-playbook main.yml -e "provider=local server=localhost endpoint=<public IP of VPN server> ca_password=xxxxxx"```

## Motivation and Context
It will use `ca_password` from variables if this variable has passed from `--extra-vars` or variable config file and only use auto-generated password if there is no `ca_password` variable configured.

It will enable users to provide `ca_password` when using [non-interactive installation](https://github.com/trailofbits/algo/blob/master/docs/deploy-from-ansible.md#local-installation) method.

## How Has This Been Tested?
- added test script to test this fix.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
