### PR TITLE
feat: add support for vultr api v2

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -215,7 +215,7 @@ cloud_providers:
     disk: 10
   vultr:
     os: Ubuntu 20.04 LTS x64
-    size: 1024 MB RAM,25 GB SSD,1.00 TB BW
+    size: vc2-1c-1gb
   linode:
     type: g6-nanode-1
     image: linode/ubuntu20.04

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible==6.1.0
+ansible==7.3.0
 jinja2~=3.0.3
 netaddr

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -4,35 +4,50 @@
 
 - block:
     - name: Creating a firewall group
-      vultr_firewall_group:
+      vultr.cloud.firewall_group:
+        api_key: "{{ vultr_api_key }}"
         name: "{{ algo_server_name }}"
 
     - name: Creating firewall rules
-      vultr_firewall_rule:
+      vultr.cloud.firewall_rule:
+        api_key: "{{ vultr_api_key }}"
         group: "{{ algo_server_name }}"
         protocol: "{{ item.protocol }}"
         port: "{{ item.port }}"
-        ip_version: "{{ item.ip }}"
-        cidr: "{{ item.cidr }}"
-      with_items:
-        - { protocol: tcp, port: "{{ ssh_port }}", ip: v4, cidr: 0.0.0.0/0 }
-        - { protocol: tcp, port: "{{ ssh_port }}", ip: v6, cidr: "::/0" }
-        - { protocol: udp, port: 500, ip: v4, cidr: 0.0.0.0/0 }
-        - { protocol: udp, port: 500, ip: v6, cidr: "::/0" }
-        - { protocol: udp, port: 4500, ip: v4, cidr: 0.0.0.0/0 }
-        - { protocol: udp, port: 4500, ip: v6, cidr: "::/0" }
-        - { protocol: udp, port: "{{ wireguard_port }}", ip: v4, cidr: 0.0.0.0/0 }
-        - { protocol: udp, port: "{{ wireguard_port }}", ip: v6, cidr: "::/0" }
+        ip_type: "{{ item.ip }}"
+        subnet: "{{ item.subnet }}"
+        subnet_size: "0"
+      loop:
+        - { protocol: tcp, port: "{{ ssh_port }}", ip: v4, subnet: 0.0.0.0/0 }
+        - { protocol: tcp, port: "{{ ssh_port }}", ip: v6, subnet: "::/0" }
+        - { protocol: udp, port: 500, ip: v4, subnet: 0.0.0.0/0 }
+        - { protocol: udp, port: 500, ip: v6, subnet: "::/0" }
+        - { protocol: udp, port: 4500, ip: v4, subnet: 0.0.0.0/0 }
+        - { protocol: udp, port: 4500, ip: v6, subnet: "::/0" }
+        - {
+            protocol: udp,
+            port: "{{ wireguard_port }}",
+            ip: v4,
+            subnet: 0.0.0.0/0
+          }
+        - {
+            protocol: udp,
+            port: "{{ wireguard_port }}",
+            ip: v6,
+            subnet: "::/0"
+          }
 
     - name: Upload the startup script
-      vultr_startup_script:
+      vultr.cloud.startup_script:
+        api_key: "{{ vultr_api_key }}"
         name: algo-startup
         script: |
           {{ lookup('template', 'files/cloud-init/base.yml') }}
 
     - name: Creating a server
-      vultr_server:
-        name: "{{ algo_server_name }}"
+      vultr.cloud.instance:
+        api_key: "{{ vultr_api_key }}"
+        label: "{{ algo_server_name }}"
         startup_script: algo-startup
         hostname: "{{ algo_server_name }}"
         os: "{{ cloud_providers.vultr.os }}"
@@ -40,14 +55,14 @@
         region: "{{ algo_vultr_region }}"
         firewall_group: "{{ algo_server_name }}"
         state: started
-        tag: Environment:Algo
-        ipv6_enabled: true
-        auto_backup_enabled: false
-        notify_activate: false
+        tags: ["Environment:Algo"]
+        enable_ipv6: true
+        backups: false
+        activation_email: false
       register: vultr_server
 
     - set_fact:
-        cloud_instance_ip: "{{ vultr_server.vultr_server.v4_main_ip }}"
+        cloud_instance_ip: "{{ vultr_server.vultr_instance.main_ip }}"
         ansible_ssh_user: algo
         ansible_ssh_port: "{{ ssh_port }}"
         cloudinit: true

--- a/roles/cloud-vultr/tasks/prompts.yml
+++ b/roles/cloud-vultr/tasks/prompts.yml
@@ -12,9 +12,13 @@
   set_fact:
     algo_vultr_config: "{{ vultr_config | default(_vultr_config.user_input) | default(lookup('env','VULTR_API_CONFIG'), true) }}"
 
+- name: Set the Vultr API Key as a fact
+  set_fact:
+    vultr_api_key: "{{ lookup('ansible.builtin.ini', 'key', section='default', file=algo_vultr_config) }}"
+
 - name: Get regions
   uri:
-    url: https://api.vultr.com/v1/regions/list
+    url: https://api.vultr.com/v2/regions
     method: GET
     status_code: 200
   register: _vultr_regions
@@ -22,7 +26,7 @@
 - name: Format regions
   set_fact:
     regions: >-
-      [ {% for k, v in _vultr_regions.json.items() %}
+      [ {% for v in _vultr_regions.json['regions'] %}
       {{ v }}{% if not loop.last %},{% endif %}
       {% endfor %} ]
 
@@ -32,17 +36,14 @@
 
 - name: Set default region
   set_fact:
-    default_region: >-
-      {% for r in vultr_regions %}
-      {%- if r['DCID'] == "1" %}{{ loop.index }}{% endif %}
-      {%- endfor %}
+    default_region: 1
 
 - pause:
     prompt: |
       What region should the server be located in?
       (https://www.vultr.com/locations/):
         {% for r in vultr_regions %}
-        {{ loop.index }}.   {{ r['name'] }}
+        {{ loop.index }}.   {{ r['city'] }}
         {% endfor %}
 
       Enter the number of your desired region
@@ -54,5 +55,5 @@
   set_fact:
     algo_vultr_region: >-
       {% if region is defined %}{{ region }}
-      {%- elif _algo_region.user_input %}{{ vultr_regions[_algo_region.user_input | int -1 ]['name'] }}
-      {%- else %}{{ vultr_regions[default_region | int - 1]['name'] }}{% endif %}
+      {%- elif _algo_region.user_input %}{{ vultr_regions[_algo_region.user_input | int -1 ]['id'] }}
+      {%- else %}{{ vultr_regions[default_region | int - 1]['id'] }}{% endif %}


### PR DESCRIPTION
## Description

Added support for Vultr Api v2 as new accounts on Vultr won't be able to use v1 api. Old accounts will be unable to use v1 api after June 2023.

## Motivation and Context

This change makes sure AlgoVPN can be use by new and old users of Vultr

Fixes #14580 

## How Has This Been Tested?
Tested by Creating a VPS on Vultr with Ubuntu on my macbook m1

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ]  I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ]  I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
