### PR TITLE
Add AF_UNIX to SystemD RestrictAddressFamilies for future VICI support

### DIFF
--- a/roles/strongswan/templates/100-CustomLimitations.conf.j2
+++ b/roles/strongswan/templates/100-CustomLimitations.conf.j2
@@ -11,7 +11,8 @@ ProtectKernelTunables=yes
 ProtectControlGroups=yes
 
 # Network restrictions - include IPsec kernel communication requirements
-RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_PACKET
+# AF_UNIX required for VICI socket communication (swanctl/modern StrongSwan interface)
+RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_PACKET AF_UNIX
 
 # Allow access to IPsec configuration, state, and kernel interfaces
 ReadWritePaths=/etc/ipsec.d /var/lib/strongswan


### PR DESCRIPTION
## Summary

- Add `AF_UNIX` to SystemD `RestrictAddressFamilies` for StrongSwan service hardening
- Preparatory work for #14810 (stroke to swanctl migration)

## Context

StrongSwan's stroke interface is [officially deprecated](https://docs.strongswan.org/docs/latest/howtos/introduction.html) in favor of the modern VICI/swanctl interface. [StrongSwan 6.0.0](https://strongswan.org/blog/2024/12/03/strongswan-6.0.0-released.html) (released December 2024) no longer builds stroke by default.

After thorough research (see [comment on #14810](https://github.com/trailofbits/algo/issues/14810#issuecomment-3590690056)), full migration is deferred due to:
- High complexity (35+ files, different defaults, certificate path changes)
- Ubuntu 24.04 works fine with current stroke interface
- Ubuntu 26.04 is 18 months away

This PR makes a single, zero-risk preparatory change.

## Changes

```diff
# roles/strongswan/templates/100-CustomLimitations.conf.j2
-RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_PACKET
+# AF_UNIX required for VICI socket communication (swanctl/modern StrongSwan interface)
+RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_PACKET AF_UNIX
```

## Why AF_UNIX?

The VICI interface uses a UNIX domain socket (`/var/run/charon.vici`) for communication between swanctl and the charon daemon. Without `AF_UNIX` in SystemD's `RestrictAddressFamilies`, any future swanctl commands would fail.

## Test plan

- [ ] Verify StrongSwan service starts normally on Ubuntu 24.04
- [ ] Verify existing IPsec connections work unchanged
- [ ] Verify `ipsec statusall` still functions (stroke interface unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)