### PR TITLE
Fix AIP boolean assertion for Ansible 12 jinja2_native mode

### DIFF
--- a/roles/common/tasks/aip/main.yml
+++ b/roles/common/tasks/aip/main.yml
@@ -11,5 +11,5 @@
 
 - name: Verify SNAT IPv4 found
   assert:
-    that: snat_aipv4 | ansible.utils.ipv4
+    that: (snat_aipv4 | ansible.utils.ipv4) | bool
     msg: The SNAT IPv4 address not found. Cannot proceed with the alternative ingress ip.


### PR DESCRIPTION
## Summary

- Fix `assert.that` clause in AIP task that fails with Ansible 12+ due to `jinja2_native` mode
- The `ansible.utils.ipv4` filter returns the IP string (not a boolean), which causes "Conditional result was derived from value of type 'str'" error
- Add `| bool` filter to convert the truthy string to a proper boolean

Fixes #14948

## Test plan

- [x] `ansible-playbook main.yml --syntax-check` passes
- [x] `ansible-lint roles/common/tasks/aip/main.yml` passes (0 failures, 0 warnings)
- [x] `pytest tests/unit/ -q` passes (91 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)