### PR TITLE
Fix comma bug in wg config, Dockerfile dependencies, added 'update' to Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3-alpine
 
 ARG VERSION="git"
-ARG PACKAGES="bash libffi openssh-client openssl rsync tini gcc libffi-dev linux-headers make musl-dev openssl-dev"
+ARG PACKAGES="bash libffi openssh-client openssl rsync tini gcc libffi-dev linux-headers make musl-dev openssl-dev cargo"
 
 LABEL name="algo" \
       version="${VERSION}" \

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 ## docker-build: Build and tag a docker image
 .PHONY: docker-build
 
-IMAGE          := trailofbits/algo
-TAG	  	       := latest
-DOCKERFILE     := Dockerfile
-CONFIGURATIONS := $(shell pwd)
+IMAGE 		:= trailofbits/algo
+TAG			:= latest
+DOCKERFILE	:= Dockerfile
+PWD			:= $$(pwd)
 
 docker-build:
 	docker build \
@@ -21,10 +21,22 @@ docker-deploy:
 	--cap-drop=all \
 	--rm \
 	-it \
-	-v $(CONFIGURATIONS):/data \
+	-v $(PWD):/data \
 	$(IMAGE):$(TAG)
 
-## docker-clean: Remove images and containers.
+# update the users on existing VPN
+.PHONY: docker-update
+
+docker-update:
+	docker run \
+	--cap-drop=all \
+	--rm \
+	-it \
+	-e "ALGO_ARGS=update-users" \
+	-v $(PWD):/data \
+	$(IMAGE):$(TAG)
+
+## docker-prune: Remove images and containers.
 .PHONY: docker-prune
 
 docker-prune:

--- a/playbooks/cloud-pre.yml
+++ b/playbooks/cloud-pre.yml
@@ -21,7 +21,6 @@
       state: present
       name:
         - pyOpenSSL>=0.15
-        - jinja2==2.8
         - segno
     tags:
       - always

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible==2.9.7
+jinja2==2.8
 netaddr

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -13,8 +13,6 @@ wireguard_dns_servers: >-
   {% for host in dns_servers.ipv4 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% if ipv6_support %},{% for host in dns_servers.ipv6 %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
   {% endif %}
 wireguard_client_ip: >-
-  {{ wireguard_network_ipv4 | ipmath(index|int+2) }}
-  {{ ',' + wireguard_network_ipv6 | ipmath(index|int+2) if ipv6_support else '' }}
+  {{ wireguard_network_ipv4 | ipmath(index|int+2) }}{{ ', ' + wireguard_network_ipv6 | ipmath(index|int+2) if ipv6_support else '' }}
 wireguard_server_ip: >-
-  {{ wireguard_network_ipv4 | ipaddr('1') }}
-  {{ ',' + wireguard_network_ipv6 | ipaddr('1') if ipv6_support else '' }}
+  {{ wireguard_network_ipv4 | ipaddr('1') }}{{ ', ' + wireguard_network_ipv6 | ipaddr('1') if ipv6_support else '' }}


### PR DESCRIPTION
## Description
This is three quick fixes I figured I would share with the community. 
1. The wireguard config generator had a comma error, fixed @ `roles/wireguard/defaults/main.yml`
2. Docker Image wouldn't build on any OS (added cargo dependency and it builds on MacOs and Ubuntu) @ `Dockerfile`
3. Added a quick and easy Make Command for updating users in accordance with the documentation @ `Makefile`
   - I also changed the Makefile to work on any OS using `$$(pwd)` format. 

## Motivation and Context
Couldn't find any open issues on this but this fixes the issues above. This makes it easier for those deploying Algo from Docker, especially if they want to build their own docker image. 

## How Has This Been Tested?
Deployed a VPN to AWS and Linode using these changes from GitLab CI/CD, Ubuntu, and MacOS. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) _(Not necessary)_ 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. _(Not necessary)_ 
- [ ] I have updated the documentation accordingly. _(Not necessary)_ 
- [ ] I have added tests to cover my changes. _(Not necessary)_ 
- [X] All new and existing tests passed.
