### PR TITLE
Wsl2 support for generated configs

### DIFF
--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -8,6 +8,6 @@ DNS = {{ wireguard_dns_servers }}
 [Peer]
 PublicKey = {{ lookup('file', wireguard_pki_path + '/public/' + IP_subject_alt_name) }}
 PresharedKey = {{ lookup('file', wireguard_pki_path + '/preshared/' + item.1) }}
-AllowedIPs = 0.0.0.0/0,::/0
+AllowedIPs = ::/128, 0.0.0.0/1, 128.0.0.0/1
 Endpoint = {{ IP_subject_alt_name }}:{{ wireguard_port }}
 {{ 'PersistentKeepalive = ' + wireguard_PersistentKeepalive|string if wireguard_PersistentKeepalive > 0 else '' }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

By default generated configs does not allow WSL2 to access network with wireguard enabled. So here is the quick fix for it: https://github.com/microsoft/WSL/issues/7895#issuecomment-1010606617

I guess DNS server must be changed too to 1.1.1.1, does not work without it for me. 

