### PR TITLE
fix: update-users not working (fixes #14849)

### DIFF
--- a/users.yml
+++ b/users.yml
@@ -24,11 +24,12 @@
 
         - name: Build list of installed servers
           set_fact:
-            server_list: >-
-              [{% for i in _configs_list.files %}
-                {% set config = lookup('file', i.path) | from_yaml %}
-                {{ {'server': config.server, 'IP_subject_alt_name': config.IP_subject_alt_name} }}
-              {% endfor %}]
+            server_list: "{{ server_list | default([]) + [ {'server': config.server, 'IP_subject_alt_name': config.IP_subject_alt_name} ] }}"
+          loop: "{{ _configs_list.files }}"
+          loop_control:
+            label: "{{ item.path }}"
+          vars:
+            config: "{{ lookup('file', item.path) | from_yaml }}"
 
         - name: Server address prompt
           pause:


### PR DESCRIPTION
## Description
Build server_list with Ansible loop and per-item lookup, replacing Jinja list comprehension

## Motivation and Context
```
[ERROR]: Task failed: Finalization of task args for 'ansible.builtin.pause' failed: Error while resolving value for 'prompt': object of type 'str' has no attribute 'server'

Task failed.
Origin: /XXXXXX/trailofbits/algo/users.yml:33:11

31               {% endfor %}]
32
33         - name: Server address prompt
             ^ column 11

<<< caused by >>>

Finalization of task args for 'ansible.builtin.pause' failed.
Origin: /XXXXXX/trailofbits/algo/users.yml:34:11

32
33         - name: Server address prompt
34           pause:
             ^ column 11

<<< caused by >>>

Error while resolving value for 'prompt': object of type 'str' has no attribute 'server'
Origin: /XXXXXX/trailofbits/algo/users.yml:35:21

33         - name: Server address prompt
34           pause:
35             prompt: |
                       ^ column 21

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Finalization of task args for 'ansible.builtin.pause' failed: Error while resolving value for 'prompt': object of type 'str' has no attribute 'server'"}
```

## How Has This Been Tested?
- Changes were tested manually
- MacOS Tahoe
- No side effects expected

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] My code passes all linters (`./scripts/lint.sh`)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Dependencies use exact versions (e.g., `==1.2.3` not `>=1.2.0`).
