### PR TITLE
Update config.cfg: t2.micro to t3.micro

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -186,7 +186,7 @@ cloud_providers:
     # Set use_existing_eip to "true" if you want to use a pre-allocated Elastic IP
     # Additional prompt will be raised to determine which IP to use
     use_existing_eip: false
-    size: t2.micro
+    size: t3.micro
     image:
       name: "ubuntu-jammy-22.04"
       arch: x86_64


### PR DESCRIPTION
Because

1) t2.micro is not exists on every region, see "Some regions like the Middle East (Bahrain) region and the EU (Stockholm) region do not offer t2.micro instances" https://aws.amazon.com/free/free-tier-faqs/

2) t3.micro is faster https://www.cloudzero.com/advisor/t2-vs-t3/

Works for me
![image](https://github.com/trailofbits/algo/assets/3514015/dccd46d1-c7b2-4def-b79d-bc797404d55e)
