### PR TITLE
Fix Vultr

### DIFF
--- a/files/cloud-init/base.sh
+++ b/files/cloud-init/base.sh
@@ -19,6 +19,8 @@ EOF
 test -d /home/algo/.ssh || sudo -u algo mkdir -m 0700 /home/algo/.ssh
 echo "{{ lookup('file', '{{ SSH_keys.public }}') }}" | (sudo -u algo tee /home/algo/.ssh/authorized_keys && chmod 0600 /home/algo/.ssh/authorized_keys)
 
+ufw --force reset
+
 # shellcheck disable=SC2015
 dpkg -l sshguard && until apt-get remove -y --purge sshguard; do
   sleep 3

--- a/files/cloud-init/base.yml
+++ b/files/cloud-init/base.yml
@@ -25,5 +25,6 @@ write_files:
 
 runcmd:
   - set -x
+  - ufw --force reset
   - sudo apt-get remove -y --purge sshguard || true
   - systemctl restart sshd.service

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -28,9 +28,7 @@
     vultr_startup_script:
       name: algo-startup
       script:  |
-        {{ lookup('template', 'files/cloud-init/base.sh') }}
-        mkdir -p /var/lib/cloud/data/ || true
-        touch /var/lib/cloud/data/result.json
+        {{ lookup('template', 'files/cloud-init/base.yml') }}
 
   - name: Creating a server
     vultr_server:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Vultr now enables UFW by default, which breaks Algo. See #14378.

This PR disables UFW on all cloud providers. Local installs are unchanged.

This PR also changes Vultr to use `cloud-init`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Deployed to Vultr, Linode, and DigitalOcean.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
