### PR TITLE
Add pre-flight SSH connectivity check before update-users

### DIFF
--- a/users.yml
+++ b/users.yml
@@ -51,6 +51,32 @@
           include_vars:
             file: configs/{{ algo_server }}/.config.yml
 
+        - name: Test SSH connectivity to server
+          wait_for:
+            host: "{{ algo_server }}"
+            port: "{{ ansible_ssh_port | default(ssh_port) | int }}"
+            timeout: 10
+          register: ssh_check
+          ignore_errors: true
+          when: algo_server != 'localhost'
+
+        - name: Fail with helpful message if server unreachable
+          fail:
+            msg: |
+              Cannot connect to {{ algo_server }} on port {{ ansible_ssh_port | default(ssh_port) }}.
+
+              Possible causes:
+              - Server is not running (check your cloud provider console)
+              - IP address changed (common after EC2 restart without Elastic IP)
+              - Firewall/security group blocking port {{ ansible_ssh_port | default(ssh_port) }}
+
+              To diagnose:
+                nc -zv {{ algo_server }} {{ ansible_ssh_port | default(ssh_port) }}
+                ssh -vvv -p {{ ansible_ssh_port | default(ssh_port) }} -i configs/algo.pem {{ server_user | default('algo') }}@{{ algo_server }}
+          when:
+            - algo_server != 'localhost'
+            - ssh_check is failed
+
         - when: ipsec_enabled
           block:
             - name: CA password prompt


### PR DESCRIPTION
## Summary

- Adds a pre-flight SSH connectivity check in `users.yml` before the main user management tasks
- Provides a helpful error message with diagnostic steps when the server is unreachable

## Problem

When running `./algo update-users`, if the server is unreachable, users see cryptic Ansible SSH retry errors:

```
ssh_retry: attempt: 3, ssh return code is 255
```

This provides no indication of what's wrong or how to fix it.

## Solution

Added two tasks after loading server config:

1. **Test SSH connectivity** using `wait_for` module with 10-second timeout
2. **Fail with helpful message** if unreachable, including:
   - Possible causes (server not running, IP changed, firewall blocking)
   - Diagnostic commands (`nc -zv` and `ssh -vvv`)

Example error message:
```
Cannot connect to 18.202.x.x on port 4160.

Possible causes:
- Server is not running (check your cloud provider console)
- IP address changed (common after EC2 restart without Elastic IP)
- Firewall/security group blocking port 4160

To diagnose:
  nc -zv 18.202.x.x 4160
  ssh -vvv -p 4160 -i configs/algo.pem algo@18.202.x.x
```

## Test plan

- [x] Ansible syntax check passes
- [x] All 91 unit tests pass
- [x] Pre-commit hooks pass (yamllint, ansible-lint)
- [ ] Manual test with unreachable server shows helpful error
- [ ] Manual test with reachable server proceeds normally

Fixes #14878

🤖 Generated with [Claude Code](https://claude.com/claude-code)