### PR TITLE
Update cloud-linode.md

### DIFF
--- a/docs/cloud-linode.md
+++ b/docs/cloud-linode.md
@@ -4,5 +4,6 @@ Sign into the Linode Manager and go to the
 [tokens management page](https://cloud.linode.com/profile/tokens).
 
 Click `Add a Personal Access Token`. Label your new token and select *at least* the
-`Linodes` read/write permission. Press `Submit` and make sure to copy the displayed token
+`Linodes` read/write permission and `StackScripts` read/write permission. 
+Press `Submit` and make sure to copy the displayed token
 as it won't be shown again.


### PR DESCRIPTION
Update list of required permissions on the Linode Personal Access Token.

<!--- Provide a general summary of your changes in the Title above -->

Added `StackScripts` read/write as a required permission on the Personal Access Token.

## Description
<!--- Describe your changes in detail -->

Updated documentation for Linode to ensure correct permissions are set on the Personal Access Token.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If a Personal Access Token is created with just `Linodes` read/write permission, the Linode API will reject it with a `401: Your OAuth token is not authorized to use this endpoint.` in the task: `cloud-linode : Create a stackscript`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

1. Create a Linode Personal Access Token that _only_ has `Linodes` read/write permission.
2. Run `./algo` script to deploy server (selecting Linode as the provider and following remaining steps).
3. Observe 401 error from Linode API.
4. Create new Linode Personal Access Token with both `Linodes` and `StackScripts` read/write permissions
5. Re-run `./algo` script to deploy server (again, selecting Linode as the provider and answering remaining questions)
6. Server is succesfully deployed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
