### PR TITLE
Declare missing cloud collections in requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -18,3 +18,11 @@ collections:
     version: ">=3.0.0"
   - name: vultr.cloud
     version: "==1.14.0"
+  - name: amazon.aws
+    version: "==10.3.1"
+  - name: google.cloud
+    version: "==1.13.0"
+  - name: hetzner.hcloud
+    version: "==6.9.0"
+  - name: ngine_io.cloudstack
+    version: "==3.0.0"


### PR DESCRIPTION
## Summary

Four cloud roles use modules from collections that were not declared in `requirements.yml`. Deploys to these providers worked only when the collections happened to be installed from another source. On a fresh install via `ansible-galaxy install -r requirements.yml`, the roles would fail at runtime with module-not-found errors.

| Role | Modules used | Collection added |
|------|--------------|------------------|
| `cloud-ec2`, `cloud-lightsail` | `cloudformation`, `ec2_ami_info` | `amazon.aws==10.3.1` |
| `cloud-gce` | `gcp_compute_network`, `gcp_compute_firewall`, `gcp_compute_address`, `gcp_compute_instance` | `google.cloud==1.13.0` |
| `cloud-hetzner` | `hetzner.hcloud.server`, `hetzner.hcloud.ssh_key` | `hetzner.hcloud==6.9.0` |
| `cloud-cloudstack` | `cs_instance`, `cs_securitygroup`, `cs_securitygroup_rule` | `ngine_io.cloudstack==3.0.0` |

This is the same bug class as #14999, which fixed it for `vultr.cloud`.

Versions chosen are the latest stable releases. All four were verified safe for this project's runtime (Python 3.11, ansible-core 2.18+):

- `amazon.aws 10.x` drops Python <3.8 / ansible-core <2.17 — fine. Removed env vars (`EC2_ACCESS_KEY` etc.) — algo uses `AWS_ACCESS_KEY_ID`.
- `hetzner.hcloud 6.x` drops Python 3.9 / ansible-core 2.17 — fine.
- `google.cloud 1.13.0` is a minor bump.
- `ngine_io.cloudstack 3.0.0` release notes state "your playbooks should not break."

`==` matches the pattern from #14999 and CLAUDE.md's "pin exact versions" rule.

## Test plan

- [x] `uv run yamllint requirements.yml` passes
- [x] `uv run ansible-lint requirements.yml` passes (`0 failure(s), 0 warning(s)`)
- [x] `uv run ansible-galaxy install -r requirements.yml` resolves and installs all four new collections at the pinned versions
- [x] `uv run ansible-playbook main.yml --syntax-check` passes
- [ ] Deploy verification on each provider (EC2, GCE, Hetzner, CloudStack) — out of scope here; this PR only declares the dependency, it does not change deploy behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)