### PR TITLE
Read AWS credentials from disk (#14382)

### DIFF
--- a/roles/cloud-ec2/tasks/discover-credentials.yml
+++ b/roles/cloud-ec2/tasks/discover-credentials.yml
@@ -1,0 +1,35 @@
+---
+- name: "Find AWS profile and credentials file"
+  block:
+  - set_fact:
+      aws_credentials_path: "{{ lookup('env', 'HOME') }}/.aws/credentials"
+
+  - set_fact:
+      aws_credentials_path: "{{ lookup('env', 'AWS_SHARED_CREDENTIALS_FILE') }}"
+    when:
+      - lookup('env', 'AWS_SHARED_CREDENTIALS_FILE')|length > 0
+  - debug: var=aws_credentials_path
+
+  - set_fact:
+      aws_profile_id: "default"
+
+  - set_fact:
+      aws_profile_id: "{{ lookup('env', 'AWS_PROFILE') }}"
+    when:
+      - lookup('env', 'AWS_PROFILE')|length > 0
+
+- name: "Look up AWS credentials"
+  block:
+  - set_fact:
+      aws_access_key: "{{ lookup('ini', 'aws_access_key_id', section=aws_profile_id, file=aws_credentials_path) }}"
+    ignore_errors: true
+    when:
+      - aws_access_key is undefined
+      - lookup('env', 'AWS_ACCESS_KEY_ID')|length <= 0
+
+  - set_fact:
+      aws_secret_key: "{{ lookup('ini', 'aws_secret_access_key', section=aws_profile_id, file=aws_credentials_path) }}"
+    ignore_errors: true
+    when:
+      - aws_secret_key is undefined
+      - lookup('env', 'AWS_SECRET_ACCESS_KEY')|length <= 0

--- a/roles/cloud-ec2/tasks/main.yml
+++ b/roles/cloud-ec2/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: Build python virtual environment
   import_tasks: venv.yml
 
+- name: Include credential discovery
+  import_tasks: discover-credentials.yml
+
 - name: Include prompts
   import_tasks: prompts.yml
 

--- a/tests/.aws/credentials
+++ b/tests/.aws/credentials
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id=example_key
+aws_secret_access_key=example_secret

--- a/tests/.aws/credentials2
+++ b/tests/.aws/credentials2
@@ -1,0 +1,7 @@
+[default]
+aws_access_key_id=WRONG
+aws_secret_access_key=WRONG
+
+[profile1]
+aws_access_key_id=example_key
+aws_secret_access_key=example_secret

--- a/tests/aws-credentials.sh
+++ b/tests/aws-credentials.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# command line credentials should still work:
+ansible-playbook tests/validate-aws-credentials.yml \
+	-e aws_access_key=example_key \
+	-e aws_secret_key=example_secret
+
+# command line credentials should override config files:
+ansible-playbook tests/validate-aws-credentials.yml \
+	-e aws_access_key=example_key \
+	-e aws_secret_key=example_secret
+
+# In this case the config file is bad but the command line should win:
+AWS_SHARED_CREDENTIALS_FILE="$PWD/tests/.aws/credentials2" \
+	ansible-playbook tests/validate-aws-credentials.yml \
+	-e aws_access_key=example_key \
+	-e aws_secret_key=example_secret
+
+# should read from the config file in tests/.aws:
+HOME="$PWD/tests" \
+	ansible-playbook tests/validate-aws-credentials.yml
+
+AWS_SHARED_CREDENTIALS_FILE="$PWD/tests/.aws/credentials2" AWS_PROFILE=profile1 \
+	ansible-playbook tests/validate-aws-credentials.yml

--- a/tests/validate-aws-credentials.yml
+++ b/tests/validate-aws-credentials.yml
@@ -1,0 +1,7 @@
+- name: test
+  hosts: localhost
+  tasks:
+    - include_tasks: ../roles/cloud-ec2/tasks/discover-credentials.yml
+    - assert: { that: "aws_access_key == 'example_key'" }
+    - assert: { that: "aws_secret_key == 'example_secret'" }
+


### PR DESCRIPTION
## Description
Other programs can read the AWS key and secret from ~/.aws/credentials
(or other configuration file), and with this change Algo can as well.

Optional environment variables: AWS_PROFILE, AWS_SHARED_CREDENTIALS_FILE

The file is not read if the credentials are already set as an Ansible
variable or an environment variable.

## Motivation and Context
Setting the credentials on the command line or as an environment variable is an unnecessary annoyance when the credentials are already configured in the official AWS way (like you would have after running `aws configure`). And the security implications are debatable, but if I already have the credentials in a config file, I don't want them in my shell history or my shell initialization.

Issue here: https://github.com/trailofbits/algo/issues/14382

## How Has This Been Tested?
With AWS, I ran the main playbook:
```
 ansible-playbook main.yml -e "provider=ec2
                                server_name=algo
                                ondemand_cellular=false
                                ondemand_wifi=false
                                dns_adblocking=true
                                ssh_tunneling=true
                                store_pki=false
                                region=us-east-1
                                do_token=token"
```

I tested the following config file situations:
- with a configuration file set properly
- with a missing configuration file
- with a configuration file with no section header
- with a custom section header (and  `AWS_PROFILE` set)
- with wrong data in the config file but correct data set as environment variables (this worked)

Errors that came up did not stop execution unless the authentication info was wrong. The "Deploy the template" task often failed during my testing, but this is an unrelated issue--the playbook can only get to that stage if the authentication info is okay.

I also added a test script that is more limited, but does some of the above checks.

## Types of changes

- [x]  Bug fix (non-breaking change which fixes an issue). _I consider this a bugfix because the credentials file is standard and it's unusual that Algo doesn't read it._
- [ ]  New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. _This is a core AWS feature, I don't think we need to document it._
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. _The existing tests seem unrelated. Is the test procedure documented, or can we skip it?_
