### PR TITLE
security: remove unused sshpubkeys dependency (CVE-2024-23342)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ openstack = [
 ]
 cloudstack = [
     "cs>=3.0.0",
-    "sshpubkeys>=3.3.1",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,6 @@ azure = [
 ]
 cloudstack = [
     { name = "cs" },
-    { name = "sshpubkeys" },
 ]
 gcp = [
     { name = "google-auth" },
@@ -90,7 +89,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", marker = "extra == 'gcp'", specifier = ">=2.31.0" },
     { name = "segno", specifier = ">=1.6.0" },
-    { name = "sshpubkeys", marker = "extra == 'cloudstack'", specifier = ">=3.3.1" },
 ]
 provides-extras = ["aws", "azure", "gcp", "hetzner", "linode", "openstack", "cloudstack"]
 
@@ -594,18 +592,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/07/2257f13f9cd77e71f62076d220b7b59e1f11a70b90eb1e3ef8bdf0f14b34/dogpile_cache-1.4.0.tar.gz", hash = "sha256:b00a9e2f409cf9bf48c2e7a3e3e68dac5fa75913acbf1a62f827c812d35f3d09", size = 937468, upload-time = "2025-04-26T17:44:30.768Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/91/6191ee1b821a03ed2487f234b11c58b0390c305452cf31e1e33b4a53064d/dogpile_cache-1.4.0-py3-none-any.whl", hash = "sha256:f1581953afefd5f55743178694bf3b3ffb2782bba3d9537566a09db6daa48a63", size = 62881, upload-time = "2025-04-26T17:45:44.804Z" },
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
 ]
 
 [[package]]
@@ -1486,19 +1472,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "sshpubkeys"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "ecdsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/b9/e5b76b4089007dcbe9a7e71b1976d3c0f27e7110a95a13daf9620856c220/sshpubkeys-3.3.1.tar.gz", hash = "sha256:3020ed4f8c846849299370fbe98ff4157b0ccc1accec105e07cfa9ae4bb55064", size = 59210, upload-time = "2021-02-04T12:24:32.101Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/76/bc71db2f6830196554e5a197331ad668c049a12fb331075f4f579ff73cb4/sshpubkeys-3.3.1-py2.py3-none-any.whl", hash = "sha256:946f76b8fe86704b0e7c56a00d80294e39bc2305999844f079a217885060b1ac", size = 10472, upload-time = "2021-02-04T12:24:30.533Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Remove unused `sshpubkeys` from cloudstack extras, eliminating vulnerable `python-ecdsa` transitive dependency

## Problem

**CVE-2024-23342**: High severity Minerva timing attack on python-ecdsa affecting P-256 curve operations. No fix planned - ecdsa maintainers consider side-channel attacks out of scope.

Dependency chain:
```
algo [cloudstack extra]
  └── sshpubkeys >= 3.3.1
        └── ecdsa >= 0.13  ← VULNERABLE (all versions)
```

## Solution

The `sshpubkeys` package was declared as a CloudStack dependency but is **never actually imported or used** anywhere in the Algo codebase. The CloudStack role uses Ansible collection modules (`cs_securitygroup`, `cs_instance`), not this Python package.

Removing it eliminates the vulnerability with zero functional impact.

## Verification

```bash
grep ecdsa uv.lock           # Returns nothing - ecdsa removed
uv run --with pip-audit pip-audit  # No known vulnerabilities found
pytest tests/unit/ -q        # All 91 tests pass
```

## Test plan

- [x] Verify `ecdsa` no longer appears in `uv.lock`
- [x] Run `pip-audit` - passes with no vulnerabilities
- [x] Unit tests pass
- [ ] Dependabot alert #9 auto-closes after merge

Closes Dependabot alert #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)