### PR TITLE
Use legacy OpenSSL Format for Apple Devices

### DIFF
--- a/roles/strongswan/tasks/openssl.yml
+++ b/roles/strongswan/tasks/openssl.yml
@@ -155,10 +155,25 @@
         format: OpenSSH
       with_items: "{{ users }}"
 
+    - name: Get OpenSSL version
+    shell: |
+          set -o pipefail
+          {{ openssl_bin }} version |
+          cut -f 2 -d ' '
+    args:
+      executable: bash
+    register: ssl_version
+    run_once: true
+
+    - name: Set OpenSSL version fact
+      set_fact:
+        openssl_version: "{{ ssl_version.stdout }}"
+
     - name: Build the client's p12
       shell: >
         umask 077;
         {{ openssl_bin }} pkcs12
+        {{ (openssl_version is version('3', '>=')) | ternary('-legacy', '') }}
         -in certs/{{ item }}.crt
         -inkey private/{{ item }}.key
         -export
@@ -175,6 +190,7 @@
       shell: >
         umask 077;
         {{ openssl_bin }} pkcs12
+        {{ (openssl_version is version('3', '>=')) | ternary('-legacy', '') }}
         -in certs/{{ item }}.crt
         -inkey private/{{ item }}.key
         -export

--- a/roles/strongswan/tasks/openssl.yml
+++ b/roles/strongswan/tasks/openssl.yml
@@ -156,14 +156,14 @@
       with_items: "{{ users }}"
 
     - name: Get OpenSSL version
-    shell: |
-          set -o pipefail
-          {{ openssl_bin }} version |
-          cut -f 2 -d ' '
-    args:
-      executable: bash
-    register: ssl_version
-    run_once: true
+      shell: |
+        set -o pipefail
+        {{ openssl_bin }} version |
+        cut -f 2 -d ' '
+      args:
+        executable: bash
+      register: ssl_version
+      run_once: true
 
     - name: Set OpenSSL version fact
       set_fact:

--- a/users.yml
+++ b/users.yml
@@ -27,6 +27,7 @@
               [{% for i in _configs_list.files %}
                 {% set config  = lookup('file', i.path)|from_yaml %}
                 '{{ config.server }}'
+                '{{ config.IP_subject_alt_name }}'
                 {{ ',' if not loop.last else '' }}
               {% endfor %}]
 


### PR DESCRIPTION
## Description
Uses legacy key format to generate `.p12` and `.mobileprovision` files. 

## Motivation and Context
`openssl@3` uses a modern private key format unsupported on Apple devices because Apple has not updated its libraries. Importing generated `.p12` files into the modern macOS and iOS keychain leads to the wrong password error. If you try to export a private key from `.p12` and import it into Keychain separately, it will show the wrong format error. 

Closes #14558

Based on https://github.com/trailofbits/algo/pull/14622 with applied comments.

## How Has This Been Tested?
1. Amazon Lighstail
2. Cloned repo and installed via `METHOD=local ENDPOINT=<ip_adderess> USERS=hello,world ./install.sh`. I had to modify the install script to point to the fork on the `getAlgo` [step](https://github.com/trailofbits/algo/blob/6ce6f5c81e8e5a27ae6f4357512ee2e3362605aa/install.sh#L30)
3. Downloaded `.mobileprovision` files
4. Installed on macOS 14.4.1 (23E224)
5. Connected to the server.
6. Installed on iOS 17.4.
5. Connected to the server.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
