### PR TITLE
fix(scaleway): migrate to Marketplace API v2 after api-marketplace.scaleway.com removal

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -180,6 +180,7 @@ cloud_providers:
   scaleway:
     size: DEV1-S
     image: Ubuntu 22.04 Jammy Jellyfish
+    image_label: ubuntu_jammy
     arch: x86_64
   hetzner:
     server_type: cpx22

--- a/library/scaleway_compute.py
+++ b/library/scaleway_compute.py
@@ -167,19 +167,6 @@ SCALEWAY_SERVER_STATES = ("stopped", "stopping", "starting", "running", "locked"
 SCALEWAY_TRANSITIONS_STATES = ("stopping", "starting", "pending")
 
 
-def check_image_id(compute_api, image_id):
-    response = compute_api.get(path="images")
-
-    if response.ok and response.json:
-        image_ids = [image["id"] for image in response.json["images"]]
-        if image_id not in image_ids:
-            compute_api.module.fail_json(
-                msg="Error in getting image %s on %s" % (image_id, compute_api.module.params.get("api_url"))
-            )
-    else:
-        compute_api.module.fail_json(msg="Error in getting images from: %s" % compute_api.module.params.get("api_url"))
-
-
 def fetch_state(compute_api, server):
     compute_api.module.debug("fetch_state of server: %s" % server["id"])
     response = compute_api.get(path="servers/%s" % server["id"])
@@ -633,9 +620,6 @@ def core(module):
     module.params["api_url"] = SCALEWAY_LOCATION[region]["api_endpoint"]
 
     compute_api = Scaleway(module=module)
-
-    if wished_server["state"] != "absent":
-        check_image_id(compute_api, wished_server["image"])
 
     # IP parameters of the wished server depends on the configuration
     ip_payload = public_ip_payload(compute_api=compute_api, public_ip=module.params["public_ip"])

--- a/roles/cloud-scaleway/defaults/main.yml
+++ b/roles/cloud-scaleway/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
 scaleway_regions:
   - alias: par1
+    zone: fr-par-1
   - alias: ams1
+    zone: nl-ams-1

--- a/roles/cloud-scaleway/tasks/main.yml
+++ b/roles/cloud-scaleway/tasks/main.yml
@@ -33,7 +33,7 @@
         boot_type: local
         state: present
         image: "{{ scaleway_image_id }}"
-        project: "{{ algo_scaleway_org_id }}"
+        organization: "{{ algo_scaleway_org_id }}"
         region: "{{ algo_region }}"
         commercial_type: "{{ cloud_providers.scaleway.size }}"
         wait: true
@@ -60,7 +60,7 @@
         boot_type: local
         state: running
         image: "{{ scaleway_image_id }}"
-        project: "{{ algo_scaleway_org_id }}"
+        organization: "{{ algo_scaleway_org_id }}"
         region: "{{ algo_region }}"
         commercial_type: "{{ cloud_providers.scaleway.size }}"
         wait: true
@@ -68,7 +68,7 @@
           - Environment:Algo
           - AUTHORIZED_KEY={{ lookup('file', SSH_keys.public) | regex_replace(' ', '_') }}
       register: algo_instance
-      until: algo_instance.msg.public_ip
+      until: algo_instance.msg.public_ip is not none
       retries: 3
       delay: 3
 

--- a/roles/cloud-scaleway/tasks/main.yml
+++ b/roles/cloud-scaleway/tasks/main.yml
@@ -5,21 +5,25 @@
 - environment:
     SCW_TOKEN: "{{ algo_scaleway_token }}"
   block:
-    - name: Get Ubuntu 22.04 image ID from Scaleway Marketplace API
+    - name: Set Scaleway API zone name
+      set_fact:
+        scaleway_zone: >-
+          {{ scaleway_regions | selectattr('alias', 'equalto', algo_region) | map(attribute='zone') | first }}
+
+    - name: Get Ubuntu image ID from Scaleway Marketplace API
       uri:
-        url: "https://api-marketplace.scaleway.com/images?arch={{ cloud_providers.scaleway.arch }}&include_eol=false"
+        url: "https://api.scaleway.com/marketplace/v2/local-images?image_label={{ cloud_providers.scaleway.image_label }}&zone={{ scaleway_zone }}"
         method: GET
         return_content: true
       register: marketplace_images
 
-    - name: Find Ubuntu 22.04 Jammy image
+    - name: Find Ubuntu local image ID
       set_fact:
         scaleway_image_id: >-
-          {{ (marketplace_images.json.images |
-              selectattr('name', 'match', '.*Ubuntu.*22\\.04.*Jammy.*') |
-              first).versions[0].local_images |
-              selectattr('zone', 'equalto', algo_region) |
-              map(attribute='id') | first }}
+          {{ (marketplace_images.json.local_images |
+              selectattr('arch', 'equalto', cloud_providers.scaleway.arch) |
+              selectattr('type', 'equalto', 'instance_local') |
+              first).id }}
 
     - name: Create a server
       scaleway_compute:

--- a/roles/cloud-scaleway/tasks/prompts.yml
+++ b/roles/cloud-scaleway/tasks/prompts.yml
@@ -13,11 +13,11 @@
     prompt: |
       What region should the server be located in?
         {% for r in scaleway_regions %}
-        {{ loop.index }}. {{ r['alias'] }}
+        {{ loop.index }}. {{ r['zone'] }}
         {% endfor %}
 
       Enter the number of your desired region
-      [{{ scaleway_regions.0.alias }}]
+      [{{ scaleway_regions.0.zone }}]
   register: _algo_region
   when: region is undefined
 
@@ -39,8 +39,12 @@
   set_fact:
     algo_scaleway_token: "{{ scaleway_token | default(_scaleway_token.user_input) | default(lookup('env', 'SCW_TOKEN'), true) }}"
     algo_region: >-
-      {% if region is defined %}{{ region }}
-      {%- elif _algo_region.user_input %}{{ scaleway_regions[_algo_region.user_input | int - 1]['alias'] }}
-      {%- else %}{{ scaleway_regions.0.alias }}{% endif %}
+      {%- if region is defined -%}
+        {{ scaleway_regions | selectattr('zone', 'equalto', region) | map(attribute='alias') | first | default(region) }}
+      {%- elif _algo_region.user_input -%}
+        {{ scaleway_regions[_algo_region.user_input | int - 1]['alias'] }}
+      {%- else -%}
+        {{ scaleway_regions.0.alias }}
+      {%- endif -%}
     algo_scaleway_org_id: "{{ scaleway_org_id | default(_scaleway_org_id.user_input) | default(lookup('env', 'SCW_DEFAULT_ORGANIZATION_ID'), true) }}"
   no_log: true

--- a/tests/unit/test_scaleway_fix.py
+++ b/tests/unit/test_scaleway_fix.py
@@ -20,34 +20,21 @@ def load_yaml_file(file_path):
         return yaml.safe_load(f)
 
 
-def test_scaleway_main_uses_project_parameter():
-    """Test that main.yml uses 'project' instead of deprecated 'organization' parameter"""
+def test_scaleway_main_uses_organization_parameter():
+    """Test that main.yml uses 'organization' parameter (custom module, not community.general)"""
     main_yml = Path("roles/cloud-scaleway/tasks/main.yml")
     assert main_yml.exists(), "Scaleway main.yml not found"
 
     with open(main_yml) as f:
         content = f.read()
 
-    # Should NOT use the broken scaleway_organization_info module
-    assert "scaleway_organization_info" not in content, (
-        "Still using broken scaleway_organization_info module (issue #14846)"
-    )
-
-    # Should NOT use the broken scaleway_image_info module
+    assert "scaleway_organization_info" not in content, "Still using broken scaleway_organization_info module"
     assert "scaleway_image_info" not in content, "Still using broken scaleway_image_info module"
-
-    # Should use project parameter (modern approach)
-    assert "project:" in content, "Missing 'project:' parameter in scaleway_compute calls"
+    assert "organization:" in content, "Missing 'organization:' parameter in scaleway_compute calls"
     assert "algo_scaleway_org_id" in content, "Missing algo_scaleway_org_id variable reference"
+    assert "project:" not in content, "Using unsupported 'project' parameter (not in custom module)"
 
-    # Should NOT use deprecated organization parameter
-    assert 'organization: "{{' not in content, "Still using deprecated 'organization' parameter"
-
-    # Should use Marketplace API v2 for image lookup
-    assert "api.scaleway.com/marketplace/v2" in content, "Not using Scaleway Marketplace API v2 for image lookup"
-    assert "api-marketplace.scaleway.com" not in content, "Still using deprecated api-marketplace.scaleway.com domain"
-
-    print("✓ Scaleway main.yml uses modern 'project' parameter")
+    print("✓ Scaleway main.yml uses 'organization' parameter")
 
 
 def test_scaleway_prompts_collect_org_id():
@@ -93,31 +80,26 @@ def test_scaleway_config_has_valid_settings():
 
 
 def test_scaleway_marketplace_api_usage():
-    """Test that the role correctly uses Scaleway Marketplace API v2"""
+    """Test that the role correctly uses Scaleway Marketplace API v2 for image lookup"""
     main_yml = Path("roles/cloud-scaleway/tasks/main.yml")
 
     with open(main_yml) as f:
         content = f.read()
 
-    # Should use uri module to fetch from Marketplace API v2
     assert "uri:" in content, "Not using uri module for API calls"
-
-    # Should use local-images endpoint with image_label
+    assert "marketplace/v2" in content, "Not using Marketplace API v2"
     assert "local-images" in content, "Not using local-images endpoint"
     assert "image_label" in content, "Not using image_label parameter"
-
-    # Should filter for instance_local type
     assert "instance_local" in content, "Not filtering for instance_local image type"
-
-    # Should set scaleway_image_id variable
     assert "scaleway_image_id" in content, "Missing scaleway_image_id variable for image UUID"
+    assert "instance/v1" not in content, "Still using Instance API v1 for image lookup"
 
     print("✓ Scaleway role uses Marketplace API v2 correctly")
 
 
 if __name__ == "__main__":
     tests = [
-        test_scaleway_main_uses_project_parameter,
+        test_scaleway_main_uses_organization_parameter,
         test_scaleway_prompts_collect_org_id,
         test_scaleway_config_has_valid_settings,
         test_scaleway_marketplace_api_usage,

--- a/tests/unit/test_scaleway_fix.py
+++ b/tests/unit/test_scaleway_fix.py
@@ -43,8 +43,9 @@ def test_scaleway_main_uses_project_parameter():
     # Should NOT use deprecated organization parameter
     assert 'organization: "{{' not in content, "Still using deprecated 'organization' parameter"
 
-    # Should use Marketplace API for image lookup
-    assert "api-marketplace.scaleway.com" in content, "Not using Scaleway Marketplace API for image lookup"
+    # Should use Marketplace API v2 for image lookup
+    assert "api.scaleway.com/marketplace/v2" in content, "Not using Scaleway Marketplace API v2 for image lookup"
+    assert "api-marketplace.scaleway.com" not in content, "Still using deprecated api-marketplace.scaleway.com domain"
 
     print("✓ Scaleway main.yml uses modern 'project' parameter")
 
@@ -92,22 +93,26 @@ def test_scaleway_config_has_valid_settings():
 
 
 def test_scaleway_marketplace_api_usage():
-    """Test that the role correctly uses Scaleway Marketplace API"""
+    """Test that the role correctly uses Scaleway Marketplace API v2"""
     main_yml = Path("roles/cloud-scaleway/tasks/main.yml")
 
     with open(main_yml) as f:
         content = f.read()
 
-    # Should use uri module to fetch from Marketplace API
+    # Should use uri module to fetch from Marketplace API v2
     assert "uri:" in content, "Not using uri module for API calls"
 
-    # Should filter for Ubuntu 22.04 Jammy
-    assert "Ubuntu" in content and "22" in content, "Not filtering for Ubuntu 22.04 image"
+    # Should use local-images endpoint with image_label
+    assert "local-images" in content, "Not using local-images endpoint"
+    assert "image_label" in content, "Not using image_label parameter"
+
+    # Should filter for instance_local type
+    assert "instance_local" in content, "Not filtering for instance_local image type"
 
     # Should set scaleway_image_id variable
     assert "scaleway_image_id" in content, "Missing scaleway_image_id variable for image UUID"
 
-    print("✓ Scaleway role uses Marketplace API correctly")
+    print("✓ Scaleway role uses Marketplace API v2 correctly")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The Scaleway role fails with DNS resolution error (`NXDOMAIN`) during image lookup:

```
[Errno -2] Nom ou service inconnu
url: "https://api-marketplace.scaleway.com/images?arch=x86_64&include_eol=false"
```

Scaleway has removed the `api-marketplace.scaleway.com` domain entirely.

## Solution

Migrate to the new Scaleway Marketplace API v2 at `api.scaleway.com/marketplace/v2/local-images`. This endpoint:
- Returns local image IDs directly by label and zone (no nested version/local_images parsing needed)
- Uses full zone names (`fr-par-1` instead of `par1`)
- Is documented as the current Marketplace API

## Changes

- **`roles/cloud-scaleway/tasks/main.yml`**: New API endpoint + zone name mapping + simplified image lookup
- **`roles/cloud-scaleway/defaults/main.yml`**: Added `zone` field mapping aliases to full zone names
- **`config.cfg`**: Added `image_label: ubuntu_jammy` for easy Ubuntu version switching
- **`tests/unit/test_scaleway_fix.py`**: Updated assertions for v2 API

## Follow-up fixes

After the initial migration, additional runtime errors were fixed:

- **`library/scaleway_compute.py`**: Removed `check_image_id()` — this function validated images against the Instance API v1 (`GET /images`), but Marketplace API v2 UUIDs don't appear in that list, causing every deployment to fail with "Error in getting image". The check is redundant since the Scaleway API validates images at creation time.
- **`roles/cloud-scaleway/tasks/main.yml`**:
  - Replaced `project` with `organization` (the custom `library/scaleway_compute.py` module doesn't support `project`)
  - Changed `until: algo_instance.msg.public_ip` to `until: algo_instance.msg.public_ip is not none` — Ansible 12+ with Jinja2 native mode rejects `NoneType` as a boolean condition
- **`tests/unit/test_scaleway_fix.py`**: Updated assertions to match the actual parameters (`organization` not `project`, Marketplace API v2, no Instance API v1 references)

## Testing

```
$ uv run pytest tests/unit/test_scaleway_fix.py -v
============================= 4 passed =============================
```

Created with OpenCode/Big Pickle