### PR TITLE
docs: missing permission for spot instance support

### DIFF
--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -177,7 +177,8 @@ Additional variables:
                 "ec2:RunInstances",
                 "ec2:DescribeInstances",
                 "ec2:AllocateAddress",
-                "ec2:DescribeAddresses"
+                "ec2:DescribeAddresses",
+                "ec2:CreateLaunchTemplate"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
Documentation change - missing permission for spot instance support

<!--- Provide a general summary of your changes in the Title above -->

## Description
When using spot type instances, the CloudFormation creates a LaunchTemplate, but the documented IAM policy doesn't include the permission for this resource. 

## Motivation and Context
Fix an issue with the docs

## How Has This Been Tested?
Deployed a spot t3.micro in eu-west-2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. _(unsure to tick this or not, as this is just a documentation change)_
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. _(unsure to tick this or not, as this is just a documentation change)_
- [x] All new and existing tests passed.
