### PR TITLE
Install dnscrypt-proxy from ubuntu repos

### DIFF
--- a/roles/dns/tasks/ubuntu.yml
+++ b/roles/dns/tasks/ubuntu.yml
@@ -1,27 +1,29 @@
 ---
-- name: Add the repository
-  apt_repository:
-    state: present
-    codename: "{{ ansible_distribution_release }}"
-    repo: ppa:shevchuk/dnscrypt-proxy
-  register: result
-  until: result is succeeded
-  retries: 10
-  delay: 3
+- block:
+  - name: Add the repository
+    apt_repository:
+      state: present
+      codename: "{{ ansible_distribution_release }}"
+      repo: ppa:shevchuk/dnscrypt-proxy
+    register: result
+    until: result is succeeded
+    retries: 10
+    delay: 3
+
+  - name: Configure unattended-upgrades
+    copy:
+      src: 50-dnscrypt-proxy-unattended-upgrades
+      dest: /etc/apt/apt.conf.d/50-dnscrypt-proxy-unattended-upgrades
+      owner: root
+      group: root
+      mode: 0644
+  when: ansible_facts['distribution_version'] is version('20.04', '<')
 
 - name: Install dnscrypt-proxy
   apt:
     name: dnscrypt-proxy
     state: present
     update_cache: true
-
-- name: Configure unattended-upgrades
-  copy:
-    src: 50-dnscrypt-proxy-unattended-upgrades
-    dest: /etc/apt/apt.conf.d/50-dnscrypt-proxy-unattended-upgrades
-    owner: root
-    group: root
-    mode: 0644
 
 - block:
   - name: Ubuntu | Configure AppArmor policy for dnscrypt-proxy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Starting from 20.04, the repos have dnscrypt-proxy 2 included

## Motivation and Context
- Get rid of external PPA

## How Has This Been Tested?
Deployed to 18.04 and 20.04 on DigitalOcean

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Refactoring

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
