### PR TITLE
make sure cron is installed on ubuntu. #14568

### DIFF
--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -98,6 +98,7 @@
       - cgroup-tools
       - openssl
       - gnupg2
+      - cron
     sysctl:
       - item: net.ipv4.ip_forward
         value: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
added cron to Set OS specific facts for Ubuntu
## Description
<!--- Describe your changes in detail -->
I was seeing the same issue as #14568. deploying to Azure with adblocking will fail unless cron is added to OS Specific Facts.   
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/trailofbits/algo/issues/14568

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
tested the script and could saw failed deployment, as described in https://github.com/trailofbits/algo/issues/14568

Added cron to the required packages, and retested. Deployed successfully.  
  
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
