### PR TITLE
Only open VPN ports in cloud security groups when enabled

### DIFF
--- a/roles/cloud-azure/files/deployment.json.j2
+++ b/roles/cloud-azure/files/deployment.json.j2
@@ -58,8 +58,9 @@
               "priority": 100,
               "direction": "Inbound"
             }
-          },
-          {
+          }
+{% if ipsec_enabled | default(true) | bool %}
+          ,{
             "name": "AllowIPSEC500",
             "properties": {
               "description": "Allow UDP to port 500",
@@ -86,11 +87,13 @@
               "priority": 120,
               "direction": "Inbound"
             }
-          },
-          {
+          }
+{% endif %}
+{% if wireguard_enabled | default(true) | bool %}
+          ,{
             "name": "AllowWireGuard",
             "properties": {
-              "description": "Locks inbound down to ssh default port 22.",
+              "description": "Allow WireGuard VPN",
               "protocol": "Udp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('WireGuardPort')]",
@@ -101,6 +104,7 @@
               "direction": "Inbound"
             }
           }
+{% endif %}
         ]
       }
     },

--- a/roles/cloud-azure/tasks/main.yml
+++ b/roles/cloud-azure/tasks/main.yml
@@ -10,7 +10,7 @@
   azure_rm_deployment:
     state: present
     deployment_name: "{{ algo_server_name }}"
-    template: "{{ lookup('file', role_path + '/files/deployment.json') }}"
+    template: "{{ lookup('template', 'files/deployment.json.j2') }}"
     secret: "{{ secret }}"
     tenant: "{{ tenant }}"
     client_id: "{{ client_id }}"

--- a/roles/cloud-cloudstack/tasks/main.yml
+++ b/roles/cloud-cloudstack/tasks/main.yml
@@ -20,11 +20,23 @@
         start_port: "{{ item.start_port }}"
         end_port: "{{ item.end_port }}"
         cidr: "{{ item.range }}"
-      loop:
-        - { proto: tcp, start_port: "{{ ssh_port }}", end_port: "{{ ssh_port }}", range: 0.0.0.0/0 }
-        - { proto: udp, start_port: 4500, end_port: 4500, range: 0.0.0.0/0 }
-        - { proto: udp, start_port: 500, end_port: 500, range: 0.0.0.0/0 }
-        - { proto: udp, start_port: "{{ wireguard_port }}", end_port: "{{ wireguard_port }}", range: 0.0.0.0/0 }
+      loop: >-
+        {{
+          [
+            { 'proto': 'tcp', 'start_port': ssh_port, 'end_port': ssh_port, 'range': '0.0.0.0/0' }
+          ]
+          + (
+            [
+              { 'proto': 'udp', 'start_port': 500, 'end_port': 500, 'range': '0.0.0.0/0' },
+              { 'proto': 'udp', 'start_port': 4500, 'end_port': 4500, 'range': '0.0.0.0/0' }
+            ] if ipsec_enabled | default(true) | bool else []
+          )
+          + (
+            [
+              { 'proto': 'udp', 'start_port': wireguard_port, 'end_port': wireguard_port, 'range': '0.0.0.0/0' }
+            ] if wireguard_enabled | default(true) | bool else []
+          )
+        }}
 
     - name: Set facts
       set_fact:

--- a/roles/cloud-ec2/files/stack.yaml
+++ b/roles/cloud-ec2/files/stack.yaml
@@ -25,10 +25,26 @@ Parameters:
     AllowedValues:
       - spot
       - on-demand
+  IpsecEnabled:
+    Description: Whether to open IPsec ports (500, 4500) in security group
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  WireguardEnabled:
+    Description: Whether to open WireGuard port in security group
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
 Conditions:
   AllocateNewEIP: !Equals [!Ref UseThisElasticIP, '']
   AssociateExistingEIP: !Not [!Equals [!Ref UseThisElasticIP, '']]
   InstanceIsSpot: !Equals [spot, !Ref InstanceMarketTypeParameter]
+  OpenIpsecPorts: !Equals ['true', !Ref IpsecEnabled]
+  OpenWireguardPorts: !Equals ['true', !Ref WireguardEnabled]
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -120,27 +136,49 @@ Resources:
       - Subnet
     Properties:
       VpcId: !Ref VPC
-      GroupDescription: Enable SSH and IPsec
+      GroupDescription: Algo VPN security group
       SecurityGroupIngress:
         - IpProtocol: tcp
+          Description: SSH
           FromPort: !Ref SshPort
           ToPort: !Ref SshPort
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: udp
-          FromPort: '500'
-          ToPort: '500'
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: udp
-          FromPort: '4500'
-          ToPort: '4500'
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: udp
-          FromPort: !Ref WireGuardPort
-          ToPort: !Ref WireGuardPort
           CidrIp: 0.0.0.0/0
       Tags:
         - Key: Name
           Value: !Ref AWS::StackName
+
+  SecurityGroupIngressIpsec500:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: OpenIpsecPorts
+    Properties:
+      GroupId: !Ref InstanceSecurityGroup
+      Description: IPsec IKE
+      IpProtocol: udp
+      FromPort: 500
+      ToPort: 500
+      CidrIp: 0.0.0.0/0
+
+  SecurityGroupIngressIpsec4500:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: OpenIpsecPorts
+    Properties:
+      GroupId: !Ref InstanceSecurityGroup
+      Description: IPsec NAT-T
+      IpProtocol: udp
+      FromPort: 4500
+      ToPort: 4500
+      CidrIp: 0.0.0.0/0
+
+  SecurityGroupIngressWireguard:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: OpenWireguardPorts
+    Properties:
+      GroupId: !Ref InstanceSecurityGroup
+      Description: WireGuard
+      IpProtocol: udp
+      FromPort: !Ref WireGuardPort
+      ToPort: !Ref WireGuardPort
+      CidrIp: 0.0.0.0/0
 
   EC2LaunchTemplate:
     Type: AWS::EC2::LaunchTemplate

--- a/roles/cloud-ec2/tasks/cloudformation.yml
+++ b/roles/cloud-ec2/tasks/cloudformation.yml
@@ -19,6 +19,8 @@
       UserData: "{{ lookup('template', 'files/cloud-init/base.yml') | b64encode }}"
       SshPort: "{{ ssh_port }}"
       InstanceMarketTypeParameter: "{{ cloud_providers.ec2.instance_market_type }}"
+      IpsecEnabled: "{{ ipsec_enabled | default(true) | string | lower }}"
+      WireguardEnabled: "{{ wireguard_enabled | default(true) | string | lower }}"
     tags:
       Environment: Algo
   register: stack

--- a/roles/cloud-gce/tasks/main.yml
+++ b/roles/cloud-gce/tasks/main.yml
@@ -21,16 +21,12 @@
     name: algovpn
     network: "{{ gcp_compute_network }}"
     direction: INGRESS
-    allowed:
-      - ip_protocol: udp
-        ports:
-          - "500"
-          - "4500"
-          - "{{ wireguard_port | string }}"
-      - ip_protocol: tcp
-        ports:
-          - "{{ ssh_port }}"
-      - ip_protocol: icmp
+    allowed: >-
+      {{
+        [{ 'ip_protocol': 'tcp', 'ports': [ssh_port | string] }, { 'ip_protocol': 'icmp' }]
+        + ([{ 'ip_protocol': 'udp', 'ports': ['500', '4500'] }] if ipsec_enabled | default(true) | bool else [])
+        + ([{ 'ip_protocol': 'udp', 'ports': [wireguard_port | string] }] if wireguard_enabled | default(true) | bool else [])
+      }}
 
 - block:
     - name: External IP allocated

--- a/roles/cloud-lightsail/files/stack.yaml.j2
+++ b/roles/cloud-lightsail/files/stack.yaml.j2
@@ -35,6 +35,7 @@ Resources:
             FromPort: !Ref SshPort
             ToPort: !Ref SshPort
             Protocol: tcp
+{% if wireguard_enabled | default(true) | bool %}
           - AccessDirection: inbound
             Cidrs: ['0.0.0.0/0']
             Ipv6Cidrs: ['::/0']
@@ -42,6 +43,8 @@ Resources:
             FromPort: !Ref WireGuardPort
             ToPort: !Ref WireGuardPort
             Protocol: udp
+{% endif %}
+{% if ipsec_enabled | default(true) | bool %}
           - AccessDirection: inbound
             Cidrs: ['0.0.0.0/0']
             Ipv6Cidrs: ['::/0']
@@ -56,6 +59,7 @@ Resources:
             FromPort: 500
             ToPort: 500
             Protocol: udp
+{% endif %}
       Tags:
         - Key: Name
           Value: !Ref AWS::StackName

--- a/roles/cloud-lightsail/tasks/cloudformation.yml
+++ b/roles/cloud-lightsail/tasks/cloudformation.yml
@@ -8,7 +8,7 @@
     stack_name: "{{ stack_name }}"
     state: present
     region: "{{ algo_region }}"
-    template_body: "{{ lookup('file', 'roles/cloud-lightsail/files/stack.yaml') }}"
+    template_body: "{{ lookup('template', 'files/stack.yaml.j2') }}"
     template_parameters:
       InstanceTypeParameter: "{{ cloud_providers.lightsail.size }}"
       ImageIdParameter: "{{ cloud_providers.lightsail.image }}"

--- a/roles/cloud-openstack/tasks/main.yml
+++ b/roles/cloud-openstack/tasks/main.yml
@@ -20,12 +20,24 @@
     port_range_min: "{{ item.port_min }}"
     port_range_max: "{{ item.port_max }}"
     remote_ip_prefix: "{{ item.range }}"
-  loop:
-    - { proto: tcp, port_min: "{{ ssh_port }}", port_max: "{{ ssh_port }}", range: 0.0.0.0/0 }
-    - { proto: icmp, port_min: -1, port_max: -1, range: 0.0.0.0/0 }
-    - { proto: udp, port_min: 4500, port_max: 4500, range: 0.0.0.0/0 }
-    - { proto: udp, port_min: 500, port_max: 500, range: 0.0.0.0/0 }
-    - { proto: udp, port_min: "{{ wireguard_port }}", port_max: "{{ wireguard_port }}", range: 0.0.0.0/0 }
+  loop: >-
+    {{
+      [
+        { 'proto': 'tcp', 'port_min': ssh_port, 'port_max': ssh_port, 'range': '0.0.0.0/0' },
+        { 'proto': 'icmp', 'port_min': -1, 'port_max': -1, 'range': '0.0.0.0/0' }
+      ]
+      + (
+        [
+          { 'proto': 'udp', 'port_min': 500, 'port_max': 500, 'range': '0.0.0.0/0' },
+          { 'proto': 'udp', 'port_min': 4500, 'port_max': 4500, 'range': '0.0.0.0/0' }
+        ] if ipsec_enabled | default(true) | bool else []
+      )
+      + (
+        [
+          { 'proto': 'udp', 'port_min': wireguard_port, 'port_max': wireguard_port, 'range': '0.0.0.0/0' }
+        ] if wireguard_enabled | default(true) | bool else []
+      )
+    }}
 
 - name: Gather facts about flavors
   openstack.cloud.compute_flavor_info:

--- a/roles/cloud-vultr/tasks/main.yml
+++ b/roles/cloud-vultr/tasks/main.yml
@@ -19,15 +19,27 @@
         ip_type: "{{ item.ip }}"
         subnet: "{{ item.cidr.split('/')[0] }}"
         subnet_size: "{{ item.cidr.split('/')[1] }}"
-      loop:
-        - { protocol: tcp, port: "{{ ssh_port }}", ip: v4, cidr: 0.0.0.0/0 }
-        - { protocol: tcp, port: "{{ ssh_port }}", ip: v6, cidr: "::/0" }
-        - { protocol: udp, port: 500, ip: v4, cidr: 0.0.0.0/0 }
-        - { protocol: udp, port: 500, ip: v6, cidr: "::/0" }
-        - { protocol: udp, port: 4500, ip: v4, cidr: 0.0.0.0/0 }
-        - { protocol: udp, port: 4500, ip: v6, cidr: "::/0" }
-        - { protocol: udp, port: "{{ wireguard_port }}", ip: v4, cidr: 0.0.0.0/0 }
-        - { protocol: udp, port: "{{ wireguard_port }}", ip: v6, cidr: "::/0" }
+      loop: >-
+        {{
+          [
+            { 'protocol': 'tcp', 'port': ssh_port, 'ip': 'v4', 'cidr': '0.0.0.0/0' },
+            { 'protocol': 'tcp', 'port': ssh_port, 'ip': 'v6', 'cidr': '::/0' }
+          ]
+          + (
+            [
+              { 'protocol': 'udp', 'port': 500, 'ip': 'v4', 'cidr': '0.0.0.0/0' },
+              { 'protocol': 'udp', 'port': 500, 'ip': 'v6', 'cidr': '::/0' },
+              { 'protocol': 'udp', 'port': 4500, 'ip': 'v4', 'cidr': '0.0.0.0/0' },
+              { 'protocol': 'udp', 'port': 4500, 'ip': 'v6', 'cidr': '::/0' }
+            ] if ipsec_enabled | default(true) | bool else []
+          )
+          + (
+            [
+              { 'protocol': 'udp', 'port': wireguard_port, 'ip': 'v4', 'cidr': '0.0.0.0/0' },
+              { 'protocol': 'udp', 'port': wireguard_port, 'ip': 'v6', 'cidr': '::/0' }
+            ] if wireguard_enabled | default(true) | bool else []
+          )
+        }}
 
     - name: Upload the startup script
       vultr.cloud.startup_script:


### PR DESCRIPTION
## Summary

When `ipsec_enabled` or `wireguard_enabled` is `false`, don't open those ports in cloud provider security groups/firewalls. Previously, ports 500, 4500, and the WireGuard port were always opened regardless of which VPN protocols were actually enabled.

This follows the principle of least privilege - only open ports for services that are actually running.

## Changes by Provider

| Provider | Approach |
|----------|----------|
| EC2 | CloudFormation conditions for conditional SecurityGroupIngress resources |
| Lightsail | Convert to Jinja2 template with conditional port blocks |
| Azure | Convert to Jinja2 template with conditional security rules |
| Vultr | Build firewall rules list conditionally using Jinja2 |
| GCE | Build allowed list conditionally using Jinja2 |
| OpenStack | Build security rules list conditionally using Jinja2 |
| CloudStack | Build security rules list conditionally using Jinja2 |

## Notes

- The instance-level iptables firewall already blocked unused ports, so this change improves security posture at the cloud provider level
- Default behavior unchanged - both protocols enabled by default
- Based on approach proposed by @glennschler in the original issue

Fixes #14293

## Test plan

- [ ] Deploy to EC2 with `ipsec_enabled: false` - verify ports 500/4500 not in security group
- [ ] Deploy to EC2 with `wireguard_enabled: false` - verify WireGuard port not in security group
- [ ] Deploy with both enabled (default) - verify all ports present
- [ ] Test at least one other provider (Vultr, GCE, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)