### PR TITLE
Fix AWS EC2 and Lightsail deployment failures with Ansible 12

### DIFF
--- a/roles/cloud-ec2/tasks/cloudformation.yml
+++ b/roles/cloud-ec2/tasks/cloudformation.yml
@@ -1,4 +1,6 @@
 ---
+# Note: Using template_body instead of deprecated 'template' parameter.
+# The 'template' parameter is deprecated and will be removed after 2026-05-01.
 - name: Deploy the template
   cloudformation:
     aws_access_key: "{{ access_key }}"
@@ -7,7 +9,7 @@
     stack_name: "{{ stack_name }}"
     state: present
     region: "{{ algo_region }}"
-    template: roles/cloud-ec2/files/stack.yaml
+    template_body: "{{ lookup('file', 'roles/cloud-ec2/files/stack.yaml') }}"
     template_parameters:
       InstanceTypeParameter: "{{ cloud_providers.ec2.size }}"
       ImageIdParameter: "{{ ami_image }}"

--- a/roles/cloud-ec2/tasks/prompts.yml
+++ b/roles/cloud-ec2/tasks/prompts.yml
@@ -47,21 +47,25 @@
     - _file_secret_key is undefined or _file_secret_key|length <= 0
 
 # Set final credentials with proper precedence
+# Note: The 'true' parameter in default() is required for Ansible 12+ compatibility.
+# Without it, empty strings from env lookups stop the default chain since they're
+# "defined" values, not "undefined". The 'true' makes default() also trigger on
+# falsy values (empty strings, None).
 - set_fact:
     access_key: >-
       {{ aws_access_key
-         | default(lookup('env', 'AWS_ACCESS_KEY_ID'))
-         | default(_file_access_key)
-         | default(_aws_access_key.user_input | default(None)) }}
+         | default(lookup('env', 'AWS_ACCESS_KEY_ID'), true)
+         | default(_file_access_key, true)
+         | default(_aws_access_key.user_input | default(None), true) }}
     secret_key: >-
       {{ aws_secret_key
-         | default(lookup('env', 'AWS_SECRET_ACCESS_KEY'))
-         | default(_file_secret_key)
-         | default(_aws_secret_key.user_input | default(None)) }}
+         | default(lookup('env', 'AWS_SECRET_ACCESS_KEY'), true)
+         | default(_file_secret_key, true)
+         | default(_aws_secret_key.user_input | default(None), true) }}
     session_token: >-
       {{ aws_session_token
-         | default(lookup('env', 'AWS_SESSION_TOKEN'))
-         | default(_file_session_token)
+         | default(lookup('env', 'AWS_SESSION_TOKEN'), true)
+         | default(_file_session_token, true)
          | default('') }}
   no_log: true
 

--- a/roles/cloud-lightsail/tasks/cloudformation.yml
+++ b/roles/cloud-lightsail/tasks/cloudformation.yml
@@ -1,4 +1,6 @@
 ---
+# Note: Using template_body instead of deprecated 'template' parameter.
+# The 'template' parameter is deprecated and will be removed after 2026-05-01.
 - name: Deploy the template
   cloudformation:
     aws_access_key: "{{ access_key }}"
@@ -6,7 +8,7 @@
     stack_name: "{{ stack_name }}"
     state: present
     region: "{{ algo_region }}"
-    template: roles/cloud-lightsail/files/stack.yaml
+    template_body: "{{ lookup('file', 'roles/cloud-lightsail/files/stack.yaml') }}"
     template_parameters:
       InstanceTypeParameter: "{{ cloud_providers.lightsail.size }}"
       ImageIdParameter: "{{ cloud_providers.lightsail.image }}"


### PR DESCRIPTION
## Summary

- Fix EC2 credential chain to properly handle empty strings from env lookups
- Migrate CloudFormation tasks from deprecated `template` to `template_body` parameter
- Add explanatory comments for Ansible 12 compatibility

## Root Cause

In Ansible 12, `jinja2_native` mode is always enabled, which changes how empty strings are handled:

1. `lookup('env', 'AWS_ACCESS_KEY_ID')` returns `''` (empty string) when the env var is not set
2. The `default()` filter only triggers for **undefined** values, not empty strings
3. An empty string `''` is a defined value, so `| default(...)` doesn't trigger
4. The credential chain stops at the first empty string
5. `access_key = ''` gets passed to AWS modules → "Unable to locate credentials"

## Solution

Add `true` as the second parameter to all `default()` calls:
```yaml
# Before (broken in Ansible 12):
| default(lookup('env', 'AWS_ACCESS_KEY_ID'))

# After (works in Ansible 12):
| default(lookup('env', 'AWS_ACCESS_KEY_ID'), true)
```

The `true` parameter makes `default()` also trigger on falsy values (empty strings, None), not just undefined.

## CloudFormation Migration

Also migrated from deprecated `template:` parameter to `template_body:` as recommended by the [amazon.aws collection](https://github.com/ansible-collections/amazon.aws/pull/2048).

## Test plan

- [x] Ansible syntax check passes
- [x] All 91 unit tests pass
- [ ] Verify EC2 deployment works with credentials file
- [ ] Verify Lightsail deployment works

Fixes #14842

🤖 Generated with [Claude Code](https://claude.com/claude-code)