### PR TITLE
fix: resolve QR code generation silently failing after uv migration

### DIFF
--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -61,9 +61,9 @@
         - name: Generate QR codes
           shell: >
             umask 077;
-            which segno &&
-            segno --scale=5 --output={{ item }}.png \
-              "{{ lookup('template', 'client.conf.j2') }}" || true
+            {{ ansible_playbook_python | dirname }}/segno
+            --scale=5 --output={{ item }}.png
+            "{{ lookup('template', 'client.conf.j2') }}"
           changed_when: false
           loop: "{{ wireguard_users }}"
           loop_control:


### PR DESCRIPTION
## Description

Replace `which segno && segno ... || true` with a direct path via
`{{ ansible_playbook_python | dirname }}/segno`, resolving the binary
from the same venv that Ansible is running in.

## Motivation and Context

The QR code task uses `which segno && segno ... || true`, which relies on
the venv `bin/` being on PATH. This works when running via `./algo` or
`uv run ansible-playbook`, but silently produces no QR codes when Ansible
is invoked outside the project venv (e.g., system ansible or
`uv tool run --from ansible-core`).

This is the only task in the playbooks that uses `which` to locate a
venv-installed binary — everything else goes through Python imports via
`ansible_python_interpreter`, which is why nothing else breaks outside
the venv.

Using `{{ ansible_playbook_python | dirname }}/segno` resolves the binary
directly from the venv, removing the PATH dependency. `|| true` is also
removed — segno is a declared dependency in `pyproject.toml`, so a failure
should be surfaced, not swallowed.

## How Has This Been Tested?

- Verified `segno` generates valid PNGs when invoked via the `dirname` path
  approach, including with multiline WireGuard config content
- Linting passes (`ansible-lint`, `yamllint`)
- Not tested with a full deployment — would appreciate a deploy test from
  a maintainer before merging

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] My code passes all linters (`./scripts/lint.sh`)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Dependencies use exact versions (e.g., `==1.2.3` not `>=1.2.0`).