### PR TITLE
fix: Add IPv6 support for WireGuard endpoint addresses

### DIFF
--- a/roles/wireguard/templates/client.conf.j2
+++ b/roles/wireguard/templates/client.conf.j2
@@ -9,5 +9,5 @@ DNS = {{ wireguard_dns_servers }}
 PublicKey = {{ lookup('file', wireguard_pki_path + '/public/' + IP_subject_alt_name) }}
 PresharedKey = {{ lookup('file', wireguard_pki_path + '/preshared/' + item.1) }}
 AllowedIPs = 0.0.0.0/0,::/0
-Endpoint = {{ IP_subject_alt_name }}:{{ wireguard_port }}
+Endpoint = {% if IP_subject_alt_name|ansible.utils.ipv6 %}[{{ IP_subject_alt_name }}]:{{ wireguard_port }}{% else %}{{ IP_subject_alt_name }}:{{ wireguard_port }}{% endif %}
 {{ 'PersistentKeepalive = ' + wireguard_PersistentKeepalive|string if wireguard_PersistentKeepalive > 0 else '' }}


### PR DESCRIPTION
## Summary

Fixes issue #14750 where IPv6 addresses in WireGuard configuration files were not properly formatted with square brackets when used with port numbers.

## Changes

- Updated the `client.conf.j2` template to detect IPv6 addresses using the `ansible.utils.ipv6` filter
- IPv6 addresses are now wrapped in square brackets as required by WireGuard configuration format
- IPv4 addresses and hostnames remain unchanged

## Test plan

- [x] Tested template logic with IPv4, IPv6, and hostname endpoints
- [x] Verified correct output formatting:
  - IPv4: `192.168.1.1:51820`
  - IPv6: `[2600:3c01::f03c:91ff:fedf:3b2a]:51820`
  - Hostname: `vpn.example.com:51820`
- [x] Syntax validation passes

## Before/After

**Before:**
```
Endpoint = 2600:3c01::f03c:91ff:fedf:3b2a:51820
```

**After:**
```
Endpoint = [2600:3c01::f03c:91ff:fedf:3b2a]:51820
```

🤖 Generated with [Claude Code](https://claude.ai/code)