### PR TITLE
Added support for EC2 Spot instances

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -177,6 +177,10 @@ cloud_providers:
     image:
       name: "ubuntu-focal-20.04"
       owner: "099720109477"
+    # Change instance_market_type from "on-demand" to "spot" to take advantage of
+    # simplified spot launch options
+    # See https://aws.amazon.com/blogs/compute/new-amazon-ec2-spot-pricing/
+    instance_market_type: on-demand
   gce:
     size: f1-micro
     image: ubuntu-2004-lts

--- a/docs/cloud-amazon-ec2.md
+++ b/docs/cloud-amazon-ec2.md
@@ -48,22 +48,27 @@ On the final screen, click the Download CSV button. This file includes the AWS a
 
 After you have downloaded Algo and installed its dependencies, the next step is running Algo to provision the VPN server  on your AWS account.
 
-First you will be asked which server type to setup. You would want to enter "2" to use Amazon EC2.
+First you will be asked which server type to setup. You would want to enter "3" to use Amazon EC2.
 
 ```
 $ ./algo
 
   What provider would you like to use?
     1. DigitalOcean
-    2. Amazon EC2
-    3. Microsoft Azure
-    4. Google Compute Engine
-    5. Scaleway
-    6. OpenStack (DreamCompute optimised)
-    7. Install to existing Ubuntu 16.04 server (Advanced)
+    2. Amazon Lightsail
+    3. Amazon EC2
+    4. Microsoft Azure
+    5. Google Compute Engine
+    6. Hetzner Cloud
+    7. Vultr
+    8. Scaleway
+    9. OpenStack (DreamCompute optimised)
+    10. CloudStack (Exoscale optimised)
+    11. Linode
+    12. Install to existing Ubuntu 18.04 or 20.04 server (for more advanced users)
 
 Enter the number of your desired provider
-: 2
+: 3
 ```
 
 Next you will be asked for the AWS Access Key (Access Key ID) and AWS Secret Key (Secret Access Key) that you received in  the CSV file when you setup the account (don't worry if you don't see your text entered in the console; the key input is  hidden here by Algo).

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -111,6 +111,12 @@ Possible options can be gathered via cli `aws ec2 describe-regions`
 Additional variables:
 
 - [encrypted](https://aws.amazon.com/blogs/aws/new-encrypted-ebs-boot-volumes/) - Encrypted EBS boot volume. Boolean (Default: false)
+- [size](https://aws.amazon.com/ec2/instance-types/) - EC2 instance type. String (Default: t2.micro)
+- [instance_market_type](https://aws.amazon.com/ec2/pricing/) - Two pricing models are supported: on-demand and spot. String (Default: on-demand)
+  * If using spot instance types, one additional IAM permission along with the below minimum is required for deployment:
+    ```
+      "ec2:CreateLaunchTemplate"
+    ```
 
 #### Minimum required IAM permissions for deployment:
 

--- a/roles/cloud-ec2/files/stack.yaml
+++ b/roles/cloud-ec2/files/stack.yaml
@@ -20,9 +20,17 @@ Parameters:
     Type: String
   SshPort:
     Type: String
+  InstanceMarketTypeParameter:
+    Description: Launch a Spot instance or standard on-demand instance
+    Type: String
+    Default: on-demand
+    AllowedValues:
+      - spot
+      - on-demand
 Conditions:
   AllocateNewEIP: !Equals [!Ref UseThisElasticIP, '']
   AssociateExistingEIP: !Not [!Equals [!Ref UseThisElasticIP, '']]
+  InstanceIsSpot: !Equals [spot, !Ref InstanceMarketTypeParameter]
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -146,6 +154,15 @@ Resources:
         - Key: Name
           Value: !Ref AWS::StackName
 
+  EC2LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Condition: InstanceIsSpot    # Only create this template if requested
+    Properties:                  # a spot instance_market_type in config.cfg
+      LaunchTemplateName: !Ref AWS::StackName
+      LaunchTemplateData:
+        InstanceMarketOptions:
+          MarketType: spot
+
   EC2Instance:
     Type: AWS::EC2::Instance
     DependsOn:
@@ -169,6 +186,14 @@ Resources:
       SubnetId: !Ref Subnet
       Ipv6AddressCount: 1
       UserData: !Ref UserData
+      LaunchTemplate:
+        !If               # Only if Conditions created "EC2LaunchTemplate"
+          - InstanceIsSpot
+          -
+            LaunchTemplateId:
+              !Ref EC2LaunchTemplate
+            Version: 1
+          - !Ref AWS::NoValue  # Else this LaunchTemplate not set
       Tags:
         - Key: Name
           Value: !Ref AWS::StackName

--- a/roles/cloud-ec2/tasks/cloudformation.yml
+++ b/roles/cloud-ec2/tasks/cloudformation.yml
@@ -16,6 +16,7 @@
       EbsEncrypted: "{{ encrypted }}"
       UserData: "{{ lookup('template', 'files/cloud-init/base.yml') | b64encode }}"
       SshPort: "{{ ssh_port }}"
+      InstanceMarketTypeParameter: "{{ cloud_providers.ec2.instance_market_type }}"
     tags:
       Environment: Algo
   register: stack


### PR DESCRIPTION
Implements a new variable with the original default set in the config.cfg ec2 section named `instance_market_type` which has two possible values; `spot` or the default `on-demand`. Changing to `spot` launches a spot instance when deploying to ec2.

<!--- Provide a general summary of your changes in the Title above -->

## Description

## Motivation and Context
In 2018 EC2 changed the spot instances model, giving extended instance lifetimes without the frequent terminations which occurred in the old pricing model. Using spot instances instead of on-demand instances can significantly lower hourly costs.
  - As described in AWS blog post [Simplified purchasing without bidding and fewer interruptions
](https://aws.amazon.com/blogs/compute/new-amazon-ec2-spot-pricing/)

closes #1399 

The ec2 role file stack.yaml now implements EC2LaunchTemplate, which is a CloudFormation resource required to specify spot instances. This template data is an optional property of the existing EC2Instance resource, so only included for the spot instance condition. When requesting the default on-demand instances, the data structure sent to deploy the CloudFormation stack is identical to past versions of Algo.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Tested deployment to EC2 from Ubuntu 20.04 and macOS 10.15.x
- Regression tested deployment of ec2 on-demand instances, and feature tested ec2 spot instances
   - Tested InstanceTypes t2.micro (the default) and t3a.micro for both instance pricing models
- Tested with spot instances lifetime of up to 10 months. Never experienced forced termination of instances, or identified price surge. Before the EC2 changes of 2018 it was common to experience abrupt instance termination as well as concern of  surge pricing over the cost of on-demand

- [Documented](https://github.com/trailofbits/algo/blob/dfee28f8e479802c31bf210d98f26f2a55352a67/docs/deploy-from-ansible.md?plain=1#L115-L121) the need to set the `instance_market_type` variable, and to add an additional IAM permission if requesting a spot instance
  ```
      "ec2:CreateLaunchTemplate"
  ```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x]  New feature (non-breaking change which adds functionality)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
