### PR TITLE
fix(aip): correct assertion for SNAT IPv4 address validation

### DIFF
--- a/roles/common/tasks/aip/main.yml
+++ b/roles/common/tasks/aip/main.yml
@@ -11,5 +11,5 @@
 
 - name: Verify SNAT IPv4 found
   assert:
-    that: snat_aipv4 | ansible.utils.ipv4
+    that: snat_aipv4 | trim is ansible.utils.ipv4_address
     msg: The SNAT IPv4 address not found. Cannot proceed with the alternative ingress ip.


### PR DESCRIPTION
## Description
Ensure the SNAT IPv4 validation uses a boolean test so `assert` no longer fails on a string result.

## Motivation and Context
Fixes #14948. The assertion was using a filter that returns a string, which caused Ansible to error when evaluating the condition.

## How Has This Been Tested?
I ran it and it didn't crash.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code passes all linters (`./scripts/lint.sh`)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Dependencies use exact versions (e.g., `==1.2.3` not `>=1.2.0`).