### PR TITLE
Explicitly set SSH permissions in base.sh

### DIFF
--- a/files/cloud-init/base.sh
+++ b/files/cloud-init/base.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 set -eux
 
+# shellcheck disable=SC2230
 which sudo || until \
   apt-get update -y && \
   apt-get install sudo -yf --install-suggests; do
@@ -15,9 +16,10 @@ cat <<EOF >/etc/ssh/sshd_config
 {{ lookup('template', 'files/cloud-init/sshd_config') }}
 EOF
 
-test -d /home/algo/.ssh || (umask 077 && sudo -u algo mkdir -p /home/algo/.ssh/)
-echo "{{ lookup('file', '{{ SSH_keys.public }}') }}" | (umask 177 && sudo -u algo tee /home/algo/.ssh/authorized_keys)
+test -d /home/algo/.ssh || sudo -u algo mkdir -m 0700 /home/algo/.ssh
+echo "{{ lookup('file', '{{ SSH_keys.public }}') }}" | (sudo -u algo tee /home/algo/.ssh/authorized_keys && chmod 0600 /home/algo/.ssh/authorized_keys)
 
+# shellcheck disable=SC2015
 dpkg -l sshguard && until apt-get remove -y --purge sshguard; do
   sleep 3
 done || true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Apparently `umask` does not propagate through to `sudo` commands. This change explicitly sets the permissions on the `.ssh` directory and `authorized_keys` file for the user `algo`.

Also not all cloud providers obey the `#!` in a script like this so we must assume the script will be run by `dash` rather than `bash`.

Closes #1925.

## How Has This Been Tested?
Tested on Vultr, Lightsail, and Linode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
