### PR TITLE
Add grouped updates to dependabot docker ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,7 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
The `docker` ecosystem entry in `.github/dependabot.yml` was the only one missing a `groups:` block, so Docker base-image updates came as ungrouped individual PRs while `github-actions` and `uv` used grouped PRs. This adds a matching `docker` group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)