### PR TITLE
Add and sort multiple new Azure regions

### DIFF
--- a/roles/cloud-azure/defaults/main.yml
+++ b/roles/cloud-azure/defaults/main.yml
@@ -2,17 +2,66 @@
 _azure_regions: >
   [
     {
-      "displayName": "East Asia",
-      "latitude": "22.267",
-      "longitude": "114.188",
-      "name": "eastasia",
+      "displayName": "Australia Central",
+      "latitude": "-35.3075",
+      "longitude": "149.1244",
+      "name": "australiacentral",
       "subscriptionId": null
     },
     {
-      "displayName": "Southeast Asia",
-      "latitude": "1.283",
-      "longitude": "103.833",
-      "name": "southeastasia",
+      "displayName": "Australia Central 2",
+      "latitude": "-35.3075",
+      "longitude": "149.1244",
+      "name": "australiacentral2",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Australia East",
+      "latitude": "-33.86",
+      "longitude": "151.2094",
+      "name": "australiaeast",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Australia Southeast",
+      "latitude": "-37.8136",
+      "longitude": "144.9631",
+      "name": "australiasoutheast",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Brazil South",
+      "latitude": "-23.55",
+      "longitude": "-46.633",
+      "name": "brazilsouth",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Brazil Southeast",
+      "latitude": "-22.90278",
+      "longitude": "-43.2075",
+      "name": "brazilsoutheast",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Canada Central",
+      "latitude": "43.653",
+      "longitude": "-79.383",
+      "name": "canadacentral",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Canada East",
+      "latitude": "46.817",
+      "longitude": "-71.217",
+      "name": "canadaeast",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Central India",
+      "latitude": "18.5822",
+      "longitude": "73.9197",
+      "name": "centralindia",
       "subscriptionId": null
     },
     {
@@ -20,6 +69,13 @@ _azure_regions: >
       "latitude": "41.5908",
       "longitude": "-93.6208",
       "name": "centralus",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "East Asia",
+      "latitude": "22.267",
+      "longitude": "114.188",
+      "name": "eastasia",
       "subscriptionId": null
     },
     {
@@ -37,12 +93,238 @@ _azure_regions: >
       "subscriptionId": null
     },
     {
+      "displayName": "France Central",
+      "latitude": "46.3772",
+      "longitude": "2.3730",
+      "name": "francecentral",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "France South",
+      "latitude": "43.8345",
+      "longitude": "2.1972",
+      "name": "francesouth",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Germany North",
+      "latitude": "53.073635",
+      "longitude": "8.806422",
+      "name": "germanynorth",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Germany West Central",
+      "latitude": "50.110924",
+      "longitude": "8.682127",
+      "name": "germanywestcentral",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Japan East",
+      "latitude": "35.68",
+      "longitude": "139.77",
+      "name": "japaneast",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Japan West",
+      "latitude": "34.6939",
+      "longitude": "135.5022",
+      "name": "japanwest",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Jio India Central",
+      "latitude": "21.146633",
+      "longitude": "79.08886",
+      "name": "jioindiacentral",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Jio India West",
+      "latitude": "22.470701",
+      "longitude": "70.05773",
+      "name": "jioindiawest",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Korea Central",
+      "latitude": "37.5665",
+      "longitude": "126.9780",
+      "name": "koreacentral",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Korea South",
+      "latitude": "35.1796",
+      "longitude": "129.0756",
+      "name": "koreasouth",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "North Central US",
+      "latitude": "41.8819",
+      "longitude": "-87.6278",
+      "name": "northcentralus",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "North Europe",
+      "latitude": "53.3478",
+      "longitude": "-6.2597",
+      "name": "northeurope",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Norway East",
+      "latitude": "59.913868",
+      "longitude": "10.752245",
+      "name": "norwayeast",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Norway West",
+      "latitude": "58.969975",
+      "longitude": "5.733107",
+      "name": "norwaywest",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "South Africa North",
+      "latitude": "-25.731340",
+      "longitude": "28.218370",
+      "name": "southafricanorth",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "South Africa West",
+      "latitude": "-34.075691",
+      "longitude": "18.843266",
+      "name": "southafricawest",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "South Central US",
+      "latitude": "29.4167",
+      "longitude": "-98.5",
+      "name": "southcentralus",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "South India",
+      "latitude": "12.9822",
+      "longitude": "80.1636",
+      "name": "southindia",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Southeast Asia",
+      "latitude": "1.283",
+      "longitude": "103.833",
+      "name": "southeastasia",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Sweden Central",
+      "latitude": "60.67488",
+      "longitude": "17.14127",
+      "name": "swedencentral",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Sweden South",
+      "latitude": "55.6059",
+      "longitude": "13.0007",
+      "name": "swedensouth",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Switzerland North",
+      "latitude": "47.451542",
+      "longitude": "8.564572",
+      "name": "switzerlandnorth",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "Switzerland West",
+      "latitude": "46.204391",
+      "longitude": "6.143158",
+      "name": "switzerlandwest",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "UAE Central",
+      "latitude": "24.466667",
+      "longitude": "54.366669",
+      "name": "uaecentral",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "UAE North",
+      "latitude": "25.266666",
+      "longitude": "55.316666",
+      "name": "uaenorth",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "UK South",
+      "latitude": "50.941",
+      "longitude": "-0.799",
+      "name": "uksouth",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "UK West",
+      "latitude": "53.427",
+      "longitude": "-3.084",
+      "name": "ukwest",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "West Central US",
+      "latitude": "40.890",
+      "longitude": "-110.234",
+      "name": "westcentralus",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "West Europe",
+      "latitude": "52.3667",
+      "longitude": "4.9",
+      "name": "westeurope",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "West India",
+      "latitude": "19.088",
+      "longitude": "72.868",
+      "name": "westindia",
+      "subscriptionId": null
+    },
+    {
       "displayName": "West US",
       "latitude": "37.783",
       "longitude": "-122.417",
       "name": "westus",
       "subscriptionId": null
     },
+    {
+      "displayName": "West US 2",
+      "latitude": "47.233",
+      "longitude": "-119.852",
+      "name": "westus2",
+      "subscriptionId": null
+    },
+    {
+      "displayName": "West US 3",
+      "latitude": "33.448376",
+      "longitude": "-112.074036",
+      "name": "westus3",
+      "subscriptionId": null
+    }
+  ]
+
     {
       "displayName": "North Central US",
       "latitude": "41.8819",


### PR DESCRIPTION
## Description
Azure has added several regions, some net-new and others moved from standalone cloud instances into general Azure.  This change adds the new regions and sorts the regions by the displayName property.  Staging ("stage") and early-access ("EAUP") regions are excluded.

## Motivation and Context
Azure Germany, in particular, will soon not be a standalone cloud and I wanted to use Algo to deploy into that region.

## How Has This Been Tested?
Exported Azure regions through az CLI and did JSON transform into the main.yml in my local repo; successfully deployed Algo on a VM in germanywestcentral.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation. (No new documentation needed.)
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes. (No testable code changed.)
- [] All new and existing tests passed.