### PR TITLE
Fix OS Name for Vultr

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -209,7 +209,7 @@ cloud_providers:
     image: Linux Ubuntu 20.04 LTS 64-bit
     disk: 10
   vultr:
-    os: Ubuntu 20.04 x64
+    os: Ubuntu 20.04 LTS x64
     size: 1024 MB RAM,25 GB SSD,1.00 TB BW
   linode:
     type: g6-nanode-1


### PR DESCRIPTION
## Description
Vultr changed the name of the OS in their API from `Ubuntu 20.04 x64` to `Ubuntu 20.04 LTS x64`, breaking Algo with the default config.

It currently yields the following error message:
```
TASK [cloud-vultr : Creating a server] ******************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Could not find os with ID or name: Ubuntu 20.04 x64"}
```

See `OSID: 387` in https://api.vultr.com/v1/os/list

## Motivation and Context
The motivation is that Algo no longer works with Vultr with the default config. I can't find an existing issue for this.

## How Has This Been Tested?
1. Follow the instructions for configure Algo for Vultr
2. Observe that running Algo does not complete with the error above
3. Apply the fix
4. Observe that running Algo now works correctly with Vultr

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.