### PR TITLE
fix: fix server selection in update-user

### DIFF
--- a/users.yml
+++ b/users.yml
@@ -25,19 +25,17 @@
           set_fact:
             server_list: >-
               [{% for i in _configs_list.files %}
-                {% set config  = lookup('file', i.path)|from_yaml %}
-                '{{ config.server }}'
-                '{{ config.IP_subject_alt_name }}'
-                {{ ',' if not loop.last else '' }}
+                {% set config = lookup('file', i.path) | from_yaml %}
+                {{ {'server': config.server, 'IP_subject_alt_name': config.IP_subject_alt_name} }}
               {% endfor %}]
 
         - name: Server address prompt
           pause:
             prompt: |
-              Select the server to update user list below:
+              Select the server to update user list below: 
                 {% for r in server_list %}
-                {{ loop.index }}. {{ r }}
-                {% endfor %}
+                  {{ loop.index }}. {{ r.server }} ({{ r.IP_subject_alt_name }})
+              {% endfor %}
           register: _server
       when: server is undefined
 
@@ -46,7 +44,7 @@
           set_fact:
             algo_server: >-
               {% if server is defined %}{{ server }}
-              {%- elif _server.user_input %}{{ server_list[_server.user_input | int -1 ] }}
+              {%- elif _server.user_input %}{{ server_list[_server.user_input | int -1 ].server }}
               {%- else %}omit{% endif %}
 
         - name: Import host specific variables


### PR DESCRIPTION
Fixes server selection in update-user while preserving a nice display of server along with its alt_name in the list

## Description

This commit fixes a bug preventing correct selection of server when trying to update users. It improves the prompt's clarity by providing both server name and IP_subject_alt_name. It also ensures server selection from the list uses actual server names instead of list descriptions strings that caused the initial bug.

The previous code was using directly the strings generated from the "Build list of installed servers" as server identifier. 
A previous commit (#14718) introduced some display-related text in the string provoking errors at the step "Server address prompt" since the provided strings no longer represent server identity.

2 possible choices:
1. Keep the initial system of passing strings from "Build list of installed servers" to "Server address prompt"
  1. Benefits: It works, it was the initial behavior before #14718 
  2. Drawback 1: Cannot display some helpful data in the prompt like the IP_subject_alt_name of the server
  3. Drawback 2: Prone to the same error in the future if somebody adds new display-related data in the strings
2. Make "Build list of installed servers" return an array of object and "Server address prompt" pick only relevant properties for display, and relevant properties for server selection
  1. Benefit 1: Future-proof, the code is clear in the intent and the risk of re-introducing a breaking change is low
  2. Benefit 2: Keeps a nice display of the servers for selection, using `IP (name)` 
  3. Drawback: The code is a bit more complex since it now handles objects instead of plain strings, but this could count as a benefit too because now the manipulated data is explicitly named with object keys

This PR went with the option 2


## Motivation and Context
Solves issue #14726 

## How Has This Been Tested?
Manually tested using the same reproduction steps provided in issue #14726 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
