### PR TITLE
Move the dnscrypt-proxy cache file

### DIFF
--- a/roles/dns/files/apparmor.profile.dnscrypt-proxy
+++ b/roles/dns/files/apparmor.profile.dnscrypt-proxy
@@ -14,7 +14,7 @@
 
   /etc/dnscrypt-proxy/** r,
   /usr/bin/dnscrypt-proxy mr,
-  /tmp/public-resolvers.md* rw,
+  /var/cache/{private/,}dnscrypt-proxy/** rw,
 
   /tmp/*.tmp w,
   owner /tmp/*.tmp r,

--- a/roles/dns/templates/dnscrypt-proxy.toml.j2
+++ b/roles/dns/templates/dnscrypt-proxy.toml.j2
@@ -118,11 +118,12 @@ timeout = 2500
 keepalive = 30
 
 
-## Use the REFUSED return code for blocked responses
-## Setting this to `false` means that some responses will be lies.
-## Unfortunately, `false` appears to be required for Android 8+
+## Response for blocked queries. Options are `refused`, `hinfo` (default) or
+## an IP response. To give an IP response, use the format `a:<IPv4>,aaaa:<IPv6>`.
+## Using the `hinfo` option means that some responses will be lies.
+## Unfortunately, the `hinfo` option appears to be required for Android 8+
 
-refused_code_in_responses = false
+# blocked_query_response = 'refused'
 
 
 ## Load-balancing strategy: 'p2' (default), 'ph', 'first' or 'random'
@@ -523,7 +524,7 @@ cache_neg_max_ttl = 600
 
   [sources.'public-resolvers']
   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']
-  cache_file = '/tmp/public-resolvers.md'
+  cache_file = '/var/cache/dnscrypt-proxy/public-resolvers.md'
   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
   prefix = ''
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move the `dnscrypt-proxy` cache file of public resolvers from `/tmp` to `/var/cache/dnscrypt-proxy`.

## Motivation and Context
Several years ago in #1120 I moved the `dnscrypt-proxy` cache file of public resolvers to `/tmp`. The default had been to write it to `/etc/dnscrypt-proxy` but this was failing because `dnscrypt-proxy` does not run as `root` and also is blocked from writing to that directory by AppArmor.

Recently, as reported in #14234, there was a problem with the signing of the public resolver file which prevented `dnscrypt-proxy` from starting during Algo deployment. This could have also affected any existing Algo servers that were rebooted while the error was present since the cache file in `/tmp` would have been lost after a reboot.

According to the author of `dnscrypt-proxy` [here](https://github.com/DNSCrypt/dnscrypt-resolvers/issues/519#issuecomment-869169729), recent versions will ignore problems fetching the public resolver file and continue to use the cached version.

Therefore this change moves the cache to the Ubuntu package location of `/var/cache/dnscrypt-proxy` and adjusts the AppArmor rules. The PPA version of `dnscrypt-proxy`, which is still used on Ubuntu 18.04 deployments, uses `/var/cache/private/dnscrypt-proxy`, but creates `/var/cache/dnscrypt-proxy` as a symbolic link to that directory.

This change also updates the `dnscrypt-proxy` config to eliminate the warning message:
```
config option `refused_code_in_responses` is deprecated, use `blocked_query_response`
```

## How Has This Been Tested?
Deployed to Vultr with Ubuntu 18.04 and 20.04.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
