### PR TITLE
Change config.cfg comment regarding ec2 spot option

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -183,9 +183,8 @@ cloud_providers:
     image:
       name: "ubuntu-focal-20.04"
       owner: "099720109477"
-    # Change instance_market_type from "on-demand" to "spot" to take advantage of
-    # simplified spot launch options
-    # See https://aws.amazon.com/blogs/compute/new-amazon-ec2-spot-pricing/
+    # Change instance_market_type from "on-demand" to "spot" to launch a spot
+    # instance. See deploy-from-ansible.md for spot's additional IAM permission
     instance_market_type: on-demand
   gce:
     size: e2-micro


### PR DESCRIPTION
Reference the documentation to know the proper IAM permissions

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the old ec2 section comment which instructed how to change from 
on-demand to spot instances. Advise to reference the existing document to
change the ec2 IAM policy for spot instances 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #14344 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Documentation via config file comment
 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
