### PR TITLE
Update Hetzner server type from deprecated cpx11 to cpx22

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -179,7 +179,7 @@ cloud_providers:
     image: Ubuntu 22.04 Jammy Jellyfish
     arch: x86_64
   hetzner:
-    server_type: cpx11
+    server_type: cpx22
     image: ubuntu-22.04
   openstack:
     flavor_ram: ">=512"


### PR DESCRIPTION
## Summary
- Update default Hetzner server type from `cpx11` to `cpx22`
- Hetzner deprecated cx11/cpx11 types; smallest available are now cx22/cpx22
- Required for compatibility with hcloud 2.11.1 (PR #14870)

## Test plan
- [ ] Hetzner deployment test with new server type

🤖 Generated with [Claude Code](https://claude.com/claude-code)