### PR TITLE
Switch to globally available Hetzner instance type

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -206,7 +206,7 @@ cloud_providers:
     image: Ubuntu 22.04 Jammy Jellyfish
     arch: x86_64
   hetzner:
-    server_type: cx22
+    server_type: cpx21
     image: ubuntu-22.04
   openstack:
     flavor_ram: ">=512"

--- a/config.cfg
+++ b/config.cfg
@@ -206,7 +206,7 @@ cloud_providers:
     image: Ubuntu 22.04 Jammy Jellyfish
     arch: x86_64
   hetzner:
-    server_type: cpx21
+    server_type: cpx11 
     image: ubuntu-22.04
   openstack:
     flavor_ram: ">=512"


### PR DESCRIPTION
The old cx* Intel instance types are only available in EU data centers. The cpx* AMD types are available in the US and Asia as well.

## Description

## Motivation and Context
Fixes #14562 for the moment.

## How Has This Been Tested?
I replaced the default with cpx11 and verified that that the cpx type worked in Hetzner's US data center.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
