### PR TITLE
Use region code instead of name to deploy in non-default Vultr region.

### DIFF
--- a/roles/cloud-vultr/tasks/prompts.yml
+++ b/roles/cloud-vultr/tasks/prompts.yml
@@ -54,5 +54,5 @@
   set_fact:
     algo_vultr_region: >-
       {% if region is defined %}{{ region }}
-      {%- elif _algo_region.user_input %}{{ vultr_regions[_algo_region.user_input | int -1 ]['name'] | lower }}
+      {%- elif _algo_region.user_input %}{{ vultr_regions[_algo_region.user_input | int -1 ]['regioncode'] | lower }}
       {%- else %}{{ vultr_regions[default_region | int - 1]['regioncode'] | lower }}{% endif %}


### PR DESCRIPTION
## Description
Use region code instead of name to deploy in non-default Vultr region.

## Motivation and Context
Fixes #14712 

## How Has This Been Tested?
Successfully deployed to Vultr's London region.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
