### PR TITLE
Add vultr.cloud dependency to fix Vultr deploys

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -17,4 +17,4 @@ collections:
   - name: azure.azcollection
     version: ">=3.0.0"
   - name: vultr.cloud
-    version: ">=1.14.0"
+    version: "==1.14.0"

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,3 +16,5 @@ collections:
     version: ">=1.26.0"
   - name: azure.azcollection
     version: ">=3.0.0"
+  - name: vultr.cloud
+    version: ">=1.14.0"


### PR DESCRIPTION
## Description
Deploys to Vultr currently fail with a serialization error from an outdated upstream package (it tries to JSON serialize bytes). Pinning the latest package fixes the issue.

The current state of the repo throws this error when deploying to Vultr:

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Module failed: Object of type 'bytes' is not JSON serializable by the 'tagless' profile."}
```

## Motivation and Context
This issue is mentioned in an older Algo PR (https://github.com/trailofbits/algo/pull/14853):

**IMPORTANT**: There is a bug in `vultr.cloud` collection v1.13.0 that prevents this from working completely.

The module's `configure()` method calls:
```python
self.module.params["script"] = base64.b64encode(self.module.params["script"].encode())
```

The `base64.b64encode()` returns **bytes**, which cannot be JSON serialized. It should be:
```python
self.module.params["script"] = base64.b64encode(self.module.params["script"].encode()).decode('ascii')
```

A relevant fix has landed in the latest upstream package.

## How Has This Been Tested?
Running `./algo` with a Vultr deploy fails, then applying this patch makes it succeed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code passes all linters (`./scripts/lint.sh`)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Dependencies use exact versions (e.g., `==1.2.3` not `>=1.2.0`).
