### PR TITLE
Update Google Compute Environment machine type

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -178,7 +178,7 @@ cloud_providers:
       name: "ubuntu-focal-20.04"
       owner: "099720109477"
   gce:
-    size: f1-micro
+    size: e2-micro
     image: ubuntu-2004-lts
     external_static_ip: false
   lightsail:


### PR DESCRIPTION
Google advised that the f1-micro tier will no longer be free after 31AUG21 and suggested e2-micro will be the new free tier.

## Description
changed f1-micro to e2-micro

## Motivation and Context
maintain free-ness.

## How Has This Been Tested?
I successfully built two new VPN instances to test

## Types of changes
x Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
