### PR TITLE
cloud-pre.yml: use 4096 bits for ssh rsa key

### DIFF
--- a/playbooks/cloud-pre.yml
+++ b/playbooks/cloud-pre.yml
@@ -32,7 +32,7 @@
     - name: Generate the SSH private key
       openssl_privatekey:
         path: "{{ SSH_keys.private }}"
-        size: 2048
+        size: 4096
         mode: "0600"
         type: RSA
 


### PR DESCRIPTION
The ssh-key we generated used 2048 bits while even openssh's ssh-keygen defaults to 3072 nowadays [0].

While RSA-2048 is probably ok (?) and what NIST recommends for keys until around 2030, its probably better to switch to more bits.

This is also just a temporary solution as we should also switch to ed25519.

Thanks to Dan M (@dmur1 or dan@hexarcana.ch) for pointing this out.

[0] https://github.com/openssh/openssh-portable/blob/19d3ee2f3adf7d9a606ff015c1e153744702c4c9/ssh-keygen.c#L83

