### PR TITLE
update Azure venv - msrestazure & azure-cli-core to resolve errors

### DIFF
--- a/roles/cloud-azure/tasks/venv.yml
+++ b/roles/cloud-azure/tasks/venv.yml
@@ -5,7 +5,7 @@
       - packaging
       - requests[security]
       - xmltodict
-      - azure-cli-core==2.0.35
+      - azure-cli-core==2.16.0
       - azure-cli-nspkg==3.0.2
       - azure-common==1.1.11
       - azure-mgmt-authorization==0.51.1
@@ -32,7 +32,7 @@
       - azure-nspkg==2.0.0
       - azure-storage==0.35.1
       - msrest==0.6.1
-      - msrestazure==0.5.0
+      - msrestazure==0.6.4
       - azure-keyvault==1.0.0a1
       - azure-graphrbac==0.40.0
       - azure-mgmt-cosmosdb==0.5.2


### PR DESCRIPTION
Resolves: https://github.com/trailofbits/algo/issues/1881 

(I needed the update to azure-cli-core as suggested by @benzin1984 but the new version didn't work for me without an update to msrestazure as well). 

## Description

(venv) Dependency changes:
msrestazure==0.6.4
azure-cli-core==2.16.0


## Motivation and Context
Algo scripts would fail with time error described here: https://stackoverflow.com/questions/58569361/attributeerror-module-time-has-no-attribute-clock-in-python-3-8 

## How Has This Been Tested?
Created test azure deployments. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
