### PR TITLE
Remove hosts-file.net/ad_servers.txt

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -49,7 +49,6 @@ reduce_mtu: 0
 # /etc/systemd/system/dnsmasq.service.d/100-CustomLimitations.conf
 adblock_lists:
  - "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"
- - "https://hosts-file.net/ad_servers.txt"
 
 # Enable DNS encryption.
 # If 'false', 'dns_servers' should be specified below.


### PR DESCRIPTION
## Description
hosts-file.net/ad_servers.txt now leads to a 404 page. The list is no longer published nor maintained.

## Motivation and Context
More information:

https://forums.malwarebytes.com/topic/257401-inquiry-regarding-automated-processing-of-hosts-files/
[pi-hole/pi-hole#3236](https://github.com/pi-hole/pi-hole/pull/3236#issue-396455876)
[uBlockOrigin/uBlock-issues#971](https://github.com/uBlockOrigin/uBlock-issues/issues/971#issue-591298291)
https://www.reddit.com/r/pihole/comments/fsg11e/hostsfilenet/

## How Has This Been Tested?
Deployed successful test instance to Google Cloud. Adblocking and dns resolution still functioned as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
x Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
