### PR TITLE
Add explicit confirmation for local installation

### DIFF
--- a/docs/deploy-to-ubuntu.md
+++ b/docs/deploy-to-ubuntu.md
@@ -21,6 +21,17 @@ For local installation on the same machine, you must run:
 sudo ./algo
 ```
 
+## Confirmation Prompt
+
+Local installation displays a warning and requires you to type `yes` to proceed. This ensures you understand that Algo will modify firewall rules and system settings, and that there is no uninstall option.
+
+For automated deployments or CI/CD pipelines, skip the confirmation with:
+```bash
+ansible-playbook main.yml -e "provider=local local_install_confirmed=true server=localhost endpoint=YOUR_IP"
+```
+
+Only use `local_install_confirmed=true` when you have already taken a backup and understand the risks.
+
 ## Road Warrior Setup
 
 A "road warrior" setup lets you securely access your home network and its resources when traveling. This involves installing Algo on a server within your home LAN.

--- a/roles/local/tasks/prompts.yml
+++ b/roles/local/tasks/prompts.yml
@@ -1,14 +1,43 @@
 ---
-- pause:
+- name: Display local installation warning
+  pause:
     prompt: |
-      https://trailofbits.github.io/algo/deploy-to-ubuntu.html
 
-      Local installation might break your server. Use at your own risk.
+      ======================================================================
+                          *** DESTRUCTIVE OPERATION ***
+      ======================================================================
 
-      Proceed? Press ENTER to continue or CTRL+C and A to abort...
-  when: not tests|default(false)|bool
-  tags:
-    - skip_ansible_lint
+      Algo is designed for DEDICATED VPN servers only.
+
+      This installation will:
+        - Replace all firewall rules (blocks most incoming traffic)
+        - Modify system network and DNS settings
+        - Install and configure VPN services
+
+      THERE IS NO UNINSTALL OPTION.
+
+      If this server runs other services (web, database, mail, etc.),
+      they will likely become inaccessible.
+
+      Recommended: Take a snapshot/backup before proceeding.
+
+      Documentation: https://trailofbits.github.io/algo/deploy-to-ubuntu.html
+
+      ======================================================================
+
+      Type 'yes' to confirm you understand the risks and want to proceed:
+  register: _local_warning_confirm
+  when:
+    - not tests | default(false) | bool
+    - not local_install_confirmed | default(false) | bool
+
+- name: Abort if not confirmed
+  fail:
+    msg: "Installation aborted by user. Your server was not modified."
+  when:
+    - not tests | default(false) | bool
+    - not local_install_confirmed | default(false) | bool
+    - _local_warning_confirm.user_input | default('') | lower != 'yes'
 
 - pause:
     prompt: |


### PR DESCRIPTION
## Summary

- Enhance local installation warning to require typing `yes` to proceed
- List specific consequences (firewall rules, DNS settings, no uninstall option)
- Add `local_install_confirmed` variable for automated deployments
- Document skip method in deploy-to-ubuntu.md

## Context

Users following external tutorials often don't see the documentation warning until after their server is already modified. This change makes the risks impossible to miss by requiring explicit confirmation.

The confirmation can be skipped for automation with:
```bash
ansible-playbook main.yml -e "provider=local local_install_confirmed=true ..."
```

Closes #14362

## Test plan

- [ ] Run local installation and verify warning appears
- [ ] Verify typing anything other than `yes` aborts installation
- [ ] Verify `-e local_install_confirmed=true` skips the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)