### PR TITLE
Refactor cloud-init/base.sh

### DIFF
--- a/files/cloud-init/base.sh
+++ b/files/cloud-init/base.sh
@@ -1,25 +1,41 @@
 #!/bin/bash
-set -eux
+set -euxo pipefail
 
-which sudo || until \
-  apt-get update -y && \
-  apt-get install sudo -yf --install-suggests; do
-  sleep 3
+readonly user='algo'
+
+export DEBIAN_FRONTEND='noninteractive'
+
+until which sudo; do
+    apt-get update -qq
+    apt-get install -qqf --install-suggests sudo
+    sleep 3
 done
 
-getent passwd algo || useradd -m -d /home/algo -s /bin/bash -G adm -p '!' algo
+getent passwd "${user}" \
+    || useradd -m -d "/home/${user}" -s /bin/bash -G adm -p '!' "${user}"
 
-(umask 337 && echo "algo ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/10-algo-user)
+(
+    umask 0337 \
+        && printf '%s\n' "${user} ALL=(ALL) NOPASSWD:ALL" \
+        >"/etc/sudoers.d/10-${user}-user"
+)
 
-cat <<EOF >/etc/ssh/sshd_config
-{{ lookup('template', 'files/cloud-init/sshd_config') }}
-EOF
+printf "{{ lookup('template', 'files/cloud-init/sshd_config') }}\n" \
+    >/etc/ssh/sshd_config
 
-test -d /home/algo/.ssh || (umask 077 && sudo -u algo mkdir -p /home/algo/.ssh/)
-echo "{{ lookup('file', '{{ SSH_keys.public }}') }}" | (umask 177 && sudo -u algo tee /home/algo/.ssh/authorized_keys)
+# This should be idempotent; correct permsission on .ssh dir if exists
+install -o "${user}" -g "${user}" -m 0700 -d "/home/${user}/.ssh"
 
-dpkg -l sshguard && until apt-get remove -y --purge sshguard; do
-  sleep 3
-done || true
+# umask does not reliably work with sudo
+install -o "${user}" -g "${user}" -m 0600 \
+    /dev/null "/home/${user}/.ssh/authorized_keys"
+
+printf "{{ lookup('file', '{{ SSH_keys.public }}') }}\n" \
+    >"/home/${user}/.ssh/authorized_keys"
+
+until ! dpkg -l sshguard; do
+    apt-get remove -qq --purge sshguard
+    sleep 3
+done || :
 
 systemctl restart sshd.service

--- a/files/cloud-init/base.sh
+++ b/files/cloud-init/base.sh
@@ -17,7 +17,7 @@ getent passwd "${user}" \
 (
     umask 0337 \
         && printf '%s\n' "${user} ALL=(ALL) NOPASSWD:ALL" \
-        >"/etc/sudoers.d/10-${user}-user"
+        >"/etc/sudoers.d/10-algo-user"
 )
 
 printf "{{ lookup('template', 'files/cloud-init/sshd_config') }}\n" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Pass shellcheck
* Use variable for username
* Fix issues with umask and sudo
* Simplify until loops
<!--- Describe your changes in detail -->

## Motivation and Context

A famous person once said "explicit is better than implicit." Because of
potential variations in cloud environments and options in `/etc/sudoers{,d}`,
such as `Defaults umask_override`, it was possible for `/home/algo/.ssh` and
`/home/algo/.ssh/authorized_keys` to be created with the wrong permissions.
This happened to me on VULTR, which led me to review the `cloud-init/bash.sh`
script in an effort to fix the issues that I encountered.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I tested my changes by deploying to VULTR from a virtual environment with the following commands:

```sh
python3 -m venv .venv
. .venv/bin/activate
pip install -U -r requirements.txt
./algo
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.