### PR TITLE
Use cheapest EC2 instance as default

### DIFF
--- a/docs/cloud-amazon-ec2.md
+++ b/docs/cloud-amazon-ec2.md
@@ -6,13 +6,17 @@ Creating an Amazon AWS account requires giving Amazon a phone number that can re
 
 ### Select an EC2 plan
 
-The cheapest EC2 plan you can choose is the "Free Plan" a.k.a. the "AWS Free Tier." It is only available to new AWS customers, it has limits on usage, and it converts to standard pricing after 12 months (the "introductory period"). After you exceed the usage limits, after the 12 month period, or if you are an existing AWS customer, then you will pay standard pay-as-you-go service prices.
+The default EC2 plan (`t4g.nano` arm64) is the cheapest non "Free Plan" option. If you have a new AWS account or are eligible for the "AWS Free Tier" plan and would like to use that plan follow the instructions below.
+
+The "Free Plan" a.k.a. the ["AWS Free Tier"](https://aws.amazon.com/free/) is only available to new AWS customers, it has limits on usage, and it converts to standard pricing after 12 months (the "introductory period"). After you exceed the usage limits, after the 12 month period, or if you are an existing AWS customer, then you will pay standard pay-as-you-go service prices. To use your free tier credits change the following values in the ec2 section of your `config.cfg` file:
+* Set the `size` to `t2.micro`
+* Set the `arch` to `x86_64`
 
 *Note*: Your Algo instance will not stop working when you hit the bandwidth limit, you will just start accumulating service charges on your AWS account.
 
 As of the time of this writing (July 2018), the Free Tier limits include "750 hours of Amazon EC2 Linux t2.micro instance  usage" per month, 15 GB of bandwidth (outbound) per month, and 30 GB of cloud storage. Algo will not even use 1% of the storage limit, but you may have to monitor your bandwidth usage or keep an eye out for the email from Amazon when you are about to exceed the Free Tier limits.
 
-Addtional configurations are documented in the [EC2 section of the deploy from ansible guide](https://github.com/trailofbits/algo/blob/master/docs/deploy-from-ansible.md#amazon-ec2)
+Additional configurations are documented in the [EC2 section of the deploy from ansible guide](https://github.com/trailofbits/algo/blob/master/docs/deploy-from-ansible.md#amazon-ec2)
 
 ### Create an AWS permissions policy
 
@@ -81,11 +85,11 @@ Next you will be asked for the AWS Access Key (Access Key ID) and AWS Secret Key
 Enter your aws_access_key (http://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html)
 Note: Make sure to use an IAM user with an acceptable policy attached (see https://github.com/trailofbits/algo/blob/master/docs/deploy-from-ansible.md).
 [pasted values will not be displayed]
-[AKIA...]: 
+[AKIA...]:
 
 Enter your aws_secret_key (http://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html)
 [pasted values will not be displayed]
-[ABCD...]: 
+[ABCD...]:
 ```
 
 You will be prompted for the server name to enter. Feel free to leave this as the default ("algo") if you are not certain  how this will affect your setup. Here we chose to call it "algovpn".
@@ -116,7 +120,7 @@ What region should the server be located in?
     14. us-east-2
     15. us-west-1
     16. us-west-2
-  
+
 Enter the number of your desired region
 [13]
 :

--- a/docs/cloud-amazon-ec2.md
+++ b/docs/cloud-amazon-ec2.md
@@ -6,15 +6,17 @@ Creating an Amazon AWS account requires giving Amazon a phone number that can re
 
 ### Select an EC2 plan
 
-The default EC2 plan (`t4g.nano` arm64) is the cheapest non "Free Plan" option. If you have a new AWS account or are eligible for the "AWS Free Tier" plan and would like to use that plan follow the instructions below.
-
-The "Free Plan" a.k.a. the ["AWS Free Tier"](https://aws.amazon.com/free/) is only available to new AWS customers, it has limits on usage, and it converts to standard pricing after 12 months (the "introductory period"). After you exceed the usage limits, after the 12 month period, or if you are an existing AWS customer, then you will pay standard pay-as-you-go service prices. To use your free tier credits change the following values in the ec2 section of your `config.cfg` file:
-* Set the `size` to `t2.micro`
-* Set the `arch` to `x86_64`
+The cheapest EC2 plan you can choose is the "Free Plan" a.k.a. the ["AWS Free Tier"](https://aws.amazon.com/free/). It is only available to new AWS customers, it has limits on usage, and it converts to standard pricing after 12 months (the "introductory period"). After you exceed the usage limits, after the 12 month period, or if you are an existing AWS customer, then you will pay standard pay-as-you-go service prices.
 
 *Note*: Your Algo instance will not stop working when you hit the bandwidth limit, you will just start accumulating service charges on your AWS account.
 
 As of the time of this writing (July 2018), the Free Tier limits include "750 hours of Amazon EC2 Linux t2.micro instance  usage" per month, 15 GB of bandwidth (outbound) per month, and 30 GB of cloud storage. Algo will not even use 1% of the storage limit, but you may have to monitor your bandwidth usage or keep an eye out for the email from Amazon when you are about to exceed the Free Tier limits.
+
+If you are not eligible for the free tier plan or have passed the 12 months of the introductory period, you can switch to [AWS Graviton](https://aws.amazon.com/ec2/graviton/) instances that are generally cheaper. To use the graviton instances, make the following changes in the ec2 section of your `config.cfg` file:
+* Set the `size` to `t4g.nano`
+* Set the `arch` to `arm64`
+
+> Currently, among all the instance sizes available on AWS, the t4g.nano instance is the least expensive option that does not require any promotional offers. However, AWS is currently running a promotion that provides a free trial of the `t4g.small` instance until December 31, 2023, which is available to all customers. For more information about this promotion, please refer to the [documentation](https://aws.amazon.com/ec2/faqs/#t4g-instances).
 
 Additional configurations are documented in the [EC2 section of the deploy from ansible guide](https://github.com/trailofbits/algo/blob/master/docs/deploy-from-ansible.md#amazon-ec2)
 
@@ -22,7 +24,7 @@ Additional configurations are documented in the [EC2 section of the deploy from 
 
 In the AWS console, find the policies menu: click Services > IAM > Policies. Click Create Policy.
 
-Here, you have the policy editor. Switch to the JSON tab and copy-paste over the existing empty policy with [the minimum required AWS policy needed for Algo deployment](https://github.com/trailofbits/algo/blob/master/docs/deploy-from-ansible.md#minimum-required-iam-permissions-for-deployment). 
+Here, you have the policy editor. Switch to the JSON tab and copy-paste over the existing empty policy with [the minimum required AWS policy needed for Algo deployment](https://github.com/trailofbits/algo/blob/master/docs/deploy-from-ansible.md#minimum-required-iam-permissions-for-deployment).
 
 When prompted to name the policy, name it `AlgoVPN_Provisioning`.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add documentation for using the AWS graviton instances that are generally cheaper.
More info on the motivation and context below, I'm also open to suggestions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

For existing AWS customers or the accounts that have used their first year "free credits", the cheapest EC2 option is the graviton (arm64) EC2 class with the smallest size `t4g.nano`. I used this instance size with spot instances for a couple of months for as low as $2/month (everything included)

Also added a section about the AWS promotion on `t4g.small` instances.

## How Has This Been Tested?

Deployed an instance to my aws account.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change 

These changes do not modify any existing instances, but the default behavior for the new EC2 instances launched will be different as the default size and architecture have changed. This could be viewed as a breaking change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
