### PR TITLE
docs: add tests vs filters pattern for boolean checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,15 @@ servers: "{{ servers | default([]) + [item.name] }}"
 loop: "{{ configs }}"
 ```
 
+**Use tests (not filters) for boolean checks:**
+```yaml
+# WRONG - filters return transformed data, not booleans
+that: my_ip | ansible.utils.ipv4
+
+# CORRECT - tests return native booleans
+that: my_ip is ansible.utils.ipv4_address
+```
+
 ## DNS Architecture
 
 Algo uses a randomly generated IP in 172.16.0.0/12 on the loopback interface (`local_service_ip`) for DNS. This provides consistency across WireGuard and IPsec but requires understanding systemd socket activation.


### PR DESCRIPTION
## Summary

- Document that Ansible tests (`is X`) return native booleans while filters (`| X`) return transformed data
- Use tests in `assert.that` and `when:` clauses where booleans are required

Lesson learned from reviewing #14949 which fixed #14948.

## Test plan

- [x] Documentation only, no code changes

🤖 Generated with [Claude Code](https://claude.ai/code)