### PR TITLE
Remove Exoscale support due to CloudStack API deprecation

### DIFF
--- a/docs/cloud-amazon-ec2.md
+++ b/docs/cloud-amazon-ec2.md
@@ -90,7 +90,7 @@ $ ./algo
     7. Vultr
     8. Scaleway
     9. OpenStack (DreamCompute optimised)
-    10. CloudStack (Exoscale optimised)
+    10. CloudStack
     11. Linode
     12. Install to existing Ubuntu server (for more advanced users)
 

--- a/docs/cloud-cloudstack.md
+++ b/docs/cloud-cloudstack.md
@@ -1,11 +1,15 @@
 ### Configuration file
 
-Algo scripts will ask you for the API detail. You need to fetch the API credentials and the endpoint from the provider control panel.
+> **⚠️ Important Note:** Exoscale is no longer supported as they deprecated their CloudStack API on May 1, 2024. Please use alternative providers like Hetzner, DigitalOcean, Vultr, or Scaleway.
 
-Example for Exoscale (European cloud provider exposing CloudStack API), visit https://portal.exoscale.com/u/<your@account>/account/profile/api to gather the required information: CloudStack api key and secret.
+Algo scripts will ask you for the API details. You need to fetch the API credentials and the endpoint from your CloudStack provider's control panel.
+
+For CloudStack providers, you'll need to set:
 
 ```bash
 export CLOUDSTACK_KEY="<your api key>"
 export CLOUDSTACK_SECRET="<your secret>"
-export CLOUDSTACK_ENDPOINT="https://api.exoscale.com/compute"
+export CLOUDSTACK_ENDPOINT="<your provider's API endpoint>"
 ```
+
+Make sure your provider supports the CloudStack API. Contact your provider for the correct API endpoint URL.

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -291,11 +291,13 @@ You need to source the rc file prior to run Algo. Download it from the OpenStack
 
 ### CloudStack
 
+> **Note:** Exoscale is no longer supported as they deprecated their CloudStack API on May 1, 2024.
+
 Required variables:
 
 - [cs_config](https://trailofbits.github.io/algo/cloud-cloudstack.html): /path/to/.cloudstack.ini
-- cs_region: e.g. `exoscale`
-- cs_zones: e.g. `ch-gva2`
+- cs_region: your CloudStack region
+- cs_zones: your CloudStack zone
 
 The first two can also be defined in your environment, using the variables `CLOUDSTACK_CONFIG` and `CLOUDSTACK_REGION`.
 

--- a/roles/cloud-cloudstack/tasks/prompts.yml
+++ b/roles/cloud-cloudstack/tasks/prompts.yml
@@ -34,9 +34,25 @@
         algo_cs_token: "{{ cs_secret | default(_cs_secret.user_input | default(None)) | default(lookup('env', 'CLOUDSTACK_SECRET'), true) }}"
         algo_cs_url: >-
           {{ cs_url | default(_cs_url.user_input|default(None)) |
-             default(lookup('env', 'CLOUDSTACK_ENDPOINT'), true) |
-             default('https://api.exoscale.com/compute', true) }}
+             default(lookup('env', 'CLOUDSTACK_ENDPOINT'), true) }}
       no_log: true
+
+    - name: Check for Exoscale API endpoint
+      fail:
+        msg: |
+          ERROR: Exoscale CloudStack API has been deprecated as of May 1, 2024.
+
+          Exoscale has migrated from CloudStack to their proprietary API v2, which is not compatible
+          with CloudStack-based tools. Algo no longer supports Exoscale deployments.
+
+          Please consider these alternative providers:
+          - Hetzner (provider: hetzner) - German provider with European coverage
+          - DigitalOcean (provider: digitalocean) - Has Amsterdam and Frankfurt regions
+          - Vultr (provider: vultr) - Multiple European locations
+          - Scaleway (provider: scaleway) - French provider
+
+          If you're using a different CloudStack provider, please provide the correct API endpoint.
+      when: "'exoscale.com' in algo_cs_url or 'exoscale.ch' in algo_cs_url"
 
     - name: Get zones on cloud
       cs_zone_info:
@@ -53,10 +69,7 @@
 
     - name: Set the default zone
       set_fact:
-        default_zone: >-
-          {%- for z in cs_zones -%}
-          {%- if z['name'] == "ch-gva-2" %}{{ loop.index }}{% endif -%}
-          {%- endfor %}
+        default_zone: "1"  # Default to first zone in the list
 
     - pause:
         prompt: |


### PR DESCRIPTION
## Summary
Removes Exoscale support from Algo as they deprecated their CloudStack API on May 1, 2024.

## Related Issue
Fixes #14839

## Background
Exoscale has migrated from CloudStack to their proprietary API v2, which is fundamentally incompatible with CloudStack-based tools. This is not a simple version update but a complete platform change that would require a full rewrite to support.

## Changes Made

### 1. Removed Exoscale as Default Endpoint
**File:** `roles/cloud-cloudstack/tasks/prompts.yml`
- Removed `https://api.exoscale.com/compute` as the default CloudStack endpoint
- Users must now provide their CloudStack provider's endpoint explicitly

### 2. Added Exoscale Detection and Error Handling  
**File:** `roles/cloud-cloudstack/tasks/prompts.yml`
- Added check for Exoscale endpoints (exoscale.com/exoscale.ch)
- Provides clear error message explaining the deprecation
- Suggests alternative providers with European presence

### 3. Updated Documentation
**Files:** 
- `docs/cloud-cloudstack.md` - Added deprecation notice and removed Exoscale examples
- `docs/cloud-amazon-ec2.md` - Removed "Exoscale optimised" label from CloudStack
- `docs/deploy-from-ansible.md` - Removed Exoscale-specific examples

### 4. Removed Exoscale-Specific Defaults
**File:** `roles/cloud-cloudstack/tasks/prompts.yml`
- Removed hardcoded "ch-gva-2" zone default (Exoscale-specific)
- Now defaults to first zone in the list

## Alternative Providers for Affected Users

Users previously using Exoscale can migrate to:
- **Hetzner** (provider: hetzner) - German provider with European coverage
- **DigitalOcean** (provider: digitalocean) - Amsterdam and Frankfurt regions
- **Vultr** (provider: vultr) - Multiple European locations  
- **Scaleway** (provider: scaleway) - French provider

## Test Plan
- [x] Syntax validation passes
- [x] YAML linting passes
- [x] Ansible linting passes
- [x] All pre-commit hooks pass
- [x] Generic CloudStack support remains functional
- [x] Error message triggers when Exoscale endpoints are detected

## Impact
- **Breaking change** for Exoscale users (already broken due to API deprecation)
- **No impact** on other CloudStack providers
- **Improved UX** with clear error messages instead of cryptic API failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)