### PR TITLE
WireGuard is included in Ubuntu by default now

### DIFF
--- a/docs/client-linux-wireguard.md
+++ b/docs/client-linux-wireguard.md
@@ -5,11 +5,7 @@
 To connect to your AlgoVPN using [WireGuard](https://www.wireguard.com) from Ubuntu, first install WireGuard:
 
 ```shell
-# Ubuntu 16.04 only: Add the WireGuard repository
-sudo add-apt-repository ppa:wireguard/wireguard
-sudo apt update
-
-# Install the tools:
+sudo apt update && sudo apt upgrade
 sudo apt install wireguard openresolv
 ```
 

--- a/roles/wireguard/files/50-wireguard-unattended-upgrades
+++ b/roles/wireguard/files/50-wireguard-unattended-upgrades
@@ -1,4 +1,0 @@
-// Automatically upgrade packages from these (origin:archive) pairs
-Unattended-Upgrade::Allowed-Origins {
-    "LP-PPA-wireguard-wireguard:${distro_codename}";
-};

--- a/roles/wireguard/tasks/ubuntu.yml
+++ b/roles/wireguard/tasks/ubuntu.yml
@@ -1,33 +1,10 @@
 ---
 - block:
-  - name: WireGuard repository configured
-    apt_repository:
-      repo: ppa:wireguard/wireguard
-      state: present
-    register: result
-    until: result is succeeded
-    retries: 10
-    delay: 3
-
-  - name: Configure unattended-upgrades
-    copy:
-      src: 50-wireguard-unattended-upgrades
-      dest: /etc/apt/apt.conf.d/50-wireguard-unattended-upgrades
-      owner: root
-      group: root
-      mode: 0644
-  when: ansible_facts['distribution_version'] is version('20.04', '<')
-
 - name: WireGuard installed
   apt:
     name: wireguard
     state: present
     update_cache: true
-
-- name: WireGuard reload-module-on-update
-  file:
-    dest: /etc/wireguard/.reload-module-on-update
-    state: touch
 
 - name: Set OS specific facts
   set_fact:


### PR DESCRIPTION
WireGuard is now in Ubuntu 20.04, 18.04, and 16.04 in their default
kernels, and all other Ubuntus are EOL'd by Canonical. [1] has details
on replacing the PPA with Canonical's builtin repos, which this commit
implements.

[1] https://lists.zx2c4.com/pipermail/wireguard/2020-August/005737.html

---

I haven't tested this, so please test before merging. Also, everything usually works better after an `apt update && apt upgrade && reboot` as it usually takes Canonical a while to make Ubuntu work after the initial packages they release onto the ISO.