### PR TITLE
Add cooldown and grouping to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Maintain dependencies for Python using uv
   # Using "uv" ecosystem ensures both pyproject.toml AND uv.lock are updated together
@@ -13,4 +19,18 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      python:
+        patterns:
+          - "*"
+
+  # Maintain Docker base image (python:3.12-alpine)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- Add 7-day cooldown to protect against supply chain attacks
- Group updates by ecosystem to reduce PR noise  
- Change schedule from daily to weekly
- Add Docker ecosystem for base image updates

A 7-day cooldown blocks ~80% of supply chain attacks by giving time for malicious packages to be detected and removed before they're automatically merged.

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Confirm Dependabot picks up the new config after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)