### PR TITLE
Remove unused pyopenssl and boto dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "jinja2>=3.1.6",
     "netaddr==1.3.0",
     "pyyaml>=6.0.2",
-    "pyopenssl>=0.15",
     "segno>=1.6.0",
 ]
 
@@ -24,7 +23,6 @@ py-modules = []
 # Cloud provider dependencies (installed automatically based on provider selection)
 aws = [
     "boto3>=1.34.0",
-    "boto>=2.49.0",
 ]
 azure = [
     "azure-identity>=1.15.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -29,14 +29,12 @@ dependencies = [
     { name = "ansible" },
     { name = "jinja2" },
     { name = "netaddr" },
-    { name = "pyopenssl" },
     { name = "pyyaml" },
     { name = "segno" },
 ]
 
 [package.optional-dependencies]
 aws = [
-    { name = "boto" },
     { name = "boto3" },
 ]
 azure = [
@@ -81,7 +79,6 @@ requires-dist = [
     { name = "azure-mgmt-compute", marker = "extra == 'azure'", specifier = ">=30.0.0" },
     { name = "azure-mgmt-network", marker = "extra == 'azure'", specifier = ">=25.0.0" },
     { name = "azure-mgmt-resource", marker = "extra == 'azure'", specifier = ">=23.0.0" },
-    { name = "boto", marker = "extra == 'aws'", specifier = ">=2.49.0" },
     { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.34.0" },
     { name = "cs", marker = "extra == 'cloudstack'", specifier = ">=3.0.0" },
     { name = "google-auth", marker = "extra == 'gcp'", specifier = ">=2.28.0" },
@@ -91,7 +88,6 @@ requires-dist = [
     { name = "msrestazure", marker = "extra == 'azure'", specifier = ">=0.6.4" },
     { name = "netaddr", specifier = "==1.3.0" },
     { name = "openstacksdk", marker = "extra == 'openstack'", specifier = ">=2.1.0" },
-    { name = "pyopenssl", specifier = ">=0.15" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", marker = "extra == 'gcp'", specifier = ">=2.31.0" },
     { name = "segno", specifier = ">=1.6.0" },
@@ -308,15 +304,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926, upload-time = "2025-01-29T04:18:58.564Z" },
     { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613, upload-time = "2025-01-29T04:19:27.63Z" },
     { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646, upload-time = "2025-01-29T04:15:38.082Z" },
-]
-
-[[package]]
-name = "boto"
-version = "2.49.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/af/54a920ff4255664f5d238b5aebd8eedf7a07c7a5e71e27afcfe840b82f51/boto-2.49.0.tar.gz", hash = "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a", size = 1478498, upload-time = "2018-07-11T20:58:58.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/10/c0b78c27298029e4454a472a1919bde20cb182dab1662cec7f2ca1dcc523/boto-2.49.0-py2.py3-none-any.whl", hash = "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8", size = 1359202, upload-time = "2018-07-11T20:58:55.711Z" },
 ]
 
 [[package]]
@@ -1167,19 +1154,6 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
-]
-
-[[package]]
-name = "pyopenssl"
-version = "25.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/80/be/97b83a464498a79103036bc74d1038df4a7ef0e402cfaf4d5e113fb14759/pyopenssl-25.3.0.tar.gz", hash = "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329", size = 184073, upload-time = "2025-09-17T00:32:21.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/81/ef2b1dfd1862567d573a4fdbc9f969067621764fbb74338496840a1d2977/pyopenssl-25.3.0-py3-none-any.whl", hash = "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6", size = 57268, upload-time = "2025-09-17T00:32:19.474Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Remove `pyopenssl` from core dependencies: community.crypto 3.0.3 removed pyopenssl backend from ALL modules, now uses only `cryptography`
- Remove `boto` (legacy) from AWS optional deps: Algo only uses `boto3`/`botocore`

## Verification

### pyopenssl
- Code search: No Python files import OpenSSL/pyopenssl
- [community.crypto 3.0.3 CHANGELOG](https://github.com/ansible-collections/community.crypto/blob/main/CHANGELOG.rst) confirms pyopenssl backend was removed from ALL modules
- Runtime test in isolated venv without pyopenssl: all modules work, all 101 tests pass

### boto (legacy)
- Code search: No code imports old boto (only boto3/botocore)
- `library/lightsail_region_facts.py` uses `boto3` and `botocore`, NOT old boto
- amazon.aws collection requires only boto3 >= 1.34.0
- Runtime test in isolated venv without boto: all modules work, all 101 tests pass

## Test plan
- [x] Unit tests pass (101 passed)
- [x] Ansible playbook syntax checks pass
- [x] Pre-commit hooks pass
- [x] Verified in isolated test environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)