### PR TITLE
Update required_ansible_version regex to support ansible==2.10.x

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -24,7 +24,7 @@
     - name: Set required ansible version as a fact
       set_fact:
         required_ansible_version:
-          "{{ item |  regex_replace('^ansible[\\s+]?(?P<op>[=,>,<]+)[\\s+]?(?P<ver>\\d.\\d(.\\d+)?)$',
+          "{{ item |  regex_replace('^ansible[\\s+]?(?P<op>[=,>,<]+)[\\s+]?(?P<ver>\\d.\\d+(.\\d+)?)$',
                       '{\"op\": \"\\g<op>\",\"ver\": \"\\g<ver>\" }') }}"
       when: '"ansible" in item'
       with_items: "{{ lookup('file', 'requirements.txt').splitlines() }}"


### PR DESCRIPTION
## Description
In advance of the `algo` project actually supporting or requiring `ansible=>2.10.x`


## Motivation and Context
While testing local support for `ansible=2.10.3`,
I encountered a situation where even an updated requirements.txt does not allow algo to be run.

The cause is the regex expression expecting a single digit `y` value in the `ansible==x.y.z` declaration,
this causes the regex match to fail, and a subsequent `Verify` task emits this failure due to an empty `op` value:

```
The error was: error while evaluating conditional (ansible_version.full is version(required_ansible_version.ver, required_ansible_version.op)): ''ansible.utils.unsafe_proxy.AnsibleUnsafeText object'' has no attribute ''op'''
```

## How Has This Been Tested?
Tested in an environment with ansible==2.10.3.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.

- [x] my changes should not affect any tests or documentation