### PR TITLE
Change DNS from Cloudflare to Google

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -88,12 +88,14 @@ dnscrypt_servers:
   ipv4:
     - google
 #   - cloudflare
+#   - quad9-doh-ip4-port443-filter-pri
 #   - <YourCustomServer>  # E.g., if using NextDNS, this will be something like NextDNS-abc123.
                           # You must also fill in custom_server_stamps below. You may specify
                           # multiple custom servers.
   ipv6:
-    - google-ipv6
+#   - google-ipv6
 #   - cloudflare-ipv6
+#   - quad9-doh-ip6-port443-filter-pri
 
 custom_server_stamps:
 # YourCustomServer: 'sdns://...'

--- a/config.cfg
+++ b/config.cfg
@@ -86,13 +86,14 @@ unattended_reboot:
 # https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/v2/public-resolvers.md
 dnscrypt_servers:
   ipv4:
-    - cloudflare
-#   - google
+    - google
+#   - cloudflare
 #   - <YourCustomServer>  # E.g., if using NextDNS, this will be something like NextDNS-abc123.
                           # You must also fill in custom_server_stamps below. You may specify
                           # multiple custom servers.
   ipv6:
-    - cloudflare-ipv6
+    - google-ipv6
+#   - cloudflare-ipv6
 
 custom_server_stamps:
 # YourCustomServer: 'sdns://...'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change the default encrypted DNS provider from Cloudflare to Google.

## Motivation and Context
Cloudflare's DNS-over-HTTPS service has become unreliable and is causing issues for Algo users. See #14286 and #14308.

Personally I prefer Quad9 but they have a bad habit of changing the symbolic names of their servers and breaking things. See #14269 and #14167.

## How Has This Been Tested?
Deployed to Vultr.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
