### PR TITLE
fix(ec2): change default instance type from t2.micro to t3.micro

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -162,7 +162,7 @@ cloud_providers:
     # Set use_existing_eip to "true" if you want to use a pre-allocated Elastic IP
     # Additional prompt will be raised to determine which IP to use
     use_existing_eip: false
-    size: t2.micro
+    size: t3.micro
     image:
       name: "ubuntu-jammy-22.04"
       arch: x86_64

--- a/docs/cloud-amazon-ec2.md
+++ b/docs/cloud-amazon-ec2.md
@@ -16,7 +16,7 @@ The most cost-effective option for new AWS customers is the [AWS Free Tier](http
 - 100 GB of outbound data transfer per month
 - 30 GB of cloud storage
 
-The Free Tier is available for 12 months from account creation. Some regions like Middle East (Bahrain) and EU (Stockholm) don't offer t2.micro instances, but t3.micro is available as an alternative.
+The Free Tier is available for 12 months from account creation. Some regions like Middle East (Bahrain), EU (Stockholm), and Israel (il-central-1) don't offer t2.micro instances, but t3.micro is available as an alternative.
 
 Note that your Algo instance will continue working if you exceed bandwidth limits - you'll just start accruing standard charges on your AWS account.
 

--- a/docs/deploy-from-ansible.md
+++ b/docs/deploy-from-ansible.md
@@ -111,7 +111,7 @@ Possible options can be gathered via cli `aws ec2 describe-regions`
 Additional variables:
 
 - [encrypted](https://aws.amazon.com/blogs/aws/new-encrypted-ebs-boot-volumes/) - Encrypted EBS boot volume. Boolean (Default: true)
-- [size](https://aws.amazon.com/ec2/instance-types/) - EC2 instance type. String (Default: t2.micro)
+- [size](https://aws.amazon.com/ec2/instance-types/) - EC2 instance type. String (Default: t3.micro)
 - [image](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-images.html) - AMI `describe-images` search parameters to find the OS for the hosted image. Each OS and architecture has a unique AMI-ID. The OS owner, for example, [Ubuntu](https://cloud-images.ubuntu.com/locator/ec2/), updates these images often. If parameters below result in multiple results, the most recent AMI-ID is chosen
 
    ```

--- a/roles/cloud-ec2/files/stack.yaml
+++ b/roles/cloud-ec2/files/stack.yaml
@@ -4,7 +4,7 @@ Description: 'Algo VPN stack'
 Parameters:
   InstanceTypeParameter:
     Type: String
-    Default: t2.micro
+    Default: t3.micro
   ImageIdParameter:
     Type: AWS::EC2::Image::Id
   WireGuardPort:


### PR DESCRIPTION
## Summary

- Changes AWS EC2 default instance type from `t2.micro` to `t3.micro`
- Updates documentation to reflect the new default and add il-central-1 to affected regions list

## Context

The T2 instance family is legacy and AWS is not adding it to newer regions. This causes deployment failures in regions like il-central-1 (Israel) with the error "The requested configuration is currently not supported".

T3 instances are:
- Available in all AWS regions
- Better price/performance than T2
- Still covered under the AWS Free Tier

## Test plan

- [ ] Verify `ansible-lint` and `yamllint` pass (done locally)
- [ ] Test deployment in il-central-1 region

Fixes #14947

🤖 Generated with [Claude Code](https://claude.com/claude-code)