### PR TITLE
Fix GCE deployment error with Ansible 12 JSON parsing

### DIFF
--- a/roles/cloud-gce/tasks/prompts.yml
+++ b/roles/cloud-gce/tasks/prompts.yml
@@ -17,7 +17,7 @@
   no_log: true
 
 - set_fact:
-    credentials_file_lookup: "{{ lookup('file', credentials_file_path) }}"
+    credentials_file_lookup: "{{ lookup('file', credentials_file_path) | from_json }}"
   no_log: true
 
 - set_fact:


### PR DESCRIPTION
## Summary

- Fix GCE deployment failing with `Invalid resource field value in the request` error
- Add `| from_json` filter to explicitly parse JSON credentials file

## Root Cause

In Ansible 12, `jinja2_native` mode is always enabled. This changes how JSON strings are handled:

- The `lookup('file', ...)` returns file content as a **string**
- In older Ansible, this string was automatically converted to a dict through recursive templating
- In Ansible 12, the string remains a string, so accessing `.project_id` returns undefined
- The undefined value defaults to an empty string, causing the API request to fail

The error URL `projects//regions` (note the double slash) shows the empty project_id.

## Solution

Per the [Ansible 12 Porting Guide](https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_12.html):
> "Use the `from_json` filter on the lookup result instead."

## Test plan

- [ ] Verify GCE deployment works with valid credentials file
- [ ] Ansible syntax check passes
- [ ] Unit tests pass (87/87)

Fixes #14854

🤖 Generated with [Claude Code](https://claude.com/claude-code)