### PR TITLE
Fix Ubuntu 22.04 compatibility issues

### DIFF
--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -161,5 +161,31 @@
   include_tasks: aip/main.yml
   when: alternative_ingress_ip
 
+- name: Ubuntu 22.04+ | Use iptables-legacy for compatibility
+  block:
+    - name: Install iptables packages
+      apt:
+        name:
+          - iptables
+          - iptables-persistent
+        state: present
+        update_cache: true
+
+    - name: Configure iptables-legacy as default
+      alternatives:
+        name: "{{ item }}"
+        path: "/usr/sbin/{{ item }}-legacy"
+      with_items:
+        - iptables
+        - ip6tables
+        - iptables-save
+        - iptables-restore
+        - ip6tables-save
+        - ip6tables-restore
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_version is version('22.04', '>=')
+  tags: iptables
+
 - include_tasks: iptables.yml
   tags: iptables

--- a/roles/strongswan/tasks/ubuntu.yml
+++ b/roles/strongswan/tasks/ubuntu.yml
@@ -2,6 +2,13 @@
 - name: Set OS specific facts
   set_fact:
     strongswan_additional_plugins: []
+
+- name: Ubuntu | Ensure af_key kernel module is loaded
+  modprobe:
+    name: af_key
+    state: present
+    persistent: present
+
 - name: Ubuntu | Install strongSwan (individual)
   apt:
     name: strongswan


### PR DESCRIPTION
## Summary
- Ensures af_key kernel module is loaded for StrongSwan on minimal Ubuntu installs
- Forces iptables-legacy mode on Ubuntu 22.04+ to prevent firewall rule reordering
- Restores full VPN functionality for both WireGuard and IPsec

## Problem
Ubuntu 22.04 deployments were failing with two critical issues:

1. **StrongSwan fails on minimal installs**: The `af_key` kernel module isn't loaded by default, causing systemd namespace errors when StrongSwan tries to access `/proc/net/pfkey`

2. **VPN traffic blocked by firewall**: Ubuntu 22.04 uses iptables-nft backend which reorders rules incorrectly, placing TCP/UDP DROP rules before VPN ACCEPT rules

## Solution
This PR implements a conservative fix:

1. **Load af_key module**: Added `modprobe` task in the strongSwan role to ensure the module is loaded persistently
2. **Force iptables-legacy**: Use `update-alternatives` to switch to iptables-legacy on Ubuntu 22.04+, ensuring correct rule ordering

## Test Plan
- [x] All Python unit tests pass (`uv run pytest tests/unit/ -v`)
- [x] Ansible syntax check passes for main.yml and users.yml
- [x] No new ansible-lint errors introduced
- [x] YAML syntax validated
- [ ] Manual testing on Ubuntu 22.04 minimal and standard installations
- [ ] Verify StrongSwan starts without errors
- [ ] Confirm WireGuard clients can connect and access internet
- [ ] Confirm IPsec clients can connect and access internet

Closes #14820

🤖 Generated with [Claude Code](https://claude.ai/code)