### PR TITLE
Auto-install Ansible Galaxy collections before deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ RUN uv sync --locked --no-dev
 # Copy application code
 COPY . .
 
+# Install Ansible Galaxy collections for cloud provider modules
+RUN uv run ansible-galaxy collection install -r requirements.yml
+
 # Set executable permissions and prepare runtime
 # Note: /algo must remain root-owned for --cap-drop=all compatibility
 # (root without CAP_DAC_OVERRIDE cannot write to files owned by others)

--- a/algo
+++ b/algo
@@ -152,6 +152,12 @@ if ! command -v uv &> /dev/null; then
     echo "✓ uv installed successfully via ${UV_INSTALL_METHOD}!"
 fi
 
+# Install Ansible Galaxy collections if requirements.yml exists
+# This is needed for cloud providers that use collection modules (Linode, DigitalOcean, Azure, etc.)
+if [ -f "requirements.yml" ]; then
+    uv run ansible-galaxy collection install -r requirements.yml > /dev/null 2>&1 || true
+fi
+
 # Run the appropriate playbook
 case "$1" in
   update-users)


### PR DESCRIPTION
## Summary

- Auto-install Ansible Galaxy collections in `algo` script before running playbooks
- Add collection installation to Dockerfile at build time

## Problem

After PR #14908 migrated cloud providers to Ansible collections (Linode, DigitalOcean, Azure), users running `./algo` get errors like:

```
[WARNING]: Error loading plugin 'linode.cloud.stackscript': No module named 'ansible_collections.linode'
[ERROR]: couldn't resolve module/action 'linode.cloud.stackscript'
```

The `requirements.yml` declares the collections, but nothing in the automated workflow actually installs them.

## Solution

Add `ansible-galaxy collection install -r requirements.yml` in two places:

1. **`algo` script** - Runs silently before playbook execution, ensuring collections are available for all cloud providers
2. **`Dockerfile`** - Bakes collections into the image at build time for faster container startup

## Test plan

- [x] `shellcheck algo` - Passed
- [x] `ansible-playbook main.yml --syntax-check` - Passed
- [x] Pre-commit hooks - All passed
- [ ] Manual test: Fresh clone + `./algo` with Linode provider

Fixes #14923

🤖 Generated with [Claude Code](https://claude.com/claude-code)