### PR TITLE
Update Azure Ansible collection requirements to v3.7.0

### DIFF
--- a/roles/cloud-azure/tasks/venv.yml
+++ b/roles/cloud-azure/tasks/venv.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install requirements
   pip:
-    requirements: https://raw.githubusercontent.com/ansible-collections/azure/v2.2.0/requirements-azure.txt
+    requirements: https://raw.githubusercontent.com/ansible-collections/azure/v3.7.0/requirements-azure.txt
     state: latest
     virtualenv_python: python3


### PR DESCRIPTION
## Description
This PR updates the Azure Ansible collection requirements from v2.2.0 to the latest v3.7.0 to fix Python 3.11+ compatibility issues.

## Motivation and Context
Fixes #14680 - Users deploying on Azure with Python 3.11+ encounter ImportError with `BlobServiceClient` and other Azure-related Python packages.

## Changes
- Updated `roles/cloud-azure/tasks/venv.yml` to use v3.7.0 requirements

## Testing
The latest Azure collection (v3.7.0) includes proper support for Python 3.11+ and resolves the import errors reported in #14680.

## Credit
Original issue identified by @rbarbazz in PR #14680.

Closes #14680