### PR TITLE
Fix Vultr regions string conversion bug

### DIFF
--- a/roles/cloud-vultr/tasks/prompts.yml
+++ b/roles/cloud-vultr/tasks/prompts.yml
@@ -29,10 +29,7 @@
 
 - name: Format regions
   set_fact:
-    regions: >-
-      [ {% for v in _vultr_regions.json['regions'] %}
-      {{ v }}{% if not loop.last %},{% endif %}
-      {% endfor %} ]
+    regions: "{{ _vultr_regions.json['regions'] }}"
 
 - name: Set regions as a fact
   set_fact:


### PR DESCRIPTION
## Summary
Fixes a bug in the Vultr cloud provider role that prevented server provisioning due to incorrect region data formatting.

## Problem
The "Format regions" task was converting region dictionaries to strings using `{{ v }}` in a Jinja2 loop. This caused the subsequent `sort(attribute='country')` operation to fail with:
```
Error while resolving value for 'vultr_regions': object of type 'str' has no attribute 'country'
```

## Solution
Changed the task to directly assign the regions array from the Vultr API response, preserving the dictionary objects with their `country`, `city`, `id`, and other attributes.

**Before:**
```yaml
regions: >-
  [ {% for v in _vultr_regions.json['regions'] %}
  {{ v }}{% if not loop.last %},{% endif %}
  {% endfor %} ]
```

**After:**
```yaml
regions: "{{ _vultr_regions.json['regions'] }}"
```

## Testing
- ✅ Verified that Vultr region selection works correctly
- ✅ Regions are properly sorted by country
- ✅ All region attributes are preserved and accessible

## Impact
- Fixes Vultr region selection which was completely broken
- No changes to other cloud providers
- Simplifies the code by removing unnecessary Jinja2 loop