### PR TITLE
Ansible 2.8.8 -> 2.9.7 to fix python 3.8.2 errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==2.9.2
+ansible==2.9.7
 netaddr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==2.8.8
+ansible==2.9.2
 netaddr


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrades Ansible 2.8.8 -> ~~2.9.2~~ 2.9.7 in requirements.txt to fix issues with running Ansible on Python 3.8.2.

## Motivation and Context
I was having the issue described in: https://github.com/trailofbits/algo/issues/1622

```
ERROR! Unexpected Exception, this is probably a bug: cannot pickle '_io.TextIOWrapper' object
```

When attempting to run ./algo with Python 3.8.2 on MacOS 10.14.

## How Has This Been Tested?
I was able to run ./algo and complete an install successfully with the vultr playbook after this change.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
