### PR TITLE
update troubleshooting doc for local installation per discussion with David Meyers on gitter

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -283,10 +283,11 @@ TASK [wireguard : Generate public keys] ****************************************
 
 fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'file'. Error was a <class 'ansible.errors.AnsibleError'>, original message: could not locate file in lookup: configs/xxx.xxx.xxx.xxx/wireguard//private/dan"}
 ```
-This error is usually hit when using the local install option on a server that isn't Ubuntu 18.04 or later. You should upgrade your server to Ubuntu 18.04 or later. If this doesn't work, try removing `*.lock` files at /etc/wireguard/ as follows:
+This error is usually hit when using the local install option on a server that isn't Ubuntu 18.04 or later. You should upgrade your server to Ubuntu 18.04 or later. If this doesn't work, remove the files in /etc/wireguard and the configs directories as follows:
 
 ```ssh
-sudo rm -rf /etc/wireguard/*.lock
+sudo rm -rf /etc/wireguard/*
+rm -rf configs/*
 ```
 Then immediately re-run `./algo`.
 


### PR DESCRIPTION
I was doing a local install of algo to a Raspberry Pi 4 and hit a couple of issues that the troubleshooting doc got some but not all the way through.  I had to ask gitter (and @davidemyers in particular) for help multiple times, and, I wanted to memorialize help that @davidemyers gave me in the troubleshooting doc.

## Description
Per David, the resolution for a failed local install is to remove the config directory and all of /etc/wireguard/*.  The docs just mention lock files in /etc/wireguard.  This PR addresses that.

## Motivation and Context
Per David, the resolution for a failed local install is to remove the config directory and all of /etc/wireguard/*.  The docs just mention lock files in /etc/wireguard.  This PR addresses that.


## How Has This Been Tested?
Documentation change that I reviewed locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
