### PR TITLE
Add support for Vultr API v2

### DIFF
--- a/roles/cloud-vultr/tasks/prompts.yml
+++ b/roles/cloud-vultr/tasks/prompts.yml
@@ -12,17 +12,23 @@
   set_fact:
     algo_vultr_config: "{{ vultr_config | default(_vultr_config.user_input) | default(lookup('env','VULTR_API_CONFIG'), true) }}"
 
+- name: Set the Vultr API Key as a fact
+  set_fact:
+    vultr_api_key: "{{ lookup('ansible.builtin.ini', 'key', section='default', file=algo_vultr_config) }}"
+
 - name: Get regions
   uri:
-    url: https://api.vultr.com/v1/regions/list
+    url: https://api.vultr.com/v2/regions
     method: GET
     status_code: 200
+    headers:
+      Authorization: "Bearer {{ vultr_api_key }}"
   register: _vultr_regions
 
 - name: Format regions
   set_fact:
     regions: >-
-      [ {% for k, v in _vultr_regions.json.items() %}
+      [ {% for v in _vultr_regions.json['regions'] %}
       {{ v }}{% if not loop.last %},{% endif %}
       {% endfor %} ]
 
@@ -32,17 +38,14 @@
 
 - name: Set default region
   set_fact:
-    default_region: >-
-      {% for r in vultr_regions %}
-      {%- if r['DCID'] == "1" %}{{ loop.index }}{% endif %}
-      {%- endfor %}
+    default_region: 1
 
 - pause:
     prompt: |
       What region should the server be located in?
       (https://www.vultr.com/locations/):
         {% for r in vultr_regions %}
-        {{ loop.index }}.   {{ r['name'] }} ({{ r['regioncode'] | lower }})
+        {{ loop.index }}.   {{ r['city'] }} ({{ r['id'] }})
         {% endfor %}
 
       Enter the number of your desired region
@@ -54,5 +57,5 @@
   set_fact:
     algo_vultr_region: >-
       {% if region is defined %}{{ region }}
-      {%- elif _algo_region.user_input %}{{ vultr_regions[_algo_region.user_input | int -1 ]['regioncode'] | lower }}
-      {%- else %}{{ vultr_regions[default_region | int - 1]['regioncode'] | lower }}{% endif %}
+      {%- elif _algo_region.user_input %}{{ vultr_regions[_algo_region.user_input | int -1 ]['id'] }}
+      {%- else %}{{ vultr_regions[default_region | int - 1]['id'] }}{% endif %}


### PR DESCRIPTION
## Description
This PR updates Algo to use Vultr API v2, as v1 is deprecated and no longer available for new accounts.

## Motivation and Context
Fixes #14580 - Vultr API v1 has been deprecated. New accounts cannot use v1, and existing accounts were migrated away from v1 in June 2023.

## Changes
- Updated API endpoints from v1 to v2
- Changed authentication from API key to Bearer token
- Updated response parsing to match v2 JSON structure
- Fixed server creation parameters for v2 API

## Credit
Original PR #14587 by @dhruvkelawala provided the initial implementation.

Closes #14587