### PR TITLE
Remove disclaimer about GCloud Shell not supporting a python version. It currently supports 3.10.

### DIFF
--- a/docs/deploy-from-cloudshell.md
+++ b/docs/deploy-from-cloudshell.md
@@ -1,5 +1,4 @@
 # Deploy from Google Cloud Shell
-**IMPORTANT NOTE: As of 2021-12-14 Algo requires Python 3.8, but Google Cloud Shell only provides Python 3.7.3. The instructions below will not work until Google updates Cloud Shell to have at least Python 3.8.**
 
 If you want to try Algo but don't wish to install the software on your own system you can use the **free** [Google Cloud Shell](https://cloud.google.com/shell/) to deploy a VPN to any supported cloud provider. Note that you cannot choose `Install to existing Ubuntu server` to turn Google Cloud Shell into your VPN server.
 


### PR DESCRIPTION
## Description
Removed the previous disclaimer that prevented the use of the instructions for Google Cloud Shell deployment.

## Motivation and Context
https://github.com/trailofbits/algo/issues/14702

## How Has This Been Tested?
I went into GCloud Shell to run the command: `ls /usr/bin/python*`
to list the python versions.

The output was: `/usr/bin/python  /usr/bin/python2  /usr/bin/python2.7  /usr/bin/python3  /usr/bin/python3.10  /usr/bin/python3.10-config  /usr/bin/python3-config`

This shows it support python 2.7, 3, and 3.10.

## Types of changes
✅ Bug fix (non-breaking change which fixes an issue)
❌ New feature (non-breaking change which adds functionality)
❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
✅ I have read the **CONTRIBUTING** document.
✅ My code follows the code style of this project.
✅ My change requires a change to the documentation.
✅ I have updated the documentation accordingly.
✅ I have added tests to cover my changes.
✅ All new and existing tests passed.
