### PR TITLE
Updated Python dependency from 3.8 to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The easiest way to get an Algo server running is to run it on your local system 
         git clone https://github.com/trailofbits/algo.git
         ```
 
-3. **Install Algo's core dependencies.** Algo requires that **Python 3.8 or later** and at least one supporting package are installed on your system.
+3. **Install Algo's core dependencies.** Algo requires that **Python 3.10 or later** and at least one supporting package are installed on your system.
 
     - **macOS:** Catalina (10.15) and higher includes Python 3 as part of the optional Command Line Developer Tools package. From Terminal run:
 
@@ -55,7 +55,8 @@ The easiest way to get an Algo server running is to run it on your local system 
     - **Linux:** Recent releases of Ubuntu, Debian, and Fedora come with Python 3 already installed. Make sure your system is up-to-date and install the supporting package(s):
         * Ubuntu and Debian:
             ```bash
-            sudo apt install -y --no-install-recommends python3-virtualenv
+            sudo add-apt-repository ppa:deadsnakes/ppa
+            sudo apt install Python3.10
             ```
             On a Raspberry Pi running Ubuntu also install `libffi-dev` and `libssl-dev`.
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,10 @@ The easiest way to get an Algo server running is to run it on your local system 
 
         For macOS versions prior to Catalina, see [Deploy from macOS](docs/deploy-from-macos.md) for information on installing Python 3 .
 
-    - **Linux:** Recent releases of Ubuntu, Debian, and Fedora come with Python 3 already installed. Make sure your system is up-to-date and install the supporting package(s):
+    - **Linux:** Recent releases of Ubuntu, Debian, and Fedora come with Python 3 already installed. If your Python version is not 3.10, then you will need to use pyenv to install Python 3.10. Make sure your system is up-to-date and install the supporting package(s):
         * Ubuntu and Debian:
             ```bash
-            sudo add-apt-repository ppa:deadsnakes/ppa
-            sudo apt install Python3.10
+            sudo apt install -y --no-install-recommends python3-virtualenv
             ```
             On a Raspberry Pi running Ubuntu also install `libffi-dev` and `libssl-dev`.
 


### PR DESCRIPTION
Updated Python dependency from 3.8 to 3.10 to fix compatibility issues with Ansible.

Installing the dependencies for Algo with Python 3.8 gives this error:
`ERROR: No matching distribution found for ansible==9.1.0`

<!--- Provide a general summary of your changes in the Title above -->
Updated the docs to refer to python 3.10 as the required python version and to follow the installation steps for installing python 3.10 on Ubuntu.

## Description
- In README.md changed line 43 to list python 3.10
- In README.md changed line 58 to install python 3.10 from deadsnakes/ppa

## Motivation and Context
This is required to fix a dependency error when installing the Algo requirements from requirements.txt on python 3.8.

## How Has This Been Tested?
Installing the Algo requirements on python 3.8 gives the following error:
`ERROR: No matching distribution found for ansible==9.1.0`

Updating the python version to 3.10 fixes this error and enables a working installation of Algo. 

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (untested but does not apply since it a documentation change)
