### PR TITLE
Install required version of jinja2 earlier

### DIFF
--- a/playbooks/cloud-pre.yml
+++ b/playbooks/cloud-pre.yml
@@ -21,7 +21,6 @@
       state: present
       name:
         - pyOpenSSL>=0.15
-        - jinja2==2.8
         - segno
     tags:
       - always

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible==2.9.7
+jinja2==2.8
 netaddr


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Move the installation of the required version of jinja2 from `cloud-pre.yml` to `requirements.txt`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, jinja2 is installed twice. First the latest version is installed during setup, then the required version is installed at runtime. Algo is failing when using the latest version to check if the current directory is world writable.

Closes #14204.
Thanks to @jarrettprosser.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deployed to DigitalOcean.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
