### PR TITLE
Update README.md: Added ubuntu command that is required before running apt install

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The easiest way to get an Algo server running is to run it on your local system 
     - **Linux:** Recent releases of Ubuntu, Debian, and Fedora come with Python 3 already installed. Make sure your system is up-to-date and install the supporting package(s):
         * Ubuntu and Debian:
             ```bash
+            sudo apt-get update
             sudo apt install -y --no-install-recommends python3-virtualenv
             ```
             On a Raspberry Pi running Ubuntu also install `libffi-dev` and `libssl-dev`.


### PR DESCRIPTION

## Description
Added ubuntu command that is required before running apt install to get package lists

## Motivation and Context
To prevent the error:
E: Unable to locate package python3-virtualenv


## How Has This Been Tested?
while installing on ubuntu 20

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
