### PR TITLE
fix: Change Hetzner default server type to cx22

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -206,7 +206,7 @@ cloud_providers:
     image: Ubuntu 22.04 Jammy Jellyfish
     arch: x86_64
   hetzner:
-    server_type: cx11
+    server_type: cx22
     image: ubuntu-22.04
   openstack:
     flavor_ram: ">=512"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change the default Hetzner server type from cx11 to cx22 (the new smallest server instance at Hetzner).

## Motivation and Context

The Hetzner cx11 server type is deprecated and will be removed as of 2024-09-06.

```
TASK [cloud-hetzner : Create a server...] *************************************************************************************************************************************************
[WARNING]: Attention: The server plan cx11 is deprecated and will no longer be available for order as of 2024-09-06. Existing servers of that plan will continue to work as before and no
action is required on your part. It is possible to migrate this server to another server plan by setting the server_type parameter on the hetzner.hcloud.server module.
```

## How Has This Been Tested?

Tested with new server type cx22.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
