### PR TITLE
Skip wait_for_connection for local deployments

### DIFF
--- a/playbooks/cloud-post.yml
+++ b/playbooks/cloud-post.yml
@@ -56,3 +56,4 @@
     sleep: 10         # Check every 10 seconds (less aggressive polling)
   delegate_to: "{{ item }}"
   loop: "{{ groups['vpn-host'] }}"
+  when: cloud_instance_ip != "localhost"


### PR DESCRIPTION
## Summary

- Skip `wait_for_connection` task for localhost connections to fix Docker installation hang

## Problem

When running Algo via Docker with the `local` provider (option 12), the installation hangs after displaying:
```
[WARNING]: Reset is not implemented for this connection
```

This occurs because Ansible's local connection plugin doesn't implement the `reset` method that `wait_for_connection` tries to use.

## Solution

Add `when: cloud_instance_ip != "localhost"` to skip the `wait_for_connection` task for local deployments. This follows the same pattern already used elsewhere in the codebase:
- Line 40 in `cloud-post.yml` (SSH wait task)
- Line 64 in `roles/common/tasks/ubuntu.yml` (reboot wait task)

The task is unnecessary for localhost since it always completes instantly (`elapsed: 0`) - localhost is always reachable.

## Test plan

- [ ] Verify `ansible-lint` passes (confirmed locally)
- [ ] Verify `ansible-playbook main.yml --syntax-check` passes (confirmed locally)
- [ ] Test Docker deployment with local provider no longer shows the warning or hangs

Fixes #14627

🤖 Generated with [Claude Code](https://claude.com/claude-code)
