### PR TITLE
update windows deployment documentation

### DIFF
--- a/docs/deploy-from-windows.md
+++ b/docs/deploy-from-windows.md
@@ -39,6 +39,32 @@ git clone https://github.com/trailofbits/algo
 cd algo
 ```
 
+## Post installation steps
+
+These steps should be only if you clone the Algo repository to the host machine disk (C:, D:, etc.). WSL mount host system disks to `\mnt` directory.
+
+### Allow git to change files metadata
+
+By default git cannot change files metadata (using chmod for example) for files stored at host machine disks (https://docs.microsoft.com/en-us/windows/wsl/wsl-config#set-wsl-launch-settings). Allow it:
+
+1. Start Ubuntu Terminal.
+2. Edit /etc/wsl.conf (create it if it doesn't exist). Add the following:
+```
+[automount]
+options = "metadata"
+```
+3. Close all Ubuntu Terminals.
+4. Run powershell.
+5. Run `wsl --shutdown` in powershell.
+
+### Allow  run Ansible in a world writable directory
+
+Ansible threat host machine directories as world writable directory and do not load .cfg from it by default (https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir). For fix run inside `algo` directory:
+
+```shell
+chmod 744 .
+```
+
 Now you can continue by following the [README](https://github.com/trailofbits/algo#deploy-the-algo-server) from the 4th step to deploy your Algo server!
 
 You'll be instructed to edit the file `config.cfg` in order to specify the Algo user accounts to be created. If you're new to Linux the simplest editor to use is `nano`. To edit the file while in the `algo` directory, run:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Without this changes you get next error if you try to clone repository to mounted ntfs disk:
```
error: chmod on /mnt/c/Users/Efsta/Code/<repo>/.git/config.lock failed: Operation not permitted
fatal: could not set 'core.filemode' to 'false'
```

## Motivation and Context
You cannot correctly clone algo repository to ntfs from WSL without this changes.

## How Has This Been Tested?
Run it in WSL several times.

## Types of changes
x Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
