### PR TITLE
Make Azure OS disk type configurable and default to a cheaper type

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -165,6 +165,11 @@ SSH_keys:
 cloud_providers:
   azure:
     size: Standard_B1S
+    osDisk:
+      # The storage account type to use for the OS disk. Possible values:
+      # 'Standard_LRS', 'Premium_LRS', 'StandardSSD_LRS', 'UltraSSD_LRS',
+      # 'Premium_ZRS', 'StandardSSD_ZRS', 'PremiumV2_LRS'.
+      type: Standard_LRS
     image:
       publisher: Canonical
       offer: 0001-com-ubuntu-server-focal-daily

--- a/config.cfg
+++ b/config.cfg
@@ -172,8 +172,8 @@ cloud_providers:
       type: Standard_LRS
     image:
       publisher: Canonical
-      offer: 0001-com-ubuntu-server-focal-daily
-      sku: 20_04-daily-lts
+      offer: 0001-com-ubuntu-minimal-focal-daily
+      sku: minimal-20_04-daily-lts
       version: latest
   digitalocean:
     size: s-1vcpu-1gb

--- a/roles/cloud-azure/files/deployment.json
+++ b/roles/cloud-azure/files/deployment.json
@@ -23,6 +23,9 @@
     "imageReferenceVersion": {
       "type": "string"
     },
+    "osDiskType": {
+      "type": "string"
+    },
     "SshPort": {
       "type": "int"
     },
@@ -197,7 +200,10 @@
             "version": "[parameters('imageReferenceVersion')]"
           },
           "osDisk": {
-            "createOption": "FromImage"
+            "createOption": "FromImage",
+            "managedDisk": {
+              "storageAccountType": "[parameters('osDiskType')]"
+            }
           }
         },
         "networkProfile": {

--- a/roles/cloud-azure/tasks/main.yml
+++ b/roles/cloud-azure/tasks/main.yml
@@ -37,6 +37,8 @@
         value: "{{ cloud_providers.azure.image.sku }}"
       imageReferenceVersion:
         value: "{{ cloud_providers.azure.image.version }}"
+      osDiskType:
+        value: "{{ cloud_providers.azure.osDisk.type }}"
       SshPort:
         value: "{{ ssh_port }}"
       UserData:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This makes the OS disk type configurable for Azure deployments.

Also, this change sets the default OS disk type to `Standard_LRS` rather than `StandardSSD_LRS` (which seems to be the default in Azure), since a cheaper disk does not appear to come with any significant perfomance penalty in this case.

## Description
<!--- Describe your changes in detail -->
- The type of disk to use for the VM OS is made configurable.
- The default disk type becomes a non-SSD one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We can use a cheaper disk without performance penalty.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
By deploying to Azure cloud.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
