### PR TITLE
Allow more users

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -1,10 +1,10 @@
 ---
 
 # This is the list of users to generate.
-# Every device must have a unique username.
-# You can generate up to 250 users at one time.
-# Usernames with leading 0's or containing only numbers should be escaped in double quotes, e.g. "000dan" or "123".
-# Emails are not allowed
+# Every device must have a unique user.
+# You can add up to 65,534 new users over the lifetime of an AlgoVPN.
+# User names with leading 0's or containing only numbers should be escaped in double quotes, e.g. "000dan" or "123".
+# Email addresses are not allowed.
 users:
   - phone
   - laptop
@@ -114,7 +114,7 @@ strongswan_log_level: 2
 
 # rightsourceip for ipsec
 # ipv4
-strongswan_network: 10.19.48.0/24
+strongswan_network: 10.48.0.0/16
 # ipv6
 strongswan_network_ipv6: '2001:db8:4160::/48'
 
@@ -124,7 +124,7 @@ strongswan_network_ipv6: '2001:db8:4160::/48'
 wireguard_PersistentKeepalive: 0
 
 # WireGuard network configuration
-wireguard_network_ipv4: 10.19.49.0/24
+wireguard_network_ipv4: 10.49.0.0/16
 wireguard_network_ipv6: 2001:db8:a160::/48
 
 # Randomly generated IP address for the local dns resolver

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -13,8 +13,8 @@ wireguard_dns_servers: >-
   {% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
   {% endif %}
 wireguard_client_ip: >-
-  {{ wireguard_network_ipv4 | ipaddr(index|int+2) }}
-  {{ ',' + wireguard_network_ipv6 | ipaddr(index|int+2) if ipv6_support else '' }}
+  {{ wireguard_network_ipv4 | ipmath(index|int+2) }}
+  {{ ',' + wireguard_network_ipv6 | ipmath(index|int+2) if ipv6_support else '' }}
 wireguard_server_ip: >-
   {{ wireguard_network_ipv4 | ipaddr('1') }}
   {{ ',' + wireguard_network_ipv6 | ipaddr('1') if ipv6_support else '' }}

--- a/roles/wireguard/templates/server.conf.j2
+++ b/roles/wireguard/templates/server.conf.j2
@@ -12,6 +12,6 @@ SaveConfig = false
 # {{ u }}
 PublicKey = {{ lookup('file', wireguard_pki_path + '/public/' + u) }}
 PresharedKey = {{ lookup('file', wireguard_pki_path + '/preshared/' + u) }}
-AllowedIPs = {{ wireguard_network_ipv4 | ipaddr(index|int+1) | ipv4('address') }}/32{{ ',' + wireguard_network_ipv6 | ipaddr(index|int+1) | ipv6('address') + '/128' if ipv6_support else '' }}
+AllowedIPs = {{ wireguard_network_ipv4 | ipmath(index|int+1) | ipv4('address') }}/32{{ ',' + wireguard_network_ipv6 | ipmath(index|int+1) | ipv6('address') + '/128' if ipv6_support else '' }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
WireGuard will fail to start if the user attempts to add more than 254 `users`. This change increases the limit to 65,534, and WireGuard won't fail if this new limit is exceeded.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While it's unlikely that most Algo users will need to create more than 254 `users`, at least one user on Gitter has hit the limit. It's not obvious to users that Algo has a "memory" of all `users` ever created on a given server such that deleting old `users` does not create room for new ones.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Performed a local install with 260 `users`. Tested connectivity from iOS with the 254th, 255th, and 256th WireGuard configs.

Did not test IPsec, but strongSwan looks to be OK with the change:
```
Virtual IP pools (size/online/offline):
  10.48.0.0/16: 65534/0/0
  2001:db8:4160::/48: 2147483646/0/0
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
