### PR TITLE
Fix SSH configuration indentation in cloud-init template

### DIFF
--- a/files/cloud-init/base.yml
+++ b/files/cloud-init/base.yml
@@ -35,7 +35,7 @@ users:
 write_files:
   - path: /etc/ssh/sshd_config
     content: |
-{{ lookup('template', 'files/cloud-init/sshd_config') | indent(width=6, first=True) }}
+{{ lookup('template', 'files/cloud-init/sshd_config') | indent(width=6, first=False) }}
 
 runcmd:
   - set -x


### PR DESCRIPTION
## Summary
- Fixed SSH daemon startup failure caused by incorrect indentation in the sshd_config file
- Changed `indent(width=6, first=True)` to `indent(width=6, first=False)` in cloud-init template
- Resolves SSH connection timeouts during DigitalOcean (and potentially other cloud provider) deployments

## Problem
The SSH configuration file (`/etc/ssh/sshd_config`) was being written with 6 spaces of indentation on every line due to the `first=True` parameter in the Jinja2 indent filter. This made the configuration file invalid, causing the SSH daemon to fail during startup and preventing connections on the configured port (4160).

## Solution
Removed the `first=True` parameter (equivalent to `first=False`) from the indent filter to ensure the SSH configuration is written with proper formatting that sshd can parse.

## Test Plan
- [ ] Deploy a new Algo server on DigitalOcean
- [ ] Verify SSH connection succeeds on port 4160
- [ ] Confirm the deployment completes successfully
- [ ] Check that `/etc/ssh/sshd_config` on the deployed server has correct formatting

This bug likely affects all cloud deployments that use cloud-init for initial configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)