### PR TITLE
Discontinue use of the WireGuard PPA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update -y
-          sudo add-apt-repository -yu ppa:wireguard/wireguard
           sudo apt install -y \
             python3-pip \
             lxd \
@@ -108,7 +107,6 @@ jobs:
       - name: Install dependencies
         run: |
           set -x
-          sudo add-apt-repository -yu ppa:wireguard/wireguard
           sudo add-apt-repository -yu ppa:ubuntu-lxc/stable
           sudo apt update -y
           sudo apt install -y \

--- a/docs/client-linux-wireguard.md
+++ b/docs/client-linux-wireguard.md
@@ -9,7 +9,7 @@ To connect to your AlgoVPN using [WireGuard](https://www.wireguard.com) from Ubu
 sudo apt update && sudo apt upgrade
 
 # If the file /var/run/reboot-required exists then reboot:
-sudo reboot
+[ -e /var/run/reboot-required ] && sudo reboot
 
 # Install WireGuard:
 sudo apt install wireguard openresolv

--- a/docs/client-linux-wireguard.md
+++ b/docs/client-linux-wireguard.md
@@ -2,14 +2,9 @@
 
 ## Install WireGuard
 
-To connect to your AlgoVPN using [WireGuard](https://www.wireguard.com) from Ubuntu, first install WireGuard:
+To connect to your AlgoVPN using [WireGuard](https://www.wireguard.com) from Ubuntu, make sure your system is up-to-date then install WireGuard:
 
 ```shell
-# Ubuntu 16.04 only: Add the WireGuard repository
-sudo add-apt-repository ppa:wireguard/wireguard
-sudo apt update
-
-# Install the tools:
 sudo apt install wireguard openresolv
 ```
 

--- a/docs/client-linux-wireguard.md
+++ b/docs/client-linux-wireguard.md
@@ -5,6 +5,13 @@
 To connect to your AlgoVPN using [WireGuard](https://www.wireguard.com) from Ubuntu, make sure your system is up-to-date then install WireGuard:
 
 ```shell
+# Update your system:
+sudo apt update && sudo apt upgrade
+
+# If the file /var/run/reboot-required exists then reboot:
+sudo reboot
+
+# Install WireGuard:
 sudo apt install wireguard openresolv
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,7 +21,7 @@ No. This project is under active development. We're happy to [accept and fix iss
 
 ## What's the current status of WireGuard?
 
-[WireGuard reached "stable" 1.0.0 release](https://lists.zx2c4.com/pipermail/wireguard/2020-March/005206.html) in Spring 2020. It has undergone [substantial](https://www.wireguard.com/formal-verification/) security review. Releases are tagged with their build date -- "0.0.YYYYMMDD" -- and users should be advised to apply new updates when they are available. Your Algo server will automatically upgrade and restart WireGuard. For Ubuntu 18.04 LTS, it will retrieve updates from the [official WireGuard PPA for Ubuntu](https://launchpad.net/~wireguard/+archive/ubuntu/wireguard) by default.
+[WireGuard reached "stable" 1.0.0 release](https://lists.zx2c4.com/pipermail/wireguard/2020-March/005206.html) in Spring 2020. It has undergone [substantial](https://www.wireguard.com/formal-verification/) security review.
 
 ## Why aren't you using Tor?
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-install_headers: true
+install_headers: false
 aip_supported_providers:
   - digitalocean
 snat_aipv4: false

--- a/roles/wireguard/files/50-wireguard-unattended-upgrades
+++ b/roles/wireguard/files/50-wireguard-unattended-upgrades
@@ -1,4 +1,0 @@
-// Automatically upgrade packages from these (origin:archive) pairs
-Unattended-Upgrade::Allowed-Origins {
-    "LP-PPA-wireguard-wireguard:${distro_codename}";
-};

--- a/roles/wireguard/tasks/ubuntu.yml
+++ b/roles/wireguard/tasks/ubuntu.yml
@@ -1,33 +1,9 @@
 ---
-- block:
-  - name: WireGuard repository configured
-    apt_repository:
-      repo: ppa:wireguard/wireguard
-      state: present
-    register: result
-    until: result is succeeded
-    retries: 10
-    delay: 3
-
-  - name: Configure unattended-upgrades
-    copy:
-      src: 50-wireguard-unattended-upgrades
-      dest: /etc/apt/apt.conf.d/50-wireguard-unattended-upgrades
-      owner: root
-      group: root
-      mode: 0644
-  when: ansible_facts['distribution_version'] is version('20.04', '<')
-
 - name: WireGuard installed
   apt:
     name: wireguard
     state: present
     update_cache: true
-
-- name: WireGuard reload-module-on-update
-  file:
-    dest: /etc/wireguard/.reload-module-on-update
-    state: touch
 
 - name: Set OS specific facts
   set_fact:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Discontinue use of the [WireGuard PPA](https://launchpad.net/~wireguard/+archive/ubuntu/wireguard).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
WireGuard is now included in the Ubuntu kernel package for all supported Ubuntu versions since 16.04 LTS. Therefore [the WireGuard PPA is being removed](https://lists.zx2c4.com/pipermail/wireguard/2020-August/005737.html).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deployed to DigitalOcean and Vultr (where Algo uses 20.04) and Lightsail (where Algo still must use 18.04). Someone should test OpenStack (which still uses 18.04).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
