### PR TITLE
Fix VPN traffic routing issue with iptables NAT rules

### DIFF
--- a/roles/common/templates/rules.v4.j2
+++ b/roles/common/templates/rules.v4.j2
@@ -36,7 +36,14 @@ COMMIT
 -A PREROUTING --in-interface {{ ansible_default_ipv4['interface'] }} -p udp --dport {{ wireguard_port_avoid }} -j REDIRECT --to-port {{ wireguard_port_actual }}
 {% endif %}
 # Allow traffic from the VPN network to the outside world, and replies
--A POSTROUTING -s {{ subnets | join(',') }} -m policy --pol none --dir out {{ '-j SNAT --to ' + snat_aipv4 if snat_aipv4 else '-j MASQUERADE' }}
+{% if ipsec_enabled %}
+# For IPsec traffic - NAT the decrypted packets from the VPN subnet
+-A POSTROUTING -s {{ strongswan_network }} {{ '-j SNAT --to ' + snat_aipv4 if snat_aipv4 else '-j MASQUERADE' }}
+{% endif %}
+{% if wireguard_enabled %}
+# For WireGuard traffic - NAT packets from the VPN subnet
+-A POSTROUTING -s {{ wireguard_network_ipv4 }} {{ '-j SNAT --to ' + snat_aipv4 if snat_aipv4 else '-j MASQUERADE' }}
+{% endif %}
 
 
 COMMIT

--- a/roles/common/templates/rules.v4.j2
+++ b/roles/common/templates/rules.v4.j2
@@ -113,7 +113,7 @@ COMMIT
 
 {% if wireguard_enabled %}
 # Forward any traffic from the WireGuard VPN network
--A FORWARD -m conntrack --ctstate NEW -s {{ wireguard_network_ipv4 }} -m policy --pol none --dir in -j ACCEPT
+-A FORWARD -m conntrack --ctstate NEW -s {{ wireguard_network_ipv4 }} -j ACCEPT
 {% endif %}
 
 COMMIT

--- a/roles/common/templates/rules.v6.j2
+++ b/roles/common/templates/rules.v6.j2
@@ -35,7 +35,14 @@ COMMIT
 -A PREROUTING --in-interface {{ ansible_default_ipv6['interface'] }} -p udp --dport {{ wireguard_port_avoid }} -j REDIRECT --to-port {{ wireguard_port_actual }}
 {% endif %}
 # Allow traffic from the VPN network to the outside world, and replies
--A POSTROUTING -s {{ subnets | join(',') }} -m policy --pol none --dir out {{ '-j SNAT --to ' + ipv6_egress_ip | ansible.utils.ipaddr('address') if alternative_ingress_ip else '-j MASQUERADE' }}
+{% if ipsec_enabled %}
+# For IPsec traffic - NAT the decrypted packets from the VPN subnet
+-A POSTROUTING -s {{ strongswan_network_ipv6 }} {{ '-j SNAT --to ' + ipv6_egress_ip | ansible.utils.ipaddr('address') if alternative_ingress_ip else '-j MASQUERADE' }}
+{% endif %}
+{% if wireguard_enabled %}
+# For WireGuard traffic - NAT packets from the VPN subnet
+-A POSTROUTING -s {{ wireguard_network_ipv6 }} {{ '-j SNAT --to ' + ipv6_egress_ip | ansible.utils.ipaddr('address') if alternative_ingress_ip else '-j MASQUERADE' }}
+{% endif %}
 
 COMMIT
 

--- a/roles/common/templates/rules.v6.j2
+++ b/roles/common/templates/rules.v6.j2
@@ -113,7 +113,7 @@ COMMIT
 -A FORWARD -m conntrack --ctstate NEW -s {{ strongswan_network_ipv6 }} -m policy --pol ipsec --dir in -j ACCEPT
 {% endif %}
 {% if wireguard_enabled %}
--A FORWARD -m conntrack --ctstate NEW -s {{ wireguard_network_ipv6 }} -m policy --pol none --dir in -j ACCEPT
+-A FORWARD -m conntrack --ctstate NEW -s {{ wireguard_network_ipv6 }} -j ACCEPT
 {% endif %}
 
 # Use the ICMPV6-CHECK chain, described above

--- a/tests/unit/test_iptables_rules.py
+++ b/tests/unit/test_iptables_rules.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Test iptables rules logic for VPN traffic routing.
+
+These tests verify that the iptables rules templates generate correct
+NAT rules for both WireGuard and IPsec VPN traffic.
+"""
+
+import pytest
+import yaml
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader
+
+
+def load_template(template_name):
+    """Load a Jinja2 template from the roles/common/templates directory."""
+    template_dir = Path(__file__).parent.parent.parent / 'roles' / 'common' / 'templates'
+    env = Environment(loader=FileSystemLoader(str(template_dir)))
+    return env.get_template(template_name)
+
+
+def test_wireguard_nat_rules_ipv4():
+    """Test that WireGuard traffic gets proper NAT rules without policy matching."""
+    template = load_template('rules.v4.j2')
+    
+    # Test with WireGuard enabled
+    result = template.render(
+        ipsec_enabled=False,
+        wireguard_enabled=True,
+        wireguard_network_ipv4='10.49.0.0/16',
+        wireguard_port=51820,
+        wireguard_port_avoid=53,
+        wireguard_port_actual=51820,
+        ansible_default_ipv4={'interface': 'eth0'},
+        snat_aipv4=None,
+        BetweenClients_DROP=True,
+        block_smb=True,
+        block_netbios=True,
+        local_service_ip='10.49.0.1',
+        ansible_ssh_port=22,
+        reduce_mtu=0
+    )
+    
+    # Verify NAT rule exists without policy matching
+    assert '-A POSTROUTING -s 10.49.0.0/16 -j MASQUERADE' in result
+    # Verify no policy matching in WireGuard NAT rules
+    assert '-A POSTROUTING -s 10.49.0.0/16 -m policy' not in result
+
+
+def test_ipsec_nat_rules_ipv4():
+    """Test that IPsec traffic gets proper NAT rules without policy matching."""
+    template = load_template('rules.v4.j2')
+    
+    # Test with IPsec enabled
+    result = template.render(
+        ipsec_enabled=True,
+        wireguard_enabled=False,
+        strongswan_network='10.48.0.0/16',
+        strongswan_network_ipv6='2001:db8::/48',
+        ansible_default_ipv4={'interface': 'eth0'},
+        snat_aipv4=None,
+        BetweenClients_DROP=True,
+        block_smb=True,
+        block_netbios=True,
+        local_service_ip='10.48.0.1',
+        ansible_ssh_port=22,
+        reduce_mtu=0
+    )
+    
+    # Verify NAT rule exists without policy matching
+    assert '-A POSTROUTING -s 10.48.0.0/16 -j MASQUERADE' in result
+    # Verify no policy matching in IPsec NAT rules (this was the bug)
+    assert '-A POSTROUTING -s 10.48.0.0/16 -m policy --pol none' not in result
+
+
+def test_both_vpns_nat_rules_ipv4():
+    """Test NAT rules when both VPN types are enabled."""
+    template = load_template('rules.v4.j2')
+    
+    result = template.render(
+        ipsec_enabled=True,
+        wireguard_enabled=True,
+        strongswan_network='10.48.0.0/16',
+        wireguard_network_ipv4='10.49.0.0/16',
+        strongswan_network_ipv6='2001:db8::/48',
+        wireguard_network_ipv6='2001:db8:a160::/48',
+        wireguard_port=51820,
+        wireguard_port_avoid=53,
+        wireguard_port_actual=51820,
+        ansible_default_ipv4={'interface': 'eth0'},
+        snat_aipv4=None,
+        BetweenClients_DROP=True,
+        block_smb=True,
+        block_netbios=True,
+        local_service_ip='10.49.0.1',
+        ansible_ssh_port=22,
+        reduce_mtu=0
+    )
+    
+    # Both should have NAT rules
+    assert '-A POSTROUTING -s 10.48.0.0/16 -j MASQUERADE' in result
+    assert '-A POSTROUTING -s 10.49.0.0/16 -j MASQUERADE' in result
+    
+    # Neither should have policy matching
+    assert '-m policy --pol none' not in result
+
+
+def test_alternative_ingress_snat():
+    """Test that alternative ingress IP uses SNAT instead of MASQUERADE."""
+    template = load_template('rules.v4.j2')
+    
+    result = template.render(
+        ipsec_enabled=True,
+        wireguard_enabled=True,
+        strongswan_network='10.48.0.0/16',
+        wireguard_network_ipv4='10.49.0.0/16',
+        strongswan_network_ipv6='2001:db8::/48',
+        wireguard_network_ipv6='2001:db8:a160::/48',
+        wireguard_port=51820,
+        wireguard_port_avoid=53,
+        wireguard_port_actual=51820,
+        ansible_default_ipv4={'interface': 'eth0'},
+        snat_aipv4='192.168.1.100',  # Alternative ingress IP
+        BetweenClients_DROP=True,
+        block_smb=True,
+        block_netbios=True,
+        local_service_ip='10.49.0.1',
+        ansible_ssh_port=22,
+        reduce_mtu=0
+    )
+    
+    # Should use SNAT with specific IP instead of MASQUERADE
+    assert '-A POSTROUTING -s 10.48.0.0/16 -j SNAT --to 192.168.1.100' in result
+    assert '-A POSTROUTING -s 10.49.0.0/16 -j SNAT --to 192.168.1.100' in result
+    assert 'MASQUERADE' not in result
+
+
+def test_ipsec_forward_rule_has_policy_match():
+    """Test that IPsec FORWARD rules still use policy matching (this is correct)."""
+    template = load_template('rules.v4.j2')
+    
+    result = template.render(
+        ipsec_enabled=True,
+        wireguard_enabled=False,
+        strongswan_network='10.48.0.0/16',
+        strongswan_network_ipv6='2001:db8::/48',
+        ansible_default_ipv4={'interface': 'eth0'},
+        snat_aipv4=None,
+        BetweenClients_DROP=True,
+        block_smb=True,
+        block_netbios=True,
+        local_service_ip='10.48.0.1',
+        ansible_ssh_port=22,
+        reduce_mtu=0
+    )
+    
+    # FORWARD rule should have policy match (this is correct and should stay)
+    assert '-A FORWARD -m conntrack --ctstate NEW -s 10.48.0.0/16 -m policy --pol ipsec --dir in -j ACCEPT' in result
+
+
+def test_wireguard_forward_rule_no_policy_match():
+    """Test that WireGuard FORWARD rules don't use policy matching."""
+    template = load_template('rules.v4.j2')
+    
+    result = template.render(
+        ipsec_enabled=False,
+        wireguard_enabled=True,
+        wireguard_network_ipv4='10.49.0.0/16',
+        wireguard_port=51820,
+        wireguard_port_avoid=53,
+        wireguard_port_actual=51820,
+        ansible_default_ipv4={'interface': 'eth0'},
+        snat_aipv4=None,
+        BetweenClients_DROP=True,
+        block_smb=True,
+        block_netbios=True,
+        local_service_ip='10.49.0.1',
+        ansible_ssh_port=22,
+        reduce_mtu=0
+    )
+    
+    # WireGuard FORWARD rule should NOT have any policy match
+    assert '-A FORWARD -m conntrack --ctstate NEW -s 10.49.0.0/16 -j ACCEPT' in result
+    assert '-A FORWARD -m conntrack --ctstate NEW -s 10.49.0.0/16 -m policy' not in result
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary
Fixes critical issue where both WireGuard AND IPsec VPN clients could connect but not route traffic to the internet.

## Root Cause Analysis

The NAT and FORWARD rules incorrectly used policy matching (`-m policy --pol none`) which broke routing:

1. **NAT Issue**: The POSTROUTING chain sees **decrypted** packets from VPN clients. The `--pol none` match was blocking these packets from being NAT'd, preventing internet access.

2. **FORWARD Issue**: WireGuard packets don't use IPsec policies at all. The `--pol none` match in FORWARD was unnecessary and potentially problematic.

3. **Why it existed**: The policy matching was likely added to handle edge cases (site-to-site VPNs, preventing double NAT) that don't apply to Algo's road warrior VPN design.

## Solution

Removed all unnecessary policy matching:
- ✅ NAT rules: Simple source-based NAT for both VPN types
- ✅ WireGuard FORWARD: No policy match needed (it's not IPsec)  
- ✅ IPsec FORWARD: Kept `--pol ipsec` (correctly identifies encrypted traffic)

## Changes

1. **Fixed iptables templates**:
   - `roles/common/templates/rules.v4.j2`
   - `roles/common/templates/rules.v6.j2`

2. **Added comprehensive tests** (`tests/unit/test_iptables_rules.py`):
   - Verifies NAT rules have no policy matching
   - Verifies WireGuard FORWARD has no policy matching
   - Verifies IPsec FORWARD keeps required policy matching
   - Tests alternative ingress IP (SNAT) functionality
   - Prevents regression of this issue

## Testing
- ✅ Manually tested on live server - routing now works
- ✅ All unit tests pass (65/65 including 6 new tests)
- ✅ ansible-lint passes

## Impact
- Fixes VPN connectivity for both WireGuard and IPsec
- No breaking changes for existing functionality
- Road warrior VPN (Algo's use case) works correctly
- Would need adjustment if Algo ever adds site-to-site VPN support

🤖 Generated with [Claude Code](https://claude.ai/code)