### PR TITLE
Make clients prefer IPv6

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -116,7 +116,7 @@ strongswan_log_level: 2
 # ipv4
 strongswan_network: 10.19.48.0/24
 # ipv6
-strongswan_network_ipv6: 'fd9d:bc11:4020::/48'
+strongswan_network_ipv6: '2001:db8:4160::/48'
 
 # If you're behind NAT or a firewall and you want to receive incoming connections long after network traffic has gone silent.
 # This option will keep the "connection" open in the eyes of NAT.
@@ -125,7 +125,7 @@ wireguard_PersistentKeepalive: 0
 
 # WireGuard network configuration
 wireguard_network_ipv4: 10.19.49.0/24
-wireguard_network_ipv6: fd9d:bc11:4021::/48
+wireguard_network_ipv6: 2001:db8:a160::/48
 
 # Randomly generated IP address for the local dns resolver
 local_service_ip: "{{ '172.16.0.1' | ipmath(1048573 | random(seed=algo_server_name + ansible_fqdn)) }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the IPv6 addresses used inside the WireGuard and IPsec tunnels so that applications prefer IPv6.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a dual-stack application needs to make a DNS request it will typically call `getaddrinfo(3)`, an RFC 3484 compliant function that returns a sorted list of host addresses. The sort order depends on the addresses assigned to the network interface used for the DNS query. For example, if an interface has no IPv6 addresses then any IPv4 results will come first.

RFC 3484 states that IPv6 should be preferred over IPv4. For IPv6 results to come first in the result list the interface must have a *routable* IPv6 address. If the interface only has a Unique Local Address (ULA) it is assumed that the interface lacks external IPv6 connectivity and *IPv4* results are returned first. This is based on the assumption that NAT is never used on IPv6 networks (see `/etc/gai.conf` on Linux).

Algo uses ULA addresses inside its VPN tunnels. This causes Algo client applications to favor IPv4 over IPv6.

This PR changes Algo to use non-ULA addresses inside the tunnels. In an attempt to make the addresses unique, the network address chosen for WireGuard is `2001:db8:a160::/48` (`2001:db8::/32` is reserved for documentation and `a160` represents "alGO"). For IPsec the similar `2001:db8:4160::/48` is used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This change has been tested deployed to EC2 using WireGuard on macOS, iOS, Windows, Android, and Ubuntu; deployed to DigitalOcean using Wireguard on iOS and Ubuntu; and deployed to Vultr using IPsec on iOS.

Thanks to @shadowsaw for the Windows and Android testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
