### PR TITLE
Fix PKCS#12 mobileconfig installation errors when using openssl version > 3 (trailofbits#14558)

### DIFF
--- a/roles/strongswan/tasks/openssl.yml
+++ b/roles/strongswan/tasks/openssl.yml
@@ -155,10 +155,19 @@
         format: OpenSSH
       with_items: "{{ users }}"
 
+    - name: Gather the package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Get OpenSSL version
+      set_fact:
+        openssl_version: "{{ ansible_facts.packages['openssl'][0]['version'] }}"
+
     - name: Build the client's p12
       shell: >
         umask 077;
         {{ openssl_bin }} pkcs12
+        {{ (openssl_version is version('3', '>=')) | ternary('-legacy', '') }}
         -in certs/{{ item }}.crt
         -inkey private/{{ item }}.key
         -export
@@ -175,6 +184,7 @@
       shell: >
         umask 077;
         {{ openssl_bin }} pkcs12
+        {{ (openssl_version is version('3', '>=')) | ternary('-legacy', '') }}
         -in certs/{{ item }}.crt
         -inkey private/{{ item }}.key
         -export

--- a/roles/strongswan/tasks/openssl.yml
+++ b/roles/strongswan/tasks/openssl.yml
@@ -160,7 +160,10 @@
         manager: auto
 
     - name: Get OpenSSL version
-      shell: openssl version | cut -f 2 -d ' '
+      shell: |
+        set -o pipefail
+        {{ openssl_bin }} version |
+        cut -f 2 -d ' '
       register: ssl_version
       run_once: true
 

--- a/roles/strongswan/tasks/openssl.yml
+++ b/roles/strongswan/tasks/openssl.yml
@@ -160,8 +160,13 @@
         manager: auto
 
     - name: Get OpenSSL version
+      shell: openssl version | cut -f 2 -d ' '
+      register: ssl_version
+      run_once: true
+
+    - name: Set OpenSSL version fact
       set_fact:
-        openssl_version: "{{ ansible_facts.packages['openssl'][0]['version'] }}"
+        openssl_version: "{{ ssl_version.stdout }}"
 
     - name: Build the client's p12
       shell: >

--- a/users.yml
+++ b/users.yml
@@ -26,7 +26,7 @@
             server_list: >-
               [{% for i in _configs_list.files %}
                 {% set config  = lookup('file', i.path)|from_yaml %}
-                '{{ config.server }}'
+                '{{ config.IP_subject_alt_name }}'
                 {{ ',' if not loop.last else '' }}
               {% endfor %}]
 


### PR DESCRIPTION
Check the openssl version and add -legacy flag for newer versions when working with pkcs#12 files.  Original fix by https://github.com/omgagg/algo/tree/custom was updated to use a shell script to get the version. This fixes trailofbits#14558

## Description
In `roles/strongswan/tasks/openssl.yml`, get the version of openssl, set as a fact. In subsequent openssl tasks related to the pkcs#12 certs, if the version > 3, then add the -legacy flag, as described in [https://www.openssl.org/docs/man3.0/man1/openssl-pkcs12.html](the OpenSSL documentation).

## Motivation and Context
Per trailofbits#14558, with newer versions of OpenSSL, the mobileconfig files created could not be installed on MacOS or iOS devices (untested on Android or Windows), with the process faling with an authentication error.  By addeing the -legacy flag to the OpenSSL commands, the certs can be installed.

## How Has This Been Tested?
**Changes have only been manually tested when running algo in a docker instance, and only when building to EC2 targets.**
Due to a lack of resources, I can't easily test in other situations.
* build the docker image with `docker build . -name custom/algo:latest`
* remove any existing algo instance/stack in the ec2 region
* use the unmodified example config.cfg file
* deploy per the documentation in `docs/deploy-from-docker.md`
* add the `ipsec/apple/laptop.mobileconfig` file to MacOS (double-click)
* install the profile via system preferences
* verify ability to connect to the vpn server
* send the `ipsec/apple/iphone.mobileconfig` file to iPhone
* install the profile via system preferences
* verify ability to connect to the vpn server
* send the `ipsec/apple/desktop.mobileconfig` file to iPad
* install the profile via system preferences
* verify ability to connect to the vpn server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed. ** I honestly don't know how to run the existing tests **
