### PR TITLE
Reduce friction for bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,32 +1,15 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-
+about: Report a problem with Algo
 ---
 
-**Describe the bug**
+**What happened?**
 
-A clear and concise description of what the bug is.
 
-**To Reproduce**
+**Environment** (cloud provider, OS, WireGuard or IPsec)
 
-Steps to reproduce the behavior:
-1. Do this..
-2. Do that..
-3. ..
 
-**Expected behavior**
-
-A clear and concise description of what you expected to happen.
-
-**Additional context**
-
-Add any other context about the problem here.
-
-**Full log**
-
-<!--- Put here the FULL LOG after you run the ./algo script below -->
-
+**Output**
 ```
-PUT THE OUTPUT HERE
+Paste any error messages or relevant output here
 ```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+---
+blank_issues_enabled: true
+contact_links:
+  - name: Troubleshooting Guide
+    url: https://trailofbits.github.io/algo/troubleshooting.html
+    about: Check common issues and solutions before filing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ### Filing New Issues
 
-* Check that your issue is not already described in the [FAQ](docs/faq.md), [troubleshooting](docs/troubleshooting.md) docs, or an [existing issue](https://github.com/trailofbits/algo/issues)
+* We welcome bug reports! Before filing, a quick check of the [FAQ](docs/faq.md) or [troubleshooting](docs/troubleshooting.md) docs might have your answer
 * Algo automatically installs dependencies with uv - no manual setup required
 * We support modern clients: macOS 12+, iOS 15+, Windows 11+, Ubuntu 22.04+, etc.
 * Supported cloud providers: DigitalOcean, AWS, Azure, GCP, Vultr, Hetzner, Linode, OpenStack, CloudStack

--- a/config.cfg
+++ b/config.cfg
@@ -201,8 +201,9 @@ cloud_providers:
 
 fail_hint:
   - Sorry, but something went wrong!
-  - Please check the troubleshooting guide.
+  - Check troubleshooting for common fixes, or file an issue if you found a bug.
   - https://trailofbits.github.io/algo/troubleshooting.html
+  - https://github.com/trailofbits/algo/issues/new
 
 booleans_map:
   Y: true

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -517,4 +517,4 @@ Get-WinEvent -LogName "Microsoft-Windows-VPN-Client/Operational" -MaxEvents 50
 
 ## I have a problem not covered here
 
-If you have an issue that you cannot solve with the guidance here, [create a new discussion](https://github.com/trailofbits/algo/discussions) and ask for help. If you think you found a new issue in Algo, [file an issue](https://github.com/trailofbits/algo/issues/new).
+If you have an issue that you cannot solve with the guidance here, please [file an issue](https://github.com/trailofbits/algo/issues/new). We welcome bug reports and want to hear about problems you encounter.


### PR DESCRIPTION
## Summary

- Balance error message to present troubleshooting and issue filing equally
- Remove dead GitHub Discussions link (feature was disabled)
- Simplify bug report template from 6 sections to 3
- Add troubleshooting link to issue template chooser

## Changes

| File | Change |
|------|--------|
| `config.cfg` | Error now says "Check troubleshooting for common fixes, or file an issue if you found a bug" |
| `docs/troubleshooting.md` | Removed Discussions link, simplified to just "please file an issue" |
| `.github/ISSUE_TEMPLATE/bug_report.md` | Reduced from 6 sections to 3: What happened? / Environment / Output |
| `.github/ISSUE_TEMPLATE/config.yml` | New file - adds troubleshooting link to issue chooser |
| `CONTRIBUTING.md` | Leads with "We welcome bug reports!" |

## Test plan

- [ ] Verify error message displays correctly when deployment fails
- [ ] Check issue template renders correctly on GitHub
- [ ] Confirm troubleshooting link appears in issue chooser

🤖 Generated with [Claude Code](https://claude.com/claude-code)