### PR TITLE
Fix Ansible 12 compatibility issues

### DIFF
--- a/files/cloud-init/base.sh
+++ b/files/cloud-init/base.sh
@@ -17,7 +17,7 @@ cat <<EOF >/etc/ssh/sshd_config
 EOF
 
 test -d /home/algo/.ssh || sudo -u algo mkdir -m 0700 /home/algo/.ssh
-echo "{{ lookup('file', '{{ SSH_keys.public }}') }}" | (sudo -u algo tee /home/algo/.ssh/authorized_keys && chmod 0600 /home/algo/.ssh/authorized_keys)
+echo "{{ lookup('file', SSH_keys.public) }}" | (sudo -u algo tee /home/algo/.ssh/authorized_keys && chmod 0600 /home/algo/.ssh/authorized_keys)
 
 ufw --force reset
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Sysctl tuning
   sysctl: name="{{ item.item }}" value="{{ item.value }}"
-  when: item.item
+  when: item.item is defined and item.item != none
   with_items:
     - "{{ sysctl | default([]) }}"
   tags:

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -129,15 +129,7 @@
       - openssl
       - gnupg2
       - cron
-    sysctl:
-      - item: net.ipv4.ip_forward
-        value: 1
-      - item: net.ipv4.conf.all.forwarding
-        value: 1
-      - item: "{{ 'net.ipv6.conf.all.forwarding' if ipv6_support else none }}"
-        value: 1
-      - item: net.ipv4.conf.all.route_localnet
-        value: 1
+    sysctl: "{{ [{'item': 'net.ipv4.ip_forward', 'value': 1}, {'item': 'net.ipv4.conf.all.forwarding', 'value': 1}, {'item': 'net.ipv4.conf.all.route_localnet', 'value': 1}] + ([{'item': 'net.ipv6.conf.all.forwarding', 'value': 1}] if ipv6_support else []) }}"
 
 - name: Install packages (batch optimization)
   include_tasks: packages.yml


### PR DESCRIPTION
## Summary
- Fixes Ansible 12 string-to-boolean conversion errors in conditionals
- Resolves nested Jinja template deprecation warnings
- Ensures compatibility with stricter type checking in Ansible 12

## Related Issue
Closes #14838 

## Changes Made

### 1. Fixed Nested Jinja Template Warning
**File:** `files/cloud-init/base.sh:20`
- **Before:** `{{ lookup('file', '{{ SSH_keys.public }}') }}`
- **After:** `{{ lookup('file', SSH_keys.public) }}`
- **Reason:** Ansible is deprecating nested template expressions. The inner `{{ }}` is unnecessary since we're already in a template context.

### 2. Fixed Boolean Conditional Error
**File:** `roles/common/tasks/main.yml:20`
- **Before:** `when: item.item`
- **After:** `when: item.item is defined and item.item != none`
- **Reason:** Ansible 12 requires explicit boolean conditions. String values can no longer be implicitly evaluated as truthy/falsy.

### 3. Fixed Sysctl List Structure
**File:** `roles/common/tasks/ubuntu.yml:132`
- **Before:** List with conditional item that could be `none`
- **After:** Dynamic list construction that excludes None values
- **Reason:** Prevents `none` values from being evaluated in boolean contexts

## Test Plan
- [x] Syntax validation: `ansible-playbook main.yml --syntax-check` ✅
- [x] YAML linting: `yamllint` ✅
- [x] Shell script linting: `shellcheck` ✅
- [x] Ansible linting: `ansible-lint` ✅
- [x] All pre-commit hooks pass ✅
- [ ] Deploy test on Lightsail (requested from issue reporter)
- [ ] Deploy test with Ansible 11.x (backward compatibility)
- [ ] Deploy test with Ansible 12.x (forward compatibility)

## Compatibility
- Maintains backward compatibility with Ansible 11.x and earlier
- Ensures forward compatibility with Ansible 12.x strict type checking
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)